### PR TITLE
Perun-slave-meta now conflicts with perun-propagate

### DIFF
--- a/perun-propagate/Makefile
+++ b/perun-propagate/Makefile
@@ -1,5 +1,7 @@
 VERSION = x.x
 
+default: deb rpm
+
 all: deb rpm
 
 deb:

--- a/slave-meta/Makefile
+++ b/slave-meta/Makefile
@@ -1,5 +1,7 @@
 VERSION = x.x
 
+default: deb rpm
+
 all: deb rpm
 
 deb:

--- a/slave-meta/debian/control
+++ b/slave-meta/debian/control
@@ -11,6 +11,7 @@ Priority: optional
 Architecture: all
 #Maintainer: Pavel Zlamal <zlamal@cesnet.cz>
 Depends: bash (>= 2.05a-11), sed (>= 3.02-8), grep (>= 2.4.2-3), coreutils (>= 5.0-5), perl-base (>= 5.10.1-17), perun-slave (>= 3.0.0-0.0.5), remctl-client, heimdal-clients | krb5-user, openssh-server
+Conflicts: perun-propagate
 Description: Perun support scripts for slave scripts in MetaCentrum
  Perun support scripts for slave scripts in MetaCentrum. Including
  perun_propagate init.d script.

--- a/slave/Makefile
+++ b/slave/Makefile
@@ -2,6 +2,8 @@ VERSION = x.x
 
 default: deb rpm
 
+all: deb rpm
+
 deb:
 	dpkg-buildpackage -us -uc
 


### PR DESCRIPTION
- Added missing conflict relation from other side.
- Updated make files so "make all" and default "make"
  behaves the same -> "make deb rpm".