### PR TITLE
Attribute deletion from Metacloud_export

### DIFF
--- a/gen/metacloud_export
+++ b/gen/metacloud_export
@@ -27,7 +27,6 @@ our $A_USER_SSH_KEY;               *A_USER_SSH_KEY =              \'urn:perun:us
 our $A_USER_DISPLAY_NAME;          *A_USER_DISPLAY_NAME =         \'urn:perun:user:attribute-def:core:displayName';
 our $A_U_CERT_DNS;                 *A_U_CERT_DNS  =               \'urn:perun:user:attribute-def:virt:userCertDNs';
 our $A_RESOURCE_UNIX_GROUP_NAME;   *A_RESOURCE_UNIX_GROUP_NAME =  \'urn:perun:resource:attribute-def:virt:unixGroupName';
-our $A_GROUP_UNIX_GROUP_NAME;      *A_GROUP_UNIX_GROUP_NAME =     \'urn:perun:group_resource:attribute-def:virt:unixGroupName';
 our $A_M_STATUS;                   *A_M_STATUS =                  \'urn:perun:member:attribute-def:core:status';
 
 my $dataByUser = {};
@@ -76,8 +75,7 @@ sub processGroupData {
 	my $membersElement = ($groupData->getChildElements)[1];
 	my %groupAttributes = attributesToHash $groupData->getAttributes;
 
-	my $groupName = $groupAttributes{$A_GROUP_UNIX_GROUP_NAME};
-	processMembersData $membersElement, $groupName;
+	processMembersData $membersElement;
 }
 
 # input: (members serviceAttributes, groupName)


### PR DESCRIPTION
-Attribute group_resource unixGroupName (virt) deleted from metacloud_export (gen) service