### PR TITLE
Do not multiply AD groups by resources in ad_group_* services

### DIFF
--- a/gen/ad_group
+++ b/gen/ad_group
@@ -42,7 +42,7 @@ print FILE $baseGroupDN;
 close(FILE);
 
 my @resourcesData = $data->getChildElements;
-my @groups = ();
+my $groups = {};
 my $usersByResource = {};
 
 # FOR EACH RESOURCE
@@ -50,7 +50,7 @@ foreach my $rData (@resourcesData) {
 
 	my %rAttributes = attributesToHash $rData->getAttributes;
 	my $group = $rAttributes{$A_R_GROUP_NAME};
-	push(@groups, $group);
+	$groups->{$group} = 1;
 
 	# process members
 	my @membersData = $rData->getChildElements;
@@ -78,7 +78,7 @@ foreach my $rData (@resourcesData) {
 #
 open FILE,">:encoding(UTF-8)","$fileName" or die "Cannot open $fileName: $! \n";
 
-for my $group (sort @groups) {
+for my $group (sort keys %$groups) {
 
 	print FILE "dn: CN=" . $group . "," . $baseGroupDN . "\n";
 	print FILE "cn: " . $group . "\n";

--- a/gen/ad_group_mu_ucn
+++ b/gen/ad_group_mu_ucn
@@ -43,7 +43,7 @@ print FILE $baseGroupDN;
 close(FILE);
 
 my @resourcesData = $data->getChildElements;
-my @groups = ();
+my $groups = {};
 my $usersByResource = {};
 
 # FOR EACH RESOURCE
@@ -51,7 +51,7 @@ foreach my $rData (@resourcesData) {
 
 	my %rAttributes = attributesToHash $rData->getAttributes;
 	my $group = $rAttributes{$A_R_GROUP_NAME};
-	push(@groups, $group);
+	$groups->{$group} = 1;
 
 	# process members
 	my @membersData = $rData->getChildElements;
@@ -86,7 +86,7 @@ foreach my $rData (@resourcesData) {
 #
 open FILE,">:encoding(UTF-8)","$fileName" or die "Cannot open $fileName: $! \n";
 
-for my $group (sort @groups) {
+for my $group (sort keys %$groups) {
 
 	print FILE "dn: CN=" . $group . "," . $baseGroupDN . "\n";
 	print FILE "cn: " . $group . "\n";

--- a/gen/ad_group_vsup
+++ b/gen/ad_group_vsup
@@ -42,7 +42,7 @@ print FILE $baseGroupDN;
 close(FILE);
 
 my @resourcesData = $data->getChildElements;
-my @groups = ();
+my $groups = {};
 my $usersByResource = {};
 
 # FOR EACH RESOURCE
@@ -50,7 +50,7 @@ foreach my $rData (@resourcesData) {
 
 	my %rAttributes = attributesToHash $rData->getAttributes;
 	my $group = $rAttributes{$A_R_GROUP_NAME};
-	push(@groups, $group);
+	$groups->{$group} = 1;
 
 	# process members
 	my @membersData = $rData->getChildElements;
@@ -78,7 +78,7 @@ foreach my $rData (@resourcesData) {
 #
 open FILE,">:encoding(UTF-8)","$fileName" or die "Cannot open $fileName: $! \n";
 
-for my $group (sort @groups) {
+for my $group (sort keys %$groups) {
 
 	print FILE "dn: CN=" . $group . "," . $baseGroupDN . "\n";
 	print FILE "cn: " . $group . "\n";


### PR DESCRIPTION
- When multiple resources have same group name in AD, do not
  print them X-times in LDIF, but only once. Otherwise unnecessary
  update/replace on members is performed X-times.