### PR TITLE
Remove prefix of userCertDNs subjectDNs for all services where needed

### DIFF
--- a/gen/apache_ssl
+++ b/gen/apache_ssl
@@ -49,8 +49,12 @@ foreach my $rData ($data->getChildElements) {
 
 	my @output = ();
 	foreach my $memberAttributes (dataToAttributesHashes $rData->getChildElements) {
-		foreach my $caDN (keys %{$memberAttributes->{$A_U_CERT_DNS}}) {
-			push @output, '( %{SSL_CLIENT_I_DN} == "' . $memberAttributes->{$A_U_CERT_DNS}->{$caDN} .'" && %{SSL_CLIENT_S_DN} == "' .  $caDN . '" )';
+		foreach my $subjectDN (keys %{$memberAttributes->{$A_U_CERT_DNS}}) {
+			my $caDN = $memberAttributes->{$A_U_CERT_DNS}->{$subjectDN};
+			#strip prefixes from subjectDN
+			my $subjectDNWithoutPrefix = $subjectDN;
+			$subjectDNWithoutPrefix =~ s/^[0-9]+[:]//;
+			push @output, '( %{SSL_CLIENT_I_DN} == "' . $caDN .'" && %{SSL_CLIENT_S_DN} == "' .  $subjectDNWithoutPrefix . '" )';
 		}
 	}
 

--- a/gen/appDB
+++ b/gen/appDB
@@ -71,9 +71,11 @@ for my $voData (@vosData) {
 
 			# prepare DNs
 			my @dn = ();
-			foreach my $dn (keys %{$memberAttributes{$A_USER_CERT_DNS}}) {
-				push @dn, { "content" => $dn,
-				            "ca" => $memberAttributes{$A_USER_CERT_DNS}->{$dn},
+			foreach my $subjectDN (keys %{$memberAttributes{$A_USER_CERT_DNS}}) {
+				my $subjectDNWithoutPrefix = $subjectDN;
+				$subjectDNWithoutPrefix =~ s/^[0-9]+[:]//;
+				push @dn, { "content" => $subjectDNWithoutPrefix,
+				            "ca" => $memberAttributes{$A_USER_CERT_DNS}->{$subjectDN},
 				          };
 			}
 

--- a/gen/fedcloud_export
+++ b/gen/fedcloud_export
@@ -59,7 +59,21 @@ foreach my $memberAttributes (@membersAttributes) {
 	#do not add not valid users and blacklisted users
 	if (($memberAttributes->{$A_MEMBER_STATUS} eq $STATUS_VALID) && !defined($memberAttributes->{$A_U_F_BLACKLISTED})) {
 		my @DNs = keys %{$memberAttributes->{$A_USER_CERT_DNS}};
-		my $DN = $DNs[0];
+		# take DN with the biggest number (the last in perun)
+		my $lastDN;
+		foreach my $DN (@DNs) {
+			if(!defined($lastDN)) { $lastDN=$DN; }
+			else {
+				my $lastDNNumber = $lastDN;
+				$lastDNNumber =~ s/[:].*$//;
+				my $DNNumber = $DN;
+				$DNNumber =~ s/[:].*$//;
+				if($DNNumber > $lastDNNumber) { $lastDN=$DN; }
+			}
+		}
+		my $DN = $lastDN;
+		# strip prefix from certificate
+		$DN =~ s/^[0-9]+[:]//;
 		my $uid = $memberAttributes->{$A_R_VO_SHORT_NAME} . "_" . $memberAttributes->{$A_USER_FACILITY_UID};
 
 		my $sshKeys = "";

--- a/gen/gridmap
+++ b/gen/gridmap
@@ -35,19 +35,27 @@ my @map;
 foreach my $memberAttributes (@membersAttributes) {
 	foreach my $login (@{$memberAttributes->{$A_USER_LOGINS}}) {
 		
-		foreach my $caDN (keys %{$memberAttributes->{$A_USER_CERT_DNS}}) {
-			chomp $memberAttributes->{$A_USER_CERT_DNS}{$caDN};
-			my @entry = ($caDN, $login);
+		foreach my $subjectDN (keys %{$memberAttributes->{$A_USER_CERT_DNS}}) {
+			chomp $memberAttributes->{$A_USER_CERT_DNS}{$subjectDN};
+			my @entry = ($subjectDN, $login);
 			push(@map, \@entry);
 		}
 	}
 }
 
+my %entries = ();
 foreach my $entry (@map) {
-	open FILE,">$fileName" or die "Cannot open $fileName: $! \n";
 	foreach my $entry (@map) {
+		my $subjectDNEntry = $$entry[0];
+		#remove prefix from subject DN
+		$subjectDNEntry =~ s/^[0-9]+[:]//;
 		# "userCertDN" login
-		print FILE "\"" . $$entry[0] . "\" " . $$entry[1] . "\n";
+		$entries{"\"" . $subjectDNEntry . "\" " . $$entry[1] . "\n"} = 1;
+	}
+	
+	open FILE,">$fileName" or die "Cannot open $fileName: $! \n";
+	foreach my $entry (keys %entries) {
+		print FILE $entry;
 	}
 	close (FILE);
 }

--- a/gen/metacloud_export
+++ b/gen/metacloud_export
@@ -93,14 +93,21 @@ sub processMembersData {
 		unless(exists $dataByUser->{$login}) {
 			my @certs =  (keys %{$memberAttributes{$A_U_CERT_DNS}}, '/C=CZ/O=CESNET/CN=' . $login . '@meta.cesnet.cz');
 
-			#check for certificates duplicities
+			#check for certificates duplicities between all users
+			my %allUsersCerts = ();
+
+			my @certsDNsWithoutPrefixes;
 			for my $cert (@certs) {
-				if($allCerts{$cert}++) { die "Duplicate certificate found $cert for $login" ; }
+				my $certDNWithoutPrefix = $cert;
+				$certDNWithoutPrefix =~ s/^[0-9]+[:]//;
+				push @certsDNsWithoutPrefixes, $certDNWithoutPrefix;
+				if($allUsersCerts{$certDNWithoutPrefix} && $allUsersCerts{$certDNWithoutPrefix} ne $login) { die "Duplicate certificate found $cert for logins: $login and $allUsersCerts{$certDNWithoutPrefix}" ; }
+				else { $allUsersCerts{$certDNWithoutPrefix} = $login; }
 			}
 
 			$dataByUser->{$login}->{"login"} = $login;
 			$dataByUser->{$login}->{"krb_principals"} = [ $login . '@META' ];
-			$dataByUser->{$login}->{"cert_dns"} = \@certs;
+			$dataByUser->{$login}->{"cert_dns"} = \@certsDNsWithoutPrefixes;
 			$dataByUser->{$login}->{"ssh_keys"} = $memberAttributes{$A_USER_SSH_KEY} || [];
 			$dataByUser->{$login}->{"mail"} = $memberAttributes{$A_USER_MAIL};
 			$dataByUser->{$login}->{"full_name"} = $memberAttributes{$A_USER_DISPLAY_NAME};

--- a/gen/openvpn
+++ b/gen/openvpn
@@ -30,12 +30,19 @@ for my $rData (@resourcesData) {
 	}
 }
 
+my %membersDNs = ();
 foreach my $memberAttributes (@membersAttributes) {
-	foreach my $caDN (keys %{$memberAttributes->{$A_USER_CERT_DNS}}) {
-		chomp $memberAttributes->{$A_USER_CERT_DNS}{$caDN};
-		#print FILE $caDN . ":" . $memberAttributes->{$A_USER_CERT_DNS}{$caDN} . "\n";
-		print FILE $caDN . "\n";
+	foreach my $subjectDN (keys %{$memberAttributes->{$A_USER_CERT_DNS}}) {
+		chomp $memberAttributes->{$A_USER_CERT_DNS}{$subjectDN};
+		#remove prefix from subjectDN
+		my $subjectDNWithoutPrefix = $subjectDN;
+		$subjectDNWithoutPrefix =~ s/^[0-9]+[:]//;
+		$membersDNs{$subjectDNWithoutPrefix} = 1;
 	}
+}
+
+foreach my $subjectDN (keys %membersDNs) {
+	print FILE $subjectDN . "\n";
 }
 
 close (FILE);

--- a/gen/pkinit
+++ b/gen/pkinit
@@ -36,9 +36,12 @@ foreach my $memberAttributes (@membersAttributes) {
 	foreach my $kerberosLogin (@{$memberAttributes->{$A_USER_KERBEROS_LOGINS}}) {
 		# Get realm from the kerberosLogins
 		my ($login, $realm) = split('@', $kerberosLogin);
-		foreach my $caDN (keys %{$memberAttributes->{$A_USER_CERT_DNS}}) {
-			chomp $memberAttributes->{$A_USER_CERT_DNS}{$caDN};
-			my @entry = ($kerberosLogin, convertNonAsciiToEscapedUtf8Form $caDN);
+		foreach my $subjectDN (keys %{$memberAttributes->{$A_USER_CERT_DNS}}) {
+			chomp $memberAttributes->{$A_USER_CERT_DNS}{$subjectDN};
+			#remove prefix from subject DN
+			my $subjectDNWithoutPrefix = $subjectDN;
+			$subjectDNWithoutPrefix =~ s/^[0-9]+[:]//;
+			my @entry = ($kerberosLogin, convertNonAsciiToEscapedUtf8Form $subjectDNWithoutPrefix);
 			push(@{$realms{$realm}}, \@entry);
 		}
 	}
@@ -48,9 +51,14 @@ foreach my $realm (keys %realms) {
 	open FILE,">$fileName." . lc($realm) or die "Cannot open $fileName.$realm: $! \n";
 	# Name of the realm on the first line
 	print FILE $realm . "\n";
+	my %uniqueEntriesInRealm = ();
 	foreach my $entry (@{$realms{$realm}}) {
 		# kerberosPrincipal:userCertDN
-		print FILE $$entry[0] . ":" . $$entry[1] . "\n";
+		$uniqueEntriesInRealm{$$entry[0] . ":" . $$entry[1] . "\n"} = 1;
+	}
+
+	foreach my $entry (keys %uniqueEntriesInRealm) {
+		print FILE $entry;
 	}
 	close (FILE);
 }

--- a/gen/voms
+++ b/gen/voms
@@ -40,9 +40,12 @@ for my $rData (@resourcesData) {
 foreach my $memberAttributes (@membersAttributes) {
 	next unless $memberAttributes->{$A_USER_STATUS} eq $STATUS_VALID;
 
-	foreach my $caDN (keys %{$memberAttributes->{$A_USER_CERT_DNS}}) {
-		chomp $memberAttributes->{$A_USER_CERT_DNS}{$caDN};
-		print FILE $memberAttributes->{$A_R_VO_SHORT_NAME} . "\t" . $caDN . "\t" . $memberAttributes->{$A_USER_CERT_DNS}{$caDN} . "\t";
+	foreach my $subjectDN (keys %{$memberAttributes->{$A_USER_CERT_DNS}}) {
+		chomp $memberAttributes->{$A_USER_CERT_DNS}{$subjectDN};
+		#remove prefix from subjectDN
+		my $subjectDNWithoutPrefix = $subjectDN;
+		$subjectDNWithoutPrefix =~ s/^[0-9]+[:]//;
+		print FILE $memberAttributes->{$A_R_VO_SHORT_NAME} . "\t" . $subjectDNWithoutPrefix . "\t" . $memberAttributes->{$A_USER_CERT_DNS}{$subjectDN} . "\t";
 		print FILE $memberAttributes->{$A_USER_MAIL}."\n";
 	}
 }


### PR DESCRIPTION
 - remove prefix before writing to the file
 - in metacloud export change uniqueness only if two different users has
   the same subjectDN (not if the same user has two or more same
   subejctDNs)