### PR TITLE
Use also the old path /opt/perun/bin/ for pre/mid/post scripts

### DIFF
--- a/slave-new/Makefile
+++ b/slave-new/Makefile
@@ -29,7 +29,7 @@ meta:
 
 $(processes):
 	@echo "Generating deb package for $@..."
-	@cd $@ && NAME=$@ envsubst < ../templates/Makefile > Makefile
+	@cd $@ && NAME=$(subst process-,,$@) envsubst < ../templates/Makefile > Makefile
 	@cd $@ && if [ -d conf ]; then cat ../templates/makefile_conf_part >> Makefile; fi
 	@cd $@ && if [ -d lib ]; then cat ../templates/makefile_lib_part >> Makefile; fi
 	cd $@ && DEBEMAIL=$(maintainer_email) DEBFULLNAME=$(maintainer_name) dh_make -s -i -y -n -p "$(package_prefix_name)$@_`head -n 1 changelog | sed -e 's/.*\([0-9]\+[.][0-9]\+[.][0-9]\+\).*/\1/'`" -t "$(realpath templates/dh_make)" --createorig

--- a/slave-new/base/bin/perun
+++ b/slave-new/base/bin/perun
@@ -3,6 +3,7 @@ NAME='perunv3'
 SCRIPTS_DIR=`dirname $0`
 LIB_DIR='/opt/perun/lib/'
 CUSTOM_SCRIPTS_DIR="/etc/perun/"
+OLD_CUSTOM_SCRIPTS_DIR="/opt/perun/bin/"
 LOCK_DIR=${LOCK_DIR:=/var/lock}
 SERVICE_BLACKLIST=()	# syntax: (item1 item2 item3)
 SERVICE_WHITELIST=()
@@ -15,6 +16,10 @@ FACILITY_WHITELIST=()        # from which facilities this host accept configurat
 if [ -f "/etc/${NAME}.conf" ]; then
 	. "/etc/${NAME}.conf"
 fi
+
+# write to stderr if old path for scripts is still used
+WARN_USING_OLD_PATH_FOR_SCRIPTS="Warning: Old configuration dir ${OLD_CUSTOM_SCRIPTS_DIR}/${SERVICE}.d/ is still used."
+ls "${OLD_CUSTOM_SCRIPTS_DIR}/${SERVICE}.d/" 2>/dev/null | grep '^pre_\|^post_\|^mid_' 1>/dev/null && echo "${WARN_USING_OLD_PATH_FOR_SCRIPTS}" 1>&2
 
 # Temporarily set umask to 077 in order to have all temp configuration files private
 umask 077
@@ -285,15 +290,15 @@ function remove_backup_files {
 }
 
 function run_pre_hooks {
-	for F in `ls "${CUSTOM_SCRIPTS_DIR}/process-${SERVICE}.d"/pre_* 2>/dev/null` ;do . $F ; done
+	for F in `ls "${CUSTOM_SCRIPTS_DIR}/${SERVICE}.d"/pre_* "${OLD_CUSTOM_SCRIPTS_DIR}/${SERVICE}.d"/pre_* 2>/dev/null | perl -e ' @_ = <>;  $, = " "; $\ = "\n"; print sort { $a =~ m#^.*/(pre|post|mid)_([^/]*)# ; $a1 = $2 ; $b =~ m#^.*/(pre|post|mid)_([^/]*)# ; $b1 = $2 ; $a1 cmp $b1 } grep { m|^(.*)/(.*)$| ; $1 =~ m|^/etc/perun/| || ! ( grep { m|^/etc/perun/.*$2$| } @_ ) } @_;'` ;do . $F ; done
 }
 
 function run_mid_hooks {
-	for F in `ls "${CUSTOM_SCRIPTS_DIR}/process-${SERVICE}.d"/mid_* 2>/dev/null` ;do . $F ; done
+	for F in `ls "${CUSTOM_SCRIPTS_DIR}/${SERVICE}.d"/mid_* "${OLD_CUSTOM_SCRIPTS_DIR}/${SERVICE}.d"/mid_* 2>/dev/null | perl -e ' @_ = <>;  $, = " "; $\ = "\n"; print sort { $a =~ m#^.*/(pre|post|mid)_([^/]*)# ; $a1 = $2 ; $b =~ m#^.*/(pre|post|mid)_([^/]*)# ; $b1 = $2 ; $a1 cmp $b1 } grep { m|^(.*)/(.*)$| ; $1 =~ m|^/etc/perun/| || ! ( grep { m|^/etc/perun/.*$2$| } @_ ) } @_;'` ;do . $F ; done
 }
 
 function run_post_hooks {
-	for F in `ls "${CUSTOM_SCRIPTS_DIR}/process-${SERVICE}.d"/post_* 2>/dev/null` ;do . $F ; done
+	for F in `ls "${CUSTOM_SCRIPTS_DIR}/${SERVICE}.d"/post_* "${OLD_CUSTOM_SCRIPTS_DIR}/${SERVICE}.d"/post_* 2>/dev/null | perl -e ' @_ = <>;  $, = " "; $\ = "\n"; print sort { $a =~ m#^.*/(pre|post|mid)_([^/]*)# ; $a1 = $2 ; $b =~ m#^.*/(pre|post|mid)_([^/]*)# ; $b1 = $2 ; $a1 cmp $b1 } grep { m|^(.*)/(.*)$| ; $1 =~ m|^/etc/perun/| || ! ( grep { m|^/etc/perun/.*$2$| } @_ ) } @_;'` ;do . $F ; done
 }
 
 

--- a/slave-new/base/changelog
+++ b/slave-new/base/changelog
@@ -1,3 +1,14 @@
+perun-slave-base (3.1.1) stable; urgency=low
+
+  * Use also the old path for {service}.d (pre, mid, post) scripts. Old path 
+    is /opt/perun/bin/{service}.d/ and the new path is 
+    /etc/perun/{service}.d/. Same files in both paths has higher priority from 
+    old path (take these).
+  * Info to stderr if old path with scrips is still used (there are some
+    scripts)
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 13:22:00 +0200
+
 perun-slave-base (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-base

--- a/slave-new/generate_rpm.sh
+++ b/slave-new/generate_rpm.sh
@@ -6,6 +6,7 @@ echo "--------------------------------------------"
 
 TMPDIR="/tmp/perun-slave-rpm-build"
 GENERATE_RPM_FOR_SERVICE=$@
+SERVICE_NAME=${GENERATE_RPM_FOR_SERVICE#process-}
 PREFIX="perun-slave-"
 CHANGELOG_FILE="$GENERATE_RPM_FOR_SERVICE/changelog"
 BIN_DIR="$GENERATE_RPM_FOR_SERVICE/bin/"
@@ -61,16 +62,16 @@ CUSTOM_CONF=""
 CUSTOM_FILE_DATA=""
 # conf predefined settings
 if [ $WITH_CONF == 1 ]; then
-	CUSTOM_CONF="mkdir -p %{buildroot}/etc/perun/${GENERATE_RPM_FOR_SERVICE}.d
-cp -r conf/* %{buildroot}/etc/perun/${GENERATE_RPM_FOR_SERVICE}.d"
-	CUSTOM_FILE_DATA="/etc/perun/${GENERATE_RPM_FOR_SERVICE}.d"
+	CUSTOM_CONF="mkdir -p %{buildroot}/etc/perun/${SERVICE_NAME}.d
+cp -r conf/* %{buildroot}/etc/perun/${SERVICE_NAME}.d"
+	CUSTOM_FILE_DATA="/etc/perun/${SERVICE_NAME}.d"
 fi
 if [ $WITH_LIB == 1 ]; then
   CUSTOM_CONF="$CUSTOM_CONF
-mkdir -p %{buildroot}/opt/perun/lib/${GENERATE_RPM_FOR_SERVICE}/
-cp -r lib/* %{buildroot}/opt/perun/lib/${GENERATE_RPM_FOR_SERVICE}/"
+mkdir -p %{buildroot}/opt/perun/lib/${SERVICE_NAME}/
+cp -r lib/* %{buildroot}/opt/perun/lib/${SERVICE_NAME}/"
   CUSTOM_FILE_DATA="$CUSTOM_FILE_DATA
-/opt/perun/lib/${GENERATE_RPM_FOR_SERVICE}/"
+/opt/perun/lib/${SERVICE_NAME}/"
 fi
 
 # generate spec file

--- a/slave-new/meta/changelog
+++ b/slave-new/meta/changelog
@@ -1,3 +1,18 @@
+perun-slave-full (3.1.2) stable; urgency=low
+
+  * Change path from /etc/perun/process-{service}.d/ to /etc/perun/{service}.d
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 14:26:00 +0200
+
+perun-slave-full (3.1.1) stable; urgency=low
+
+  * Use also the old path for {service}.d (pre, mid, post) scripts. Old path 
+    is /opt/perun/bin/{service}.d/ and the new path is 
+    /etc/perun/{service}.d/. Same files in both paths has higher priority from 
+    new path (take these).
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 13:22:00 +0200
+
 perun-slave-full (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-full

--- a/slave-new/process-afs-group/changelog
+++ b/slave-new/process-afs-group/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-afs-group (3.1.1) stable; urgency=low
+
+  * Change path from /etc/perun/process-{service}.d/ to /etc/perun/{service}.d
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 14:26:00 +0200
+
 perun-slave-process-afs-group (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-process-afs-group

--- a/slave-new/process-fs-home/changelog
+++ b/slave-new/process-fs-home/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-fs-home (3.1.1) stable; urgency=low
+
+  * Change path from /etc/perun/process-{service}.d/ to /etc/perun/{service}.d
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 14:26:00 +0200
+
 perun-slave-process-fs-home (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-process-fs-home

--- a/slave-new/process-fs-project/changelog
+++ b/slave-new/process-fs-project/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-fs-project (3.1.1) stable; urgency=low
+
+  * Change path from /etc/perun/process-{service}.d/ to /etc/perun/{service}.d
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 14:26:00 +0200
+
 perun-slave-process-fs-project (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-process-fs-project

--- a/slave-new/process-fs-quotas/changelog
+++ b/slave-new/process-fs-quotas/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-fs-quotas (3.1.1) stable; urgency=low
+
+  * Change path from /etc/perun/process-{service}.d/ to /etc/perun/{service}.d
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 14:26:00 +0200
+
 perun-slave-process-fs-quotas (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-process-fs-quotas

--- a/slave-new/process-fs-scratch-local/changelog
+++ b/slave-new/process-fs-scratch-local/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-fs-scratch-local (3.1.1) stable; urgency=low
+
+  * Change path from /etc/perun/process-{service}.d/ to /etc/perun/{service}.d
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 14:26:00 +0200
+
 perun-slave-process-fs-scratch-local (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-process-fs-scratch-local

--- a/slave-new/process-fs-scratch/changelog
+++ b/slave-new/process-fs-scratch/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-fs-scratch (3.1.1) stable; urgency=low
+
+  * Change path from /etc/perun/process-{service}.d/ to /etc/perun/{service}.d
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 14:26:00 +0200
+
 perun-slave-process-fs-scratch (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-process-fs-scratch

--- a/slave-new/process-ldap-vsb-vi/bin/process-ldap_vsb_vi.sh
+++ b/slave-new/process-ldap-vsb-vi/bin/process-ldap_vsb_vi.sh
@@ -14,8 +14,8 @@ function process {
 	E_WHEN_UPDATING_LDAP=(51 'Error when updating LDAP.')
 
 	# sort & diff scripts from CPAN
-	LDIFDIFF="${LIB_DIR}/process-${SERVICE}/ldifdiff.pl"
-	LDIFSORT="${LIB_DIR}/process-${SERVICE}/ldifsort.pl"
+	LDIFDIFF="${LIB_DIR}/${SERVICE}/ldifdiff.pl"
+	LDIFSORT="${LIB_DIR}/${SERVICE}/ldifsort.pl"
 
 	# work files location
 	INFILE="${WORK_DIR}/${SERVICE}_users.ldif"

--- a/slave-new/process-ldap-vsb-vi/changelog
+++ b/slave-new/process-ldap-vsb-vi/changelog
@@ -1,3 +1,11 @@
+perun-slave-process-ldap-vsb-vi (3.1.1) stable; urgency=low
+
+  * Change path from /etc/perun/process-{service}.d/ to /etc/perun/{service}.d
+    and directory of used libreries from /opt/perun/lib/process-{service}/ to
+    /opt/perun/lib/{service}
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 14:26:00 +0200
+
 perun-slave-process-ldap-vsb-vi (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-process-ldap-vsb-vi

--- a/slave-new/process-ldap/bin/process-ldap.sh
+++ b/slave-new/process-ldap/bin/process-ldap.sh
@@ -13,8 +13,8 @@ function process {
 	E_WHEN_UPDATING_LDAP=(51 'Error when updating LDAP.')
 
 	# sort & diff scripts from CPAN
-	LDIFDIFF="${LIB_DIR}/process-${SERVICE}/ldifdiff.pl"
-	LDIFSORT="${LIB_DIR}/process-${SERVICE}/ldifsort.pl"
+	LDIFDIFF="${LIB_DIR}/${SERVICE}/ldifdiff.pl"
+	LDIFSORT="${LIB_DIR}/${SERVICE}/ldifsort.pl"
 
 	# work files location
 	INFILE="${WORK_DIR}/ldap.ldif"

--- a/slave-new/process-ldap/changelog
+++ b/slave-new/process-ldap/changelog
@@ -1,3 +1,11 @@
+perun-slave-process-ldap (3.1.1) stable; urgency=low
+
+  * Change path from /etc/perun/process-{service}.d/ to /etc/perun/{service}.d
+    and directory of used libreries from /opt/perun/lib/process-{service}/ to
+    /opt/perun/lib/{service}
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 14:26:00 +0200
+
 perun-slave-process-ldap (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-process-ldap

--- a/slave-new/process-mailman-cesnet/changelog
+++ b/slave-new/process-mailman-cesnet/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-mailman-cesnet (3.1.1) stable; urgency=low
+
+  * Change path from /etc/perun/process-{service}.d/ to /etc/perun/{service}.d
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 14:26:00 +0200
+
 perun-slave-process-mailman-cesnet (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-process-mailman-cesnet

--- a/slave-new/process-mailman/changelog
+++ b/slave-new/process-mailman/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-mailman (3.1.1) stable; urgency=low
+
+  * Change path from /etc/perun/process-{service}.d/ to /etc/perun/{service}.d
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 14:26:00 +0200
+
 perun-slave-process-mailman (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-process-mailman

--- a/slave-new/process-pbs-phys-cluster/changelog
+++ b/slave-new/process-pbs-phys-cluster/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-pbs-phys-cluster (3.1.1) stable; urgency=low
+
+  * Change path from /etc/perun/process-{service}.d/ to /etc/perun/{service}.d
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 07 Jan 2016 14:26:00 +0200
+
 perun-slave-process-pbs-phys-cluster (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-process-pbs-phys-cluster


### PR DESCRIPTION
Some changes about using /opt/perun/bin/ for pre/mid/post scripts
    
     - use scripts from both paths /opt/perun/bin/{service}.d/ and
       /etc/perun/{service}.d/
     - if two scripts has the same name, higher priority has new path script
     - change path to lib to /opt/perun/lib/{service}/ from
       'process-{service}'
     - Fix Makefile and generator of RPM to use right path (wrong path is
       /opt/perun/bin/process-{service}.d/ and
       /opt/perun/lib/process-{service}/
     - add info to all affected changelogs
     - fix ldap and ldap-svb-vi scripts to work with new correct paths
