### PR TITLE
Temporary fix to generic_send (exporting env variables)

### DIFF
--- a/send/generic_send
+++ b/send/generic_send
@@ -12,6 +12,8 @@ FACILITY_NAME=$1
 DESTINATION=$2
 DESTINATION_TYPE=$3
 
+unset LC_TIME
+unset LANG
 TRANSPORT_COMMAND="ssh -o StrictHostKeyChecking=no -o GSSAPIAuthentication=no -o GSSAPIKeyExchange=no -o ConnectTimeout=5  -i `echo ~`/.ssh/id_rsa"
 SLAVE_COMMAND="/opt/perun/bin/perun"
 SERVICE_FILES_BASE_DIR="`pwd`/../gen/spool"


### PR DESCRIPTION
     - we don't want to export some environmental variables to the endpoint
     - SendEnv set in ssh_cofig cannot be overwritten
     - so we send them rather empty, for this purpose we need to unset them
     - affected variables are LC_TIME and LANG
     - it is just temporary fix, better solution is to create separate ssh_config