### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ Thumbs.db
 ehthumbs.db
 Desktop.ini
 $RECYCLE.BIN/
+
+# Perun ignore #
+gen/spool/


### PR DESCRIPTION
- Ignore gen/spool/ folder which is created when we run gen
  scripts inside repository to test them.