### PR TITLE
Updated ldap_ad_ceitec gen script

### DIFF
--- a/gen/ldap_ad_ceitec
+++ b/gen/ldap_ad_ceitec
@@ -34,7 +34,6 @@ our $A_R_SEC_GROUP_CN; *A_R_SEC_GROUP_CN = \'urn:perun:resource:attribute-def:de
 
 # GATHER USERS
 my $users;  # $users->{$login}->{ATTR} = $attrValue;
-my $userResources; # $userResources->{$login}->{$A_R_SEC_GROUP_CN} = 1;
 # GATHER USERS FROM RESOURCES
 my $usersByResource;  # $usersByResource->{$A_R_SEC_GROUP_CN}->{users DN} = 1
 
@@ -89,9 +88,6 @@ foreach my $rData (@resourcesData) {
 		$users->{$login}->{$A_EPPNS} = $mAttributes{$A_EPPNS};
 		$users->{$login}->{$A_O} = $mAttributes{$A_O};
 		$users->{$login}->{$A_CN} = $mAttributes{$A_CN};
-
-		# store on which resources user is
-		$userResources->{$login}->{"CN=" . $rAttributes{$A_R_SEC_GROUP_CN} . "," . $baseDNGroups} = 1;
 
 		# store which users (their DN) are on this resource
 		$usersByResource->{$rAttributes{$A_R_SEC_GROUP_CN}}->{"CN=" . $mAttributes{$A_CN} . "," . $baseDNUsers} = 1
@@ -175,12 +171,6 @@ for my $login (@logins) {
 	}
 	foreach my $val (@$eppns) {
 		print FILE "eduPersonPrincipalNames: " . $val . "\n";
-	}
-
-	# print group membership if any
-	my @memberOf = sort keys %{$userResources->{$login}};
-	for my $groupDN (@memberOf) {
-		print FILE "memberOf: " . $groupDN . "\n";
 	}
 
 	# Set userAccountControl to 66048 which means Normal account + Password never expires + enabled


### PR DESCRIPTION
- We don't need memberOf for Users, since it's derived from
  Group attribute member in AD and cannot be set this way.