### PR TITLE
Better TaskResult output in AD services

### DIFF
--- a/send/ad_group
+++ b/send/ad_group
@@ -83,7 +83,15 @@ ldap_log($service_name, "Removed: " . $counter_remove . " entries.");
 ldap_log($service_name, "Updated: " . $counter_update. " entries.");
 ldap_log($service_name, "Failed: " . $counter_fail. " entries.");
 
+# print results for TaskResults in GUI
+print "Added: " . $counter_add . " entries.\n";
+print "Removed: " . $counter_remove . " entries.\n";
+print "Updated: " . $counter_update. " entries.\n";
+print "Failed: " . $counter_fail. " entries.\n";
+
 $lock->unlock();
+
+if ($counter_fail > 0) { die "Failed to process: " . $counter_fail . " entries.\nSee log at: ~/perun-engine/send/logs/$service_name.log";}
 
 # END of main script
 

--- a/send/ad_group_mu_ucn
+++ b/send/ad_group_mu_ucn
@@ -83,7 +83,15 @@ ldap_log($service_name, "Removed: " . $counter_remove . " entries.");
 ldap_log($service_name, "Updated: " . $counter_update. " entries.");
 ldap_log($service_name, "Failed: " . $counter_fail. " entries.");
 
+# print results for TaskResults in GUI
+print "Added: " . $counter_add . " entries.\n";
+print "Removed: " . $counter_remove . " entries.\n";
+print "Updated: " . $counter_update. " entries.\n";
+print "Failed: " . $counter_fail. " entries.\n";
+
 $lock->unlock();
+
+if ($counter_fail > 0) { die "Failed to process: " . $counter_fail . " entries.\nSee log at: ~/perun-engine/send/logs/$service_name.log";}
 
 # END of main script
 

--- a/send/ad_group_vsup
+++ b/send/ad_group_vsup
@@ -68,7 +68,13 @@ ldap_unbind($ldap);
 ldap_log($service_name, "Updated: " . $counter_update. " entries.");
 ldap_log($service_name, "Failed: " . $counter_fail. " entries.");
 
+# print results for TaskResults in GUI
+print "Updated: " . $counter_update. " entries.\n";
+print "Failed: " . $counter_fail. " entries.\n";
+
 $lock->unlock();
+
+if ($counter_fail > 0) { die "Failed to process: " . $counter_fail . " entries.\nSee log at: ~/perun-engine/send/logs/$service_name.log";}
 
 # END of main script
 

--- a/send/ad_user_mu
+++ b/send/ad_user_mu
@@ -86,7 +86,14 @@ ldap_log($service_name, "Added: " . $counter_add . " entries.");
 ldap_log($service_name, "Updated: " . $counter_update. " entries.");
 ldap_log($service_name, "Failed: " . $counter_fail. " entries.");
 
+# print results for TaskResults in GUI
+print "Added: " . $counter_add . " entries.\n";
+print "Updated: " . $counter_update. " entries.\n";
+print "Failed: " . $counter_fail. " entries.\n";
+
 $lock->unlock();
+
+if ($counter_fail > 0) { die "Failed to process: " . $counter_fail . " entries.\nSee log at: ~/perun-engine/send/logs/$service_name.log";}
 
 # END of main script
 

--- a/send/ad_user_mu_ucn
+++ b/send/ad_user_mu_ucn
@@ -81,7 +81,14 @@ ldap_log($service_name, "Added: " . $counter_add . " entries.");
 ldap_log($service_name, "Updated: " . $counter_update. " entries.");
 ldap_log($service_name, "Failed: " . $counter_fail. " entries.");
 
+# print results for TaskResults in GUI
+print "Added: " . $counter_add . " entries.\n";
+print "Updated: " . $counter_update. " entries.\n";
+print "Failed: " . $counter_fail. " entries.\n";
+
 $lock->unlock();
+
+if ($counter_fail > 0) { die "Failed to process: " . $counter_fail . " entries.\nSee log at: ~/perun-engine/send/logs/$service_name.log";}
 
 # END of main script
 

--- a/send/ad_user_vsup
+++ b/send/ad_user_vsup
@@ -96,7 +96,16 @@ ldap_log($service_name, "Updated: " . $counter_update. " entries (including rena
 ldap_log($service_name, "Disabled: " . $counter_disable. " entries.");
 ldap_log($service_name, "Failed: " . $counter_fail. " entries.");
 
+# print results for TaskResults in GUI
+print "Added: " . $counter_add . " entries.\n";
+print "Renamed: " . $counter_move . " entries.\n";
+print "Updated: " . $counter_update. " entries (including renamed).\n";
+print "Disabled: " . $counter_disable. " entries.\n";
+print "Failed: " . $counter_fail. " entries.\n";
+
 $lock->unlock();
+
+if ($counter_fail > 0) { die "Failed to process: " . $counter_fail . " entries.\nSee log at: ~/perun-engine/send/logs/$service_name.log";}
 
 # END of main script
 

--- a/send/ad_user_vsup_service
+++ b/send/ad_user_vsup_service
@@ -96,7 +96,16 @@ ldap_log($service_name, "Updated: " . $counter_update. " entries (including rena
 ldap_log($service_name, "Disabled: " . $counter_disable. " entries.");
 ldap_log($service_name, "Failed: " . $counter_fail. " entries.");
 
+# print results for TaskResults in GUI
+print "Added: " . $counter_add . " entries.\n";
+print "Renamed: " . $counter_move . " entries.\n";
+print "Updated: " . $counter_update. " entries (including renamed).\n";
+print "Disabled: " . $counter_disable. " entries.\n";
+print "Failed: " . $counter_fail. " entries.\n";
+
 $lock->unlock();
+
+if ($counter_fail > 0) { die "Failed to process: " . $counter_fail . " entries.\nSee log at: ~/perun-engine/send/logs/$service_name.log";}
 
 # END of main script
 


### PR DESCRIPTION
- All AD services print change counters to stdout so it's visible
  in admin GUI (TaskResult).
- If change of entry fails, let script die with message also shown
  in admin GUI (TaskResult).