### PR TITLE
Updated service ad_group_mu_ucn

### DIFF
--- a/gen/ad_group_mu_ucn
+++ b/gen/ad_group_mu_ucn
@@ -90,6 +90,7 @@ for my $group (sort @groups) {
 
 	print FILE "dn: CN=" . $group . "," . $baseGroupDN . "\n";
 	print FILE "cn: " . $group . "\n";
+	print FILE "samAccountName: " . $group . "\n";
 	print FILE "objectClass: group\n";
 	print FILE "objectClass: top\n";
 


### PR DESCRIPTION
- For the purpose of Samba on AD, we must set also samAccountName
  attribute for the groups. Groups are handled only in specified OU by CN,
  so no duplicity is created or existing samAccountName deleted.

For future use we should implemented some checking on uniqueness/availability
in Perun, since samAccountName is shared between users logins and groups.