### PR TITLE
Fix undefined values in some core attributes for gen scripts

### DIFF
--- a/gen/ad_user_vsup
+++ b/gen/ad_user_vsup
@@ -83,8 +83,8 @@ foreach my $user (($data->getChildElements)[1]->getChildElements) {
 
 		$users->{$login}->{"DN"} = "CN=".$uAttributes{$A_LOGIN}.",".$baseDN;
 		# store standard attrs
-		$users->{$login}->{$A_FIRST_NAME} = (defined $uAttributes{$A_ARTISTIC_FIRST_NAME} ? $uAttributes{$A_ARTISTIC_FIRST_NAME} : (defined $uAttributes{$A_FIRST_NAME} ? $uAttributes{$A_FIRST_NAME} : undef));
-		$users->{$login}->{$A_LAST_NAME} = (defined $uAttributes{$A_ARTISTIC_LAST_NAME} ? $uAttributes{$A_ARTISTIC_LAST_NAME} : (defined $uAttributes{$A_LAST_NAME} ? $uAttributes{$A_LAST_NAME} : undef));
+		$users->{$login}->{$A_FIRST_NAME} = $uAttributes{$A_ARTISTIC_FIRST_NAME} || $uAttributes{$A_FIRST_NAME};
+		$users->{$login}->{$A_LAST_NAME} = $uAttributes{$A_ARTISTIC_LAST_NAME} || $uAttributes{$A_LAST_NAME};
 		$users->{$login}->{$A_UCO} = $uAttributes{$A_UCO};
 		$users->{$login}->{$A_TITLE_BEFORE} = $uAttributes{$A_TITLE_BEFORE};
 		$users->{$login}->{$A_TITLE_AFTER} = $uAttributes{$A_TITLE_AFTER};

--- a/gen/ad_user_vsup_service
+++ b/gen/ad_user_vsup_service
@@ -83,8 +83,8 @@ foreach my $user (($data->getChildElements)[1]->getChildElements) {
 
 		$users->{$login}->{"DN"} = "CN=" . $uAttributes{$A_LOGIN} . "," . $baseDN;
 		# store standard attrs
-		$users->{$login}->{$A_FIRST_NAME} = (defined $uAttributes{$A_ARTISTIC_FIRST_NAME} ? $uAttributes{$A_ARTISTIC_FIRST_NAME} : (defined $uAttributes{$A_FIRST_NAME} ? $uAttributes{$A_FIRST_NAME} : undef));
-		$users->{$login}->{$A_LAST_NAME} = (defined $uAttributes{$A_ARTISTIC_LAST_NAME} ? $uAttributes{$A_ARTISTIC_LAST_NAME} : (defined $uAttributes{$A_LAST_NAME} ? $uAttributes{$A_LAST_NAME} : undef));
+		$users->{$login}->{$A_FIRST_NAME} = $uAttributes{$A_ARTISTIC_FIRST_NAME} || $uAttributes{$A_FIRST_NAME};
+		$users->{$login}->{$A_LAST_NAME} = $uAttributes{$A_ARTISTIC_LAST_NAME} || $uAttributes{$A_LAST_NAME};
 		$users->{$login}->{$A_UCO} = $uAttributes{$A_UCO};
 		$users->{$login}->{$A_TITLE_BEFORE} = $uAttributes{$A_TITLE_BEFORE};
 		$users->{$login}->{$A_TITLE_AFTER} = $uAttributes{$A_TITLE_AFTER};

--- a/gen/appDB
+++ b/gen/appDB
@@ -79,10 +79,18 @@ for my $voData (@vosData) {
 				          };
 			}
 
+			my $userName = "";
+			if($memberAttributes{$A_USER_FIRST_NAME}) {
+				$userName = $memberAttributes{$A_USER_FIRST_NAME};
+				$userName.= " " . $memberAttributes{$A_USER_LAST_NAME} if $memberAttributes{$A_USER_LAST_NAME};
+			} else {
+				$userName.= $memberAttributes{$A_USER_LAST_NAME} if $memberAttributes{$A_USER_LAST_NAME};
+			}
+	
 			# add user to contact role  (for VOs xml)
 			if(defined $resourcesAttributes{$A_R_APPDB_CONTACT_ROLE}) {
 				$voContacts->{$voShortName}->{$resourcesAttributes{$A_R_APPDB_CONTACT_ROLE} . "-" . $memberAttributes{$A_USER_ID}} = {
-						"name" => [ $memberAttributes{$A_USER_FIRST_NAME} . " " . $memberAttributes{$A_USER_LAST_NAME} ],
+						"name" => [ $userName ],
 						"role" => [ $resourcesAttributes{$A_R_APPDB_CONTACT_ROLE} ],
 						"email" => [ $memberAttributes{$A_USER_MAIL} ],
 						"sso" => [ {} ],
@@ -96,7 +104,7 @@ for my $voData (@vosData) {
 
 			#prepare user record  (for users xml)
 			my @row = {
-									"uservo" => [ $memberAttributes{$A_USER_FIRST_NAME} . " " . $memberAttributes{$A_USER_LAST_NAME} ],
+									"uservo" => [ $userName ],
 									"vo" => [ $vosAttributes{$A_VO_SHORT_NAME} ],
 									"email" => [ $memberAttributes{$A_USER_MAIL} ],
 									"sso" => [ {} ],

--- a/gen/ceitec_proteomics
+++ b/gen/ceitec_proteomics
@@ -103,8 +103,8 @@ sub processUsers {
 	my $uid = $memberAttributes{$A_USER_ID};
 
 	unless(exists $userStruc->{$uid}) {
-		$userStruc->{$uid}->{$u_name} = $memberAttributes{$A_USER_NAME};
-		$userStruc->{$uid}->{$u_surname} = $memberAttributes{$A_USER_SURNAME};
+		$userStruc->{$uid}->{$u_name} = $memberAttributes{$A_USER_NAME} || "";
+		$userStruc->{$uid}->{$u_surname} = $memberAttributes{$A_USER_SURNAME} || "";
 		$userStruc->{$uid}->{$u_email} = $memberAttributes{$A_USER_EMAIL};
 		$userStruc->{$uid}->{$u_eppns} = $memberAttributes{$A_USER_EPPN};
 	}

--- a/gen/crm_ceitec
+++ b/gen/crm_ceitec
@@ -71,8 +71,8 @@ open FILE,">:encoding(UTF-8)","$fileName" or die "Cannot open $fileName: $! \n";
 my @logins = sort keys %{$users};
 for my $login (@logins) {
 
-	my $lastName = $users->{$login}->{$A_LAST_NAME};
-	my $firstName = $users->{$login}->{$A_FIRST_NAME};
+	my $lastName = $users->{$login}->{$A_LAST_NAME} || "";
+	my $firstName = $users->{$login}->{$A_FIRST_NAME} || "";
 	my $mail = $users->{$login}->{$A_MAIL};
 	my $o = $users->{$login}->{$A_O};
 	my $eppns = $users->{$login}->{$A_EPPNS};

--- a/gen/du_users_export
+++ b/gen/du_users_export
@@ -126,8 +126,8 @@ foreach my $rData (@resourcesData) {
 					push @associatedUsers, 
 										{
 											"PerunUserID" => $richUser->{'_id'},
-											"FirstName" => $richUser->{'_firstName'},
-											"LastName" => $richUser->{'_lastName'},
+											"FirstName" => $richUser->{'_firstName'} || "",
+											"LastName" => $richUser->{'_lastName'} || "",
 											"PreferredMail" => $assocUserAttrs->{$A_USER_MAIL},
 											"LoginInEINFRA" => $assocUserAttrs->{$A_USER_LOGIN_EINFRA} ? $assocUserAttrs->{$A_USER_LOGIN_EINFRA}  : "",
 											"KerberosPrincipals" => \@assocUserKerberosLogins,
@@ -146,8 +146,8 @@ foreach my $rData (@resourcesData) {
 									"Kerberos"        => \@kerberosLogins,
 									"Shibboleth"      => \@shibbolethLogins,
 									"PerunUserID"     => $memberAttributes{$A_USER_ID},
-									"FirstName"       => $memberAttributes{$A_USER_FIRSTNAME},
-									"LastName"        => $memberAttributes{$A_USER_LASTNAME},
+									"FirstName"       => $memberAttributes{$A_USER_FIRSTNAME} || "",
+									"LastName"        => $memberAttributes{$A_USER_LASTNAME} || "",
 									"ResearchGroup"   => defined $memberAttributes{$A_U_RESEARCH_GROUP} ? $memberAttributes{$A_U_RESEARCH_GROUP} : "",
 									"Organization"    => defined $memberAttributes{$A_U_ORGANIZATION} ? $memberAttributes{$A_U_ORGANIZATION} : "",
 								};
@@ -266,8 +266,8 @@ for my $vo (keys %attributesByVo) {
 			push @voAdmins, 
 					{
 						"PerunUserID" => $richAdmin->{'_id'},
-						"FirstName" => $richAdmin->{'_firstName'},
-						"LastName" => $richAdmin->{'_lastName'},
+						"FirstName" => $richAdmin->{'_firstName'} || "",
+						"LastName" => $richAdmin->{'_lastName'} || "",
 						"PreferredMail" => $adminAttributes->{$A_USER_MAIL},
 						"LoginInEINFRA" => $adminAttributes->{$A_USER_LOGIN_EINFRA} ? $adminAttributes->{$A_USER_LOGIN_EINFRA}  : "",
 						"KerberosPrincipals" => \@kerberosLogins,

--- a/gen/ldap
+++ b/gen/ldap
@@ -85,9 +85,10 @@ foreach my $rData (@resourcesData) {
 		}
 
 		# Store same member in flat structure (use USER attributes)
-		$users->{$login}->{$A_DISPLAY_NAME} = $mAttributes{$A_DISPLAY_NAME};
+		# FirstName can be undefined, display_name and last_name not (so set them to string null) to avoid it
+		$users->{$login}->{$A_DISPLAY_NAME} = (defined $mAttributes{$A_DISPLAY_NAME} and length $mAttributes{$A_DISPLAY_NAME}) ? $mAttributes{$A_DISPLAY_NAME} : "null";
 		$users->{$login}->{$A_FIRST_NAME} = $mAttributes{$A_FIRST_NAME};
-		$users->{$login}->{$A_LAST_NAME} = $mAttributes{$A_LAST_NAME};
+		$users->{$login}->{$A_LAST_NAME} = $mAttributes{$A_LAST_NAME} || "null";
 		$users->{$login}->{$A_ORGANIZATION} = $mAttributes{$A_ORGANIZATION};
 		$users->{$login}->{$A_MAIL} = $mAttributes{$A_MAIL};
 

--- a/gen/passwd
+++ b/gen/passwd
@@ -109,8 +109,16 @@ foreach my $memberAttributes (sort $sortingFunction (values %memberAttributesByL
 	print PASSWD $memberAttributes->{$A_USER_LOGIN}.":x:";
 	print PASSWD $memberAttributes->{$A_USER_FACILITY_UID}.":";
 	print PASSWD $memberAttributes->{$A_USER_FACILITY_GID}.":";
-	print PASSWD unidecode($memberAttributes->{$A_USER_FIRST_NAME})." ";
-	print PASSWD unidecode($memberAttributes->{$A_USER_LAST_NAME}).":";
+
+	my $userName = "";
+	if($memberAttributes->{$A_USER_FIRST_NAME}) {
+		$userName = unidecode($memberAttributes->{$A_USER_FIRST_NAME});
+		$userName.= " " . unidecode($memberAttributes->{$A_USER_LAST_NAME}) if $memberAttributes->{$A_USER_LAST_NAME};
+	} else {
+		$userName.= unidecode($memberAttributes->{$A_USER_LAST_NAME}) if $memberAttributes->{$A_USER_LAST_NAME};
+	}
+
+	print PASSWD $userName . ":";
 	print PASSWD $memberAttributes->{$A_USER_FACILITY_HOME_MOUNT_POINT}."/".$memberAttributes->{$A_USER_LOGIN}.":";
 	print PASSWD $memberAttributes->{$A_USER_FACILITY_SHELL};
 	print PASSWD "\n";

--- a/gen/passwd_mu
+++ b/gen/passwd_mu
@@ -112,8 +112,16 @@ foreach my $memberAttributes (sort $sortingFunction (values %memberAttributesByL
 	print PASSWD $memberAttributes->{$A_USER_LOGIN}.":x:";
 	print PASSWD $memberAttributes->{$A_USER_FACILITY_UID}.":";
 	print PASSWD $memberAttributes->{$A_USER_FACILITY_GID}.":";
-	print PASSWD unidecode($memberAttributes->{$A_USER_FIRST_NAME})." ";
-	print PASSWD unidecode($memberAttributes->{$A_USER_LAST_NAME}).":";
+
+	my $userName = "";
+	if($memberAttributes->{$A_USER_FIRST_NAME}) {
+		$userName = unidecode($memberAttributes->{$A_USER_FIRST_NAME});
+		$userName.= " " . unidecode($memberAttributes->{$A_USER_LAST_NAME}) if $memberAttributes->{$A_USER_LAST_NAME};
+	} else {
+		$userName.= unidecode($memberAttributes->{$A_USER_LAST_NAME}) if $memberAttributes->{$A_USER_LAST_NAME};
+	}
+
+	print PASSWD $userName . ":";
 	print PASSWD $memberAttributes->{$A_USER_FACILITY_HOME_MOUNT_POINT}."/".$memberAttributes->{$A_USER_LOGIN}.":";
 	print PASSWD $memberAttributes->{$A_USER_FACILITY_SHELL};
 	if(defined($memberAttributes->{$A_USER_OPTIONAL_LOGIN})) {

--- a/gen/passwd_scp
+++ b/gen/passwd_scp
@@ -68,8 +68,16 @@ for my $login (sort keys %$userAttributesByLogin) {
 	print PASSWD $memberAttributes{$A_USER_LOGIN}.":x:";
 	print PASSWD $memberAttributes{$A_USER_FACILITY_UID}.":";
 	print PASSWD $memberAttributes{$A_USER_FACILITY_GID}.":";
-	print PASSWD unidecode($memberAttributes{$A_USER_FIRST_NAME})." ";
-	print PASSWD unidecode($memberAttributes{$A_USER_LAST_NAME}).":";
+
+	my $userName = "";
+	if($memberAttributes{$A_USER_FIRST_NAME}) { 
+		$userName = $memberAttributes{$A_USER_FIRST_NAME};
+		$userName.= " " . $memberAttributes{$A_USER_LAST_NAME} if $memberAttributes{$A_USER_LAST_NAME};
+	} else {
+		$userName.= $memberAttributes{$A_USER_LAST_NAME} if $memberAttributes{$A_USER_LAST_NAME};
+	}
+
+	print PASSWD unidecode($userName) . ":";
 	print PASSWD $memberAttributes{$A_USER_FACILITY_HOME_MOUNT_POINT}."/".$memberAttributes{$A_USER_LOGIN}.":";
 
 	print PASSWD $memberAttributes{$A_USER_FACILITY_SHELL};

--- a/gen/redmine
+++ b/gen/redmine
@@ -111,8 +111,8 @@ sub processUsers {
 
 	my %memberAttributes = attributesToHash $memberData->getAttributes;
 
-	my $firstName =        $memberAttributes{$A_USER_FIRSTNAME};
-	my $lastName =         $memberAttributes{$A_USER_LASTNAME};
+	my $firstName =        $memberAttributes{$A_USER_FIRSTNAME} || "";
+	my $lastName =         $memberAttributes{$A_USER_LASTNAME} || "";
 	my $login =            $memberAttributes{$A_USER_LOGIN};
 	my $email =            $memberAttributes{$A_USER_EMAIL};
 	my @eppns =            @{$memberAttributes{$A_USER_EPPNS}};


### PR DESCRIPTION
 - there is a new behavior of retutning core attributes from perun RPC,
   now we get UNDEF for null value in core attribute
 - for this reason we need to change behavior of working with core
   attributes in some gen scripts
 - mainly problematic attributes are user attributes (first_name,
   last_name, middle_name, title_before, title_after)
 - every service has it's own way how to work with undefined values in
   these core attributes