### PR TITLE
Modification in freeipa gen service

### DIFF
--- a/gen/freeipa
+++ b/gen/freeipa
@@ -71,6 +71,12 @@ sub processGroupName {
 	my %groupAttributes = attributesToHash $groupData->getAttributes;
 	my $ipaGroupName = $groupAttributes{$A_GROUP_IPA_G_NAME};
 
+	if(!defined($ipaGroupName)) {
+		#skip groups without ipa group name attribute set
+		print "Skipping: $groupAttributes{$A_GROUP_NAME} and all it's subgroups.\n";
+		return;
+	}
+
 	if(!$groupNames->{$ipaGroupName}) {
 		$groupNames->{$ipaGroupName} = {};
 	}
@@ -95,15 +101,16 @@ sub processGroupData {
 			$members->{$login}->{'groups'}->{$groupName} = 1;
 		} else {
 			my $member = {
-			              first_name   => $memberAttributes{$A_FIRST_NAME} eq 'null' ? '' : $memberAttributes{$A_FIRST_NAME},
-			              middle_name  => $memberAttributes{$A_MIDDLE_NAME} eq 'null' ? '' : $memberAttributes{$A_MIDDLE_NAME},
-			              last_name    => $memberAttributes{$A_LAST_NAME} eq 'null' ? '' : $memberAttributes{$A_LAST_NAME},
-			              title_before => $memberAttributes{$A_TITLE_BEFORE} eq 'null' ? '' : $memberAttributes{$A_TITLE_BEFORE},
-			              title_after  => $memberAttributes{$A_TITLE_AFTER} eq 'null' ? '' : $memberAttributes{$A_TITLE_AFTER},
-                    user_login   => $login eq 'null' ? '' : $login,
-			              mail         => $memberAttributes{$A_USER_EMAIL} eq 'null' ? '' : $memberAttributes{$A_USER_EMAIL},
+			              first_name   => $memberAttributes{$A_FIRST_NAME} ? $memberAttributes{$A_FIRST_NAME} : '',
+			              middle_name  => $memberAttributes{$A_MIDDLE_NAME} ? $memberAttributes{$A_MIDDLE_NAME} : '',
+			              last_name    => $memberAttributes{$A_LAST_NAME} ? $memberAttributes{$A_LAST_NAME} : '',
+			              title_before => $memberAttributes{$A_TITLE_BEFORE} ? $memberAttributes{$A_TITLE_BEFORE} : '',
+			              title_after  => $memberAttributes{$A_TITLE_AFTER} ? $memberAttributes{$A_TITLE_AFTER} : '',
+			              user_login   => $login ? $login : '',
+			              mail         => $memberAttributes{$A_USER_EMAIL} ? $memberAttributes{$A_USER_EMAIL} : '',
 			              groups       => { $groupName => 1 }
 			};
+
 			$members->{$login} = $member;
 		}
 	}


### PR DESCRIPTION
 - skip groups with not defined free ipa name attribute
 - test just definition of attr values, not equality to string 'null'