### PR TITLE
Use TMP file or directory before safe move in slave scripts

### DIFF
--- a/slave/base/bin/perun
+++ b/slave/base/bin/perun
@@ -67,7 +67,30 @@ E_DESTINATION_FILE=(209 'Destination file (to diff_update) does not exists or do
 E_PERMISSIONS=(210 'Cannot set permissions')
 E_CHANGE_OWNER=(211 'Cannot set owner')
 
+### declare list of all items in trap on exit
+declare -a on_exit_items
+
 ### Functions
+
+### for purpose of evaluating all on_exit items
+function on_exit()
+{
+    for i in "${on_exit_items[@]}"
+    do
+        eval $i
+    done
+}
+
+### add new on_exit item
+function add_on_exit()
+{
+    local n=${#on_exit_items[*]}
+    on_exit_items[$n]="$*"
+    if [ $n -eq 0 ]; then
+        trap on_exit EXIT
+    fi
+}
+
 function log_msg {
 	CODE=`eval echo '${'$1'[0]}'`
 	TEXT=`eval echo '${'$1'[1]}'`
@@ -125,7 +148,7 @@ function create_lock {
 	catch_error E_LOCK_DIR_NOT_WRITABLE test -w $LOCK_DIR
 
 	if mkdir "${LOCK_FILE}"; then
-		trap 'rm -r -f "${WORK_DIR}" "${LOCK_FILE}"' EXIT
+		add_on_exit "rm -rf ${LOCK_FILE}"
 		catch_error E_LOCK_PIDFILE echo $$ > "$LOCK_PIDFILE"
 	else
 		# lock file exists, check for existence of concurrent process
@@ -137,7 +160,7 @@ function create_lock {
 			catch_error E_LOCK_DELETE rm -r "$LOCK_FILE"
 			echo "Invalid lock file found and deleted: $LOCK_FILE" >&2
 			catch_error E_LOCK_FILE mkdir "${LOCK_FILE}"
-			trap 'rm -r -f "${WORK_DIR}" "${LOCK_FILE}"' EXIT
+			add_on_exit "rm -rf ${LOCK_FILE}"
 			catch_error E_LOCK_PIDFILE echo $$ > "$LOCK_PIDFILE"
 		fi
 	fi
@@ -349,7 +372,7 @@ function run_post_hooks {
 
 WORK_DIR=`mktemp -d ${TMPDIR:-/tmp}/${NAME}.XXXXXXXXXX`
 [ $? -ne 0 ] && log_msg E_WORK_DIR
-trap 'rm -r -f "${WORK_DIR}"' EXIT
+add_on_exit "rm -rf ${WORK_DIR}"
 
 ### Receive and process data
 catch_error E_TAR_FILES tar --no-same-owner --no-same-permissions -x -C "${WORK_DIR}" <&0

--- a/slave/base/changelog
+++ b/slave/base/changelog
@@ -1,3 +1,10 @@
+perun-slave-base (3.1.9) stable; urgency=medium
+
+  * Add add_on_exit function instead of basic trap, this function is a new
+    trap management with dynamic content in trap during lifecycle of scripts
+
+ -- Michal Stava <stavamichal@gmail.com>  Fri, 20 Oct 2017 09:50:00 +0200
+
 perun-slave-base (3.1.8) stable; urgency=low
 
   * Perform write check on default locking folder LOCK_DIR=/var/lock/.

--- a/slave/process-fs-home/changelog
+++ b/slave/process-fs-home/changelog
@@ -1,3 +1,11 @@
+perun-slave-process-fs-home (3.1.4) stable; urgency=medium
+
+  * Use temporary directory to prepare new home, set correct permission and
+    ownership and then move it to the right place atomically. The reason for
+    this change is to overcome problems on distributed filesystems.
+
+ -- Michal Stava <stavamichal@gmail.com>  Wed, 15 Mar 2017 14:33:00 +0100
+
 perun-slave-process-fs-home (3.1.3) stable; urgency=medium
 
   * Change service name in /etc/perun/{service}.d/ to match real service

--- a/slave/process-k5login/bin/process-k5login.sh
+++ b/slave/process-k5login/bin/process-k5login.sh
@@ -5,11 +5,15 @@ PROTOCOL_VERSION='3.0.0'
 
 function process {
 	### Status codes
-	I_K5LOGIN_CREATED=(0 '${HOME_DIR}/.k5login with entries ${PRINCIPALS} created.')
-	I_K5LOGIN_UPDATED=(0 '${HOME_DIR}/.k5login updated. Added entries are ${ADDED_PRINCIPALS}.')
+	I_K5LOGIN_CREATED=(0 '${K5LOGIN} with entries ${PRINCIPALS} created.')
+	I_K5LOGIN_UPDATED=(0 '${K5LOGIN} updated. Added entries are ${ADDED_PRINCIPALS}.')
+	I_K5LOGIN_NOT_UPDATED=(0 '${K5LOGIN} not updated. Nothing to add.')
 
 	E_DIR_NOT_EXISTS=(50 'Home directory ${HOME_DIR} does not exits.')
-	E_CHANGE_OWNER=(51 'Change owner on ${HOME_DIR}/.k5login failed.')
+	E_CHANGE_OWNER=(51 'Change owner on ${TMP_K5LOGIN} failed.')
+	E_K5LOGIN_NOT_CREATED=(52 'Move diff from ${TMP_K5LOGIN} to ${HOME_DIR}/.k5login failed.')
+	E_CANNOT_COPY_K5LOGIN=(53 'Cannot create copy of ${HOME_DIR}/.k5login to ${TMP_K5LOGIN}')
+	E_CANNOT_CREATE_TMP_K5LOGIN=(55 'Cannot create temporary ${TMP_K5LOGIN} file.')
 
 	FROM_PERUN="${WORK_DIR}/k5login"
 
@@ -20,44 +24,67 @@ function process {
 	do
 		HOME_DIR=`echo "${line}" | awk '{ print $1 };'`
 		PRINCIPALS=`echo "${line}" | sed -e 's/^[^\t]*[\t]//'`
-
+		K5LOGIN="${HOME_DIR}/.k5login"
+	
+		#set home dir of user as current working directory
 		catch_error E_DIR_NOT_EXISTS cd "${HOME_DIR}"
 
-		# If .k5login doesn't exist, create it and fill it with proper principals
-		if [ ! -f "${HOME_DIR}/.k5login" ]; then
-			log_debug "File ${HOME_DIR}/.k5login not exists and need to be created."
-			for PRINCIPAL in ${PRINCIPALS}; do
-				echo "${PRINCIPAL}" >> "${HOME_DIR}/.k5login"
-			done
-			log_debug "If not exists, file ${HOME_DIR}/.k5login was created and ${PRINCIPALS} were added into it."
-
-			# Setup rights, the .k5login will have the same owner and group as user's home directory
-			F_USER=`ls -ld "${HOME_DIR}" | awk '{ print $3; }'`
-			F_GROUP=`ls -ld "${HOME_DIR}" | awk '{ print $4; }'`
-			catch_error E_CHANGE_OWNER chown ${F_USER}.${F_GROUP} "${HOME_DIR}/.k5login"
-
-			F_USER_REAL=`ls -ld "${HOME_DIR}" | awk '{ print $3; }'`
-			F_GROUP_REAL=`ls -ld "${HOME_DIR}" | awk '{ print $4; }'`
-			log_debug "Owner was changed for file ${HOME_DIR}/.k5login. New owner is ${F_USER_REAL}:${F_GROUP_REAL} (expected ${F_USER}:${F_GROUP})"
-
-			catch_error E_PERMISSIONS chmod 0644 "${HOME_DIR}/.k5login"
-			K5LOGIN_PERMISSIONS=`stat -L -c %a "${HOME_DIR}/.k5login"`
-			log_debug "Permissions was set to ${K5LOGIN_PERMISSIONS} for file ${HOME_DIR}/.k5login (expected 0644)"
-
-			log_msg I_K5LOGIN_CREATED
-		else
-			# .k5login exists. So only add missing entries.
-			ADDED_PRINCIPALS=""
-			for principal in ${PRINCIPALS}; do
-				grep "^${principal}\\s*\$" "${HOME_DIR}/.k5login" > /dev/null
-				if [ $? -eq 1 ]; then
-					ADDED_PRINCIPALS="$ADDED_PRINCIPALS ${principal}"
-					echo "${principal}" >> "${HOME_DIR}/.k5login"
-				fi
-			done
-			if [ -n "$ADDED_PRINCIPALS" ]; then
-				log_msg I_K5LOGIN_UPDATED
-			fi
+		#prepare empty temporary file
+		TMP_K5LOGIN=`mktemp --tmpdir=${HOME_DIR} .k5login-from-perun.XXXXXXXXX`
+		if [ "$?" -ne 0 ]; then
+			log_msg E_CANNOT_CREATE_TMP_K5LOGIN
 		fi
+
+		# remove tmp k5login at the end of this script
+		add_on_exit "rm -f ${TMP_K5LOGIN}"
+
+		#copy existing k5login file to temporary file if already exists
+		if [ -f "${K5LOGIN}" ]; then
+			catch_error E_CANNOT_COPY_K5LOGIN cp -p "${K5LOGIN}" "${TMP_K5LOGIN}"
+			K5LOGIN_EXISTS=true
+		else
+			K5LOGIN_EXISTS=false
+		fi
+
+		#add not existing principals
+		ADDED_PRINCIPALS=""
+		for PRINCIPAL in ${PRINCIPALS}; do
+			grep "^${PRINCIPAL}\\s*\$" "${TMP_K5LOGIN}" > /dev/null
+			if [ "$?" -eq 1 ]; then
+				ADDED_PRINCIPALS="${ADDED_PRINCIPALS} ${PRINCIPAL}"
+				echo "${PRINCIPAL}" >> "${TMP_K5LOGIN}"
+			fi
+		done
+
+		#nothing to add, can skip to another user
+		if [ -z "${ADDED_PRINCIPALS}" ]; then
+			log_msg I_K5LOGIN_NOT_UPDATED
+			continue
+		fi
+
+		# Setup ownership, the k5login temp file will have the same owner and group as user's home directory
+		F_USER=`ls -ld "${HOME_DIR}" | awk '{ print $3; }'`
+		F_GROUP=`ls -ld "${HOME_DIR}" | awk '{ print $4; }'`
+		catch_error E_CHANGE_OWNER chown ${F_USER}.${F_GROUP} "${TMP_K5LOGIN}"
+
+		F_USER_REAL=`ls -l "${TMP_K5LOGIN}" | awk '{ print $3; }'`
+		F_GROUP_REAL=`ls -l "${TMP_K5LOGIN}" | awk '{ print $4; }'`
+		log_debug "Owner was changed for file ${TMP_K5LOGIN}. New owner is ${F_USER_REAL}:${F_GROUP_REAL} (expected ${F_USER}:${F_GROUP})"
+
+		# Setup rights, the k5login temp file will have 0644 right
+		catch_error E_PERMISSIONS chmod 0644 "${TMP_K5LOGIN}"
+		K5LOGIN_PERMISSIONS=`stat -L -c %a "${TMP_K5LOGIN}"`
+		log_debug "Permissions was set for file ${TMP_K5LOGIN}. New permissions are ${K5LOGIN_PERMISSIONS} (expected 0644)"
+
+		#if something to add, create or update k5login
+		catch_error E_K5LOGIN_NOT_UPDATED diff_mv "${TMP_K5LOGIN}" "${K5LOGIN}"
+		
+		#log info about operation (update or create)
+		if [ ${K5LOGIN_EXISTS} == true ]; then
+			log_msg I_K5LOGIN_UPDATED
+		else
+			log_msg I_K5LOGIN_CREATED
+		fi
+
 	done < "${FROM_PERUN}"
 }

--- a/slave/process-k5login/changelog
+++ b/slave/process-k5login/changelog
@@ -1,3 +1,11 @@
+perun-slave-process-k5login (3.1.3) stable; urgency=medium
+
+  * Use temporary file for k5login in home of each user, add data from Perun
+    to it and then move it atomically. The reason for this change is to 
+    overcome problems on distributed filesystems.
+
+ -- Michal Stava <stavamichal@gmail.com>  Wed, 15 Mar 2017 14:35:00 +0100
+
 perun-slave-process-k5login (3.1.2) stable; urgency=medium
 
   * Generate configuration directory /etc/perun/{service}.d automatically even


### PR DESCRIPTION
     - new function add_on_exit instead of trap (new trap management with
       dynamic content)
     - changes are just in services fs_home and k5login
     - in k5login create a copy of .k5login file for every user and then
       (after modifications) move it back to the right place with correct
       permission and ownership
     - in fs_home create a new temporary directory to defined home mount
       point, set correct permission and ownership, copy content from skel
       directory there and then move it to the right place with the right
       name