### PR TITLE
Always generate optAttributes file in ad_user_mu service

### DIFF
--- a/gen/ad_user_mu
+++ b/gen/ad_user_mu
@@ -61,7 +61,9 @@ close(FILE);
 # PRINT OPT_ATTRS FILE
 #
 open FILE,">:encoding(UTF-8)","$optAttrsFileName" or die "Cannot open $optAttrsFileName: $! \n";
+print FILE ""; # always have an empty file
 if (defined $azureDomain) { print FILE "msDS-cloudExtensionAttribute1"; }
+# append newline in case of adding another attribute !
 close(FILE);
 
 #


### PR DESCRIPTION
- Always generate an empty file "optAttributes" for ad_user_mu_service.
  It's required by send script in order to correctly append empty array to
  managed AD attributes instead of appending "undef" as last element.