### PR TITLE
Redesign service voms

### DIFF
--- a/gen/voms
+++ b/gen/voms
@@ -89,6 +89,12 @@ foreach my $resourceData ($data->getChildElements) {
 					foreach my $role (@rolesInVoForGroup) {
 						$struc->{$voShortName}->{'users'}->{$uniqueVomsUser}->{'groups'}->{$vomsGroupName}->{'roles'}->{$role} = 1;
 					}
+				# if name is not filled set all these roles for vo instead of group
+				} else {
+					#fill vo roles defined by group without name
+					foreach my $role (@rolesInVoForGroup) {
+						$struc->{$voShortName}->{'users'}->{$uniqueVomsUser}->{'roles'}->{$role} = 1;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
 - if someone create group without voms group name but with some roles,
   these roles will be added to vo roles, so there is no need to create
   a new resource for every new specific vo role defined by some group
   of people (these roles will be vo roles)
 - if group has voms group name, there is still old behavior, these
   roles will be added to the specific member in the specific group in
   vo (these roles will be group roles)