### PR TITLE
Proper cleaning during deb package build

### DIFF
--- a/slave-new/Makefile
+++ b/slave-new/Makefile
@@ -45,7 +45,7 @@ $(processes):
 	cd $@ && debuild -us -uc
 	@echo "Cleaing after $@ building process..."
 	@rm -rf "$@/"{Makefile,debian}
-	@rm "$(package_prefix_name)$@_"*.{build,changes,dsc,tar.gz}
+	@rm -f "$(package_prefix_name)$@_"*.{build,changes,dsc,tar.gz,tar.xz}
 	@echo "Generate spec file for $@..."
 	@./generate_rpm.sh $@
 


### PR DESCRIPTION
- Clean both tar.xz and tar.gz during build since both of them can
  be created depending on OS (Ubuntu/Debian).
- Using force "rm -f" since we don't want to fail if other OS is used.