### PR TITLE
Use more compatible variant of using '~~' without warnings

### DIFF
--- a/gen/fs_home
+++ b/gen/fs_home
@@ -1,10 +1,10 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use experimental 'smartmatch';
 use perunServicesInit;
 use perunServicesUtils;
 use File::Basename;
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
 our $SERVICE_NAME = basename($0);
 our $PROTOCOL_VERSION = "3.6.0";

--- a/gen/fs_home_mu
+++ b/gen/fs_home_mu
@@ -1,10 +1,10 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use experimental 'smartmatch';
 use perunServicesInit;
 use perunServicesUtils;
 use File::Basename;
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
 our $SERVICE_NAME = basename($0);
 our $PROTOCOL_VERSION = "3.0.0";

--- a/gen/fs_scratch
+++ b/gen/fs_scratch
@@ -2,10 +2,10 @@
  
 use strict;
 use warnings;
-use experimental 'smartmatch';
 use perunServicesInit;
 use perunServicesUtils;
 use File::Basename;
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
 our $SERVICE_NAME = basename($0);
 our $PROTOCOL_VERSION = "3.4.0";

--- a/send/ADConnector.pm
+++ b/send/ADConnector.pm
@@ -5,7 +5,7 @@ use Exporter 'import';
 
 use strict;
 use warnings;
-no if $] >= 5.018, warnings => "smartmatch";
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
 =pod
 

--- a/send/ad_group
+++ b/send/ad_group
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-no if $] >= 5.018, warnings => "smartmatch";
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 use Net::LDAPS;
 use Net::LDAP::Entry;
 use Net::LDAP::Message;

--- a/send/ad_group_mu_ucn
+++ b/send/ad_group_mu_ucn
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-no if $] >= 5.018, warnings => "smartmatch";
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 use Net::LDAPS;
 use Net::LDAP::Entry;
 use Net::LDAP::Message;

--- a/send/ad_group_vsup
+++ b/send/ad_group_vsup
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-no if $] >= 5.018, warnings => "smartmatch";
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 use Net::LDAPS;
 use Net::LDAP::Entry;
 use Net::LDAP::Message;

--- a/send/ldap_ad_ceitec
+++ b/send/ldap_ad_ceitec
@@ -11,7 +11,7 @@ use Encode;
 use Net::LDAP::Control::Paged;
 use Net::LDAP::Constant qw( LDAP_CONTROL_PAGED );
 use String::Random qw( random_string );
-no if $] >= 5.018, warnings => "smartmatch";
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
 # Import shared AD library
 use ADConnector;


### PR DESCRIPTION
 - '~~' is smartmatch in perl
 - we need to have compatible variant of using it between more versions
   of perl
 - this one seems to be most compatible
 - old one not work under perl version lower than 5.18