### PR TITLE
Manage Azure mapping in ad_user_mu service

### DIFF
--- a/gen/ad_user_mu
+++ b/gen/ad_user_mu
@@ -6,13 +6,14 @@ use perunServicesInit;
 use perunServicesUtils;
 
 local $::SERVICE_NAME = "ad_user_mu";
-local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+local $::PROTOCOL_VERSION = "3.0.1";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
 my $fileName = "$DIRECTORY/$::SERVICE_NAME".".ldif";
 my $baseDnFileName = "$DIRECTORY/baseDN";
+my $optAttrsFileName = "$DIRECTORY/optAttributes";
 
 my $data = perunServicesInit::getFlatData;
 
@@ -20,6 +21,7 @@ my $data = perunServicesInit::getFlatData;
 our $A_F_BASE_DN;  *A_F_BASE_DN = \'urn:perun:facility:attribute-def:def:adBaseDN';
 our $A_F_DOMAIN;  *A_F_DOMAIN = \'urn:perun:facility:attribute-def:def:adDomain';
 our $A_F_UAC;  *A_F_UAC = \'urn:perun:facility:attribute-def:def:adUAC';
+our $A_F_AZURE_DOMAIN;  *A_F_AZURE_DOMAIN = \'urn:perun:facility:attribute-def:def:adAzureDomain';
 our $A_FIRST_NAME;  *A_FIRST_NAME = \'urn:perun:user:attribute-def:core:firstName';
 our $A_LAST_NAME;  *A_LAST_NAME = \'urn:perun:user:attribute-def:core:lastName';
 our $A_DISPLAY_NAME;  *A_DISPLAY_NAME = \'urn:perun:user:attribute-def:core:displayName';
@@ -43,6 +45,7 @@ if (!defined($facilityAttributes{$A_F_UAC})) {
 my $baseDN = $facilityAttributes{$A_F_BASE_DN};
 my $domain = $facilityAttributes{$A_F_DOMAIN};
 my $uac = $facilityAttributes{$A_F_UAC};
+my $azureDomain = $facilityAttributes{$A_F_AZURE_DOMAIN};
 
 # GATHER USERS
 my $users;  # $users->{$login}->{ATTR} = $attrValue;
@@ -52,6 +55,13 @@ my $users;  # $users->{$login}->{ATTR} = $attrValue;
 #
 open FILE,">:encoding(UTF-8)","$baseDnFileName" or die "Cannot open $baseDnFileName: $! \n";
 print FILE $baseDN;
+close(FILE);
+
+#
+# PRINT OPT_ATTRS FILE
+#
+open FILE,">:encoding(UTF-8)","$optAttrsFileName" or die "Cannot open $optAttrsFileName: $! \n";
+if (defined $azureDomain) { print FILE "msDS-cloudExtensionAttribute1"; }
 close(FILE);
 
 #
@@ -128,6 +138,13 @@ for my $login (@logins) {
 	}
 	if (defined $workplaceId and length $workplaceId) {
 		print FILE "departmentNumber: " . $workplaceId . "\n";
+	}
+
+	# OPT ATTRIBUTES
+
+	if (defined $azureDomain) {
+		# manage mapping to Azure AD if present in AD config
+		print FILE "msDS-cloudExtensionAttribute1:" . $login . "@" . $azureDomain . "\n";
 	}
 
 	# print classes

--- a/send/ad_user_mu
+++ b/send/ad_user_mu
@@ -36,6 +36,12 @@ my $base_dn = <$file>;
 chomp($base_dn);
 close $file;
 
+# MANAGE OPT ATTRIBUTES
+open $file, '<', "$service_files_dir/optAttributes";
+my @opt_attrs = <$file>;
+chomp(@opt_attrs);
+close $file;
+
 # propagation destination
 my $namespace = $ARGV[1];
 chomp($namespace);
@@ -55,7 +61,7 @@ ldap_bind($ldap, $conf[1], $conf[2]);
 
 # load all data
 my @perun_entries = load_perun($service_files_dir . "/" . $service_name . ".ldif");
-my @ad_entries = load_ad($ldap, $base_dn, $filter, ['cn','displayName','sn','givenName','mail','userAccountControl','samAccountName','Department','departmentNumber']);
+my @ad_entries = load_ad($ldap, $base_dn, $filter, ['cn','displayName','sn','givenName','mail','userAccountControl','samAccountName','Department','departmentNumber', @opt_attrs]);
 
 my %ad_entries_map = ();
 
@@ -139,7 +145,7 @@ sub process_update() {
 			my $ad_entry = $ad_entries_map{$perun_entry->get_value('samAccountName')};
 
 			# attrs without cn since it's part of DN to be updated
-			my @attrs = ('displayName','sn','givenName','mail','Department','departmentNumber');
+			my @attrs = ('displayName','sn','givenName','mail','Department','departmentNumber', @opt_attrs);
 
 			# stored log messages to check if entry should be updated
 			my @entry_changed = ();


### PR DESCRIPTION
- Added new required attribute "facility:def:adAzureDomain"
  which defines MS Azure domain used for user account mapping
  (login@domain -> for MU učo@domain).
- Send new file with list of "opt" AD attributes to manage. They are appended
  to standard set of attributes (normally required). Like this we can manage
  different set of attributes per facility using same service.
- When value of "f:d:adAzureDomain" attribute is defined, generate
  value for each user entry and push AD attribute name to "opt" attributes.
- Bumped script and protocol version.