### PR TITLE
For every process-XY slave script create config dir automaticly

### DIFF
--- a/slave-new/Makefile
+++ b/slave-new/Makefile
@@ -30,7 +30,7 @@ meta:
 $(processes):
 	@echo "Generating deb package for $@..."
 	@cd $@ && NAME=$(subst process-,,$@) envsubst < ../templates/Makefile > Makefile
-	@cd $@ && if [ -d conf ]; then cat ../templates/makefile_conf_part >> Makefile; fi
+	@cd $@ && if [ $@ != $(base_package_name) ]; then cat ../templates/makefile_conf_part >> Makefile; fi
 	@cd $@ && if [ -d lib ]; then cat ../templates/makefile_lib_part >> Makefile; fi
 	cd $@ && DEBEMAIL=$(maintainer_email) DEBFULLNAME=$(maintainer_name) dh_make -i -y -n -p "$(package_prefix_name)$@_`head -n 1 changelog | sed -e 's/.*\([0-9]\+[.][0-9]\+[.][0-9]\+\).*/\1/'`" -t "$(realpath templates/dh_make)" --createorig
 	@cd $@/debian && rm *.ex *.EX README.*

--- a/slave-new/generate_rpm.sh
+++ b/slave-new/generate_rpm.sh
@@ -25,7 +25,8 @@ if [ ! -d "$GENERATE_RPM_FOR_SERVICE" ]; then
 fi
 
 WITH_CONF=0
-if [ -d "$CONF_DIR" ]; then
+# If this is process-XY, set config dir (not for base or meta)
+if echo ${GENERATE_RPM_FOR_SERVICE} | grep --quiet 'process-'; then
 	WITH_CONF=1
 fi
 
@@ -63,7 +64,7 @@ CUSTOM_FILE_DATA=""
 # conf predefined settings
 if [ $WITH_CONF == 1 ]; then
 	CUSTOM_CONF="mkdir -p %{buildroot}/etc/perun/${SERVICE_NAME}.d
-cp -r conf/* %{buildroot}/etc/perun/${SERVICE_NAME}.d"
+if ls -A conf/* > /dev/null 2>&1 ; then cp -r conf/* %{buildroot}/etc/perun/${SERVICE_NAME}.d ;fi"
 	CUSTOM_FILE_DATA="/etc/perun/${SERVICE_NAME}.d"
 fi
 if [ $WITH_LIB == 1 ]; then

--- a/slave-new/templates/makefile_conf_part
+++ b/slave-new/templates/makefile_conf_part
@@ -1,2 +1,2 @@
 	$(INSTALL) -d -m 755 $(CONFDIR)
-	$(INSTALL) ./conf/* $(CONFDIR)
+	if ls -A ./conf/* > /dev/null 2>&1 ; then $(INSTALL) ./conf/* $(CONFDIR) ;fi


### PR DESCRIPTION
 - config dir /etc/perun/XY.d need to be created automaticly for every
   slave script even if has no example pre/post script yet
 - for deb and rpm packages