### PR TITLE
Modification in passwd_nfs4 gen scripts

### DIFF
--- a/gen/passwd_nfs4
+++ b/gen/passwd_nfs4
@@ -17,7 +17,7 @@ my $data = perunServicesInit::getHierarchicalData;
 #Constants
 our $A_FACILITY_MIN_UID;                *A_FACILITY_MIN_UID =                      \'urn:perun:facility:attribute-def:virt:minUID';
 our $A_FACILITY_MAX_UID;                *A_FACILITY_MAX_UID =                      \'urn:perun:facility:attribute-def:virt:maxUID';
-our $A_MEMBER_KERBEROS_LOGINS;          *A_MEMBER_KERBEROS_LOGINS =                \'urn:perun:user:attribute-def:virt:kerberosLogins';
+our $A_MEMBER_KERBEROS_LOGINS;          *A_MEMBER_KERBEROS_LOGINS =                \'urn:perun:user:attribute-def:def:kerberosLogins';
 our $A_MEMBER_UID;                      *A_MEMBER_UID =                            \'urn:perun:user_facility:attribute-def:virt:UID';
 our $A_MEMBER_GID;                      *A_MEMBER_GID =                            \'urn:perun:user_facility:attribute-def:virt:defaultUnixGID';
 our $A_MEMBER_STATUS;                   *A_MEMBER_STATUS =                         \'urn:perun:member:attribute-def:core:status';
@@ -49,9 +49,21 @@ foreach my $rData (@resourcesData) {
 	foreach my $mData (@membersData) {
 		my %memberAttributes = attributesToHash $mData->getAttributes;
 
-		foreach my $kerberosLogin (@{$memberAttributes{$A_MEMBER_KERBEROS_LOGINS}}) {
-			if($memberAttributes{$A_MEMBER_STATUS} eq $STATUS_VALID){
-				my $passwdLine = $kerberosLogin . ":x:" . $memberAttributes{$A_MEMBER_UID} . ":" . $memberAttributes{$A_MEMBER_GID};
+		if($memberAttributes{$A_MEMBER_STATUS} eq $STATUS_VALID){
+			my %logins = ();
+			# login can have 2 possible variant "login" and "nfs/login"
+			# we don't want to have duplicits and for every login without 'nfs/' have a variant with 'nfs/'
+			foreach my $kerberosLogin (@{$memberAttributes{$A_MEMBER_KERBEROS_LOGINS}}) {
+				if($kerberosLogin =~ /^nfs\//) {
+					$logins{$kerberosLogin} = 1;
+				} else {
+					$logins{$kerberosLogin} = 1;
+					my $nfsKerberosLogin = "nfs/" . $kerberosLogin;
+					$logins{$nfsKerberosLogin} = 1;
+				}
+			}
+			for my $login (keys %logins) {
+				my $passwdLine = $login . ":x:" . $memberAttributes{$A_MEMBER_UID} . ":" . $memberAttributes{$A_MEMBER_GID};
 				$lines{$passwdLine} = 1;
 			}
 		}
@@ -61,7 +73,6 @@ foreach my $rData (@resourcesData) {
 open PASSWD,">$passwd_file_name" or die "Cannot open $passwd_file_name: $! \n";
 for my $passwdLine (keys %lines) {
 	print PASSWD $passwdLine, "\n";
-	print PASSWD "nfs/", $passwdLine, "\n";
 }
 close(PASSWD);
 

--- a/gen/passwd_nfs4_mu
+++ b/gen/passwd_nfs4_mu
@@ -17,7 +17,7 @@ my $data = perunServicesInit::getHierarchicalData;
 #Constants
 our $A_FACILITY_MIN_UID;                *A_FACILITY_MIN_UID =                      \'urn:perun:facility:attribute-def:virt:minUID';
 our $A_FACILITY_MAX_UID;                *A_FACILITY_MAX_UID =                      \'urn:perun:facility:attribute-def:virt:maxUID';
-our $A_MEMBER_KERBEROS_LOGINS;          *A_MEMBER_KERBEROS_LOGINS =                \'urn:perun:user:attribute-def:virt:kerberosLogins';
+our $A_MEMBER_KERBEROS_LOGINS;          *A_MEMBER_KERBEROS_LOGINS =                \'urn:perun:user:attribute-def:def:kerberosLogins';
 our $A_MEMBER_UID;                      *A_MEMBER_UID =                            \'urn:perun:user_facility:attribute-def:virt:UID';
 our $A_MEMBER_GID;                      *A_MEMBER_GID =                            \'urn:perun:user_facility:attribute-def:virt:defaultUnixGID';
 our $A_MEMBER_STATUS;                   *A_MEMBER_STATUS =                         \'urn:perun:member:attribute-def:core:status';
@@ -50,12 +50,21 @@ foreach my $rData (@resourcesData) {
 	foreach my $mData (@membersData) {
 		my %memberAttributes = attributesToHash $mData->getAttributes;
 
-		foreach my $kerberosLogin (@{$memberAttributes{$A_MEMBER_KERBEROS_LOGINS}}) {
-			if($memberAttributes{$A_MEMBER_STATUS} eq $STATUS_VALID){
-				my $passwdLine = $kerberosLogin . ":x:" . $memberAttributes{$A_MEMBER_UID} . ":" . $memberAttributes{$A_MEMBER_GID};
-				if(defined($memberAttributes{$A_USER_OPTIONAL_LOGIN})) {
-					$passwdLine .= ":" . $memberAttributes{$A_USER_OPTIONAL_LOGIN};
+		if($memberAttributes{$A_MEMBER_STATUS} eq $STATUS_VALID){
+			my %logins = ();
+			# login can have 2 possible variant "login" and "nfs/login"
+			# we don't want to have duplicits and for every login without 'nfs/' have a variant with 'nfs/'
+			foreach my $kerberosLogin (@{$memberAttributes{$A_MEMBER_KERBEROS_LOGINS}}) {
+				if($kerberosLogin =~ /^nfs\//) {
+					$logins{$kerberosLogin} = 1;
+				} else {
+					$logins{$kerberosLogin} = 1;
+					my $nfsKerberosLogin = "nfs/" . $kerberosLogin;
+					$logins{$nfsKerberosLogin} = 1;
 				}
+			}
+			for my $login (keys %logins) {
+				my $passwdLine = $login . ":x:" . $memberAttributes{$A_MEMBER_UID} . ":" . $memberAttributes{$A_MEMBER_GID};
 				$lines{$passwdLine} = 1;
 			}
 		}
@@ -65,7 +74,6 @@ foreach my $rData (@resourcesData) {
 open PASSWD,">$passwd_file_name" or die "Cannot open $passwd_file_name: $! \n";
 for my $passwdLine (keys %lines) {
 	print PASSWD $passwdLine, "\n";
-	print PASSWD "nfs/", $passwdLine, "\n";
 }
 close(PASSWD);
 


### PR DESCRIPTION
 - same changes for passwd_nfs4 and passwd_nfs4_mu
 - use defined attribute kerberos logins, because in virtual attribute
   there can be some other not supported logins for this service
 - change behavior of filtering duplicits in logins and creating logins
   with prefix 'nfs/'. Now we use a map with all kerberos logins to
   avoid duplicits and also create a 'nfs/login' equivalent for every
   'login' there