### PR TITLE
Fix using experimental in gen scripts fs_home and fs_scratch

### DIFF
--- a/gen/fs_home
+++ b/gen/fs_home
@@ -4,6 +4,7 @@ use warnings;
 use perunServicesInit;
 use perunServicesUtils;
 use File::Basename;
+no if $] >= 5.018, warnings => "experimental";
 
 our $SERVICE_NAME = basename($0);
 our $PROTOCOL_VERSION = "3.6.0";

--- a/gen/fs_scratch
+++ b/gen/fs_scratch
@@ -5,6 +5,7 @@ use warnings;
 use perunServicesInit;
 use perunServicesUtils;
 use File::Basename;
+no if $] >= 5.018, warnings => "smartmatch";
 
 our $SERVICE_NAME = basename($0);
 our $PROTOCOL_VERSION = "3.4.0";


### PR DESCRIPTION
 - for perl in version => 1.18 no warnings for experimental (like switch
   or smartmatch)