### PR TITLE
Use custom content format for gen scripts CLI

### DIFF
--- a/gen/perunServicesInit.pm
+++ b/gen/perunServicesInit.pm
@@ -1,4 +1,4 @@
-	#!/usr/bin/perl
+#!/usr/bin/perl
 package perunServicesInit;
 
 use Exporter 'import';
@@ -49,7 +49,7 @@ sub init {
 	} else {
 		unless(defined $facilityId) { die "ERROR: facilityId required"; }
 
-		$agent = Perun::Agent->new();
+		$agent = Perun::Agent->new('jsonsimple');
 		$servicesAgent = $agent->getServicesAgent;
 		my $facilitiesAgent = $agent->getFacilitiesAgent;
 		$service = $servicesAgent->getServiceByName( name => $::SERVICE_NAME);


### PR DESCRIPTION
- This must be added to Agent.pm too, otherwise "json" is used.
- Set it to "jsonsimple" since we can crop large portion of data not
  required for service generation.