### PR TITLE
Add quotation to mailaliases

### DIFF
--- a/gen/mailaliases
+++ b/gen/mailaliases
@@ -33,7 +33,11 @@ foreach my $rData (@resourcesData) {
 
 foreach my $login (sort keys %mailByLogin) {
 	print FILE $login . ": ";
-	print FILE $mailByLogin{$login};
+	if($mailByLogin{$login} =~ /^[\w.-]+@/) {
+		print FILE $mailByLogin{$login};
+	} else {
+		print FILE "\"$mailByLogin{$login}\"";
+	}
 	print FILE "\n";
 }
 


### PR DESCRIPTION
 - when email contains other characters than letters, '-', '.' or '@',
   then use quotation for this mail
 - ex.: a+b@c.cz => "a+b@c.cz"