### PR TITLE
Remove dependency on group name in VŠUP services

### DIFF
--- a/gen/vsup_kos
+++ b/gen/vsup_kos
@@ -4,16 +4,15 @@ use strict;
 use warnings;
 use perunServicesInit;
 use perunServicesUtils;
-sub begins_with;
 
 local $::SERVICE_NAME = "vsup_kos";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.1";
+my $SCRIPT_VERSION = "3.0.2";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
 my $fileName = "$DIRECTORY/$::SERVICE_NAME".".csv";
-my $data = perunServicesInit::getDataWithGroups;
+my $data = perunServicesInit::getHierarchicalData;
 
 # Constants
 our $A_LOGIN; *A_LOGIN = \'urn:perun:user_facility:attribute-def:virt:login';
@@ -37,7 +36,7 @@ our $A_PHONE;  *A_PHONE = \'urn:perun:user:attribute-def:def:phone';
 our $A_EMAIL_PRIV;  *A_EMAIL_PRIV = \'urn:perun:user:attribute-def:opt:privateMail';
 our $A_PHONE_PRIV;  *A_PHONE_PRIV = \'urn:perun:user:attribute-def:opt:privatePhone';
 
-our $A_GROUP_NAME; *A_GROUP_NAME = \'urn:perun:group:attribute-def:core:name';
+our $A_R_RELATION_TYPE; *A_R_RELATION_TYPE = \'urn:perun:resource:attribute-def:def:relationType';
 
 # GATHER USERS
 my $users;  # $users->{$osbIddc2}->{ATTR} = $attrValue;
@@ -48,59 +47,33 @@ my $users;  # $users->{$osbIddc2}->{ATTR} = $attrValue;
 # FOR EACH RESOURCE
 foreach my $rData ($data->getChildElements) {
 
-	my @groupsData = ($rData->getChildElements)[0]->getChildElements;
+	my %resourceAttributes = attributesToHash $rData->getAttributes;
+	my $relationType = $resourceAttributes{$A_R_RELATION_TYPE};
+	my @membersData = $rData->getChildElements;
 
-	foreach my $group (@groupsData) {
+	foreach my $member (@membersData) {
 
-		my %gAttributes = attributesToHash $group->getAttributes;
+		my %uAttributes = attributesToHash $member->getAttributes;
 
-		if ((begins_with($gAttributes{$A_GROUP_NAME},"Studenti:")) or
-			($gAttributes{$A_GROUP_NAME} eq "Absolventi") or
-			($gAttributes{$A_GROUP_NAME} eq "Zamestnanci:Pedagog") or
-			($gAttributes{$A_GROUP_NAME} eq "Externiste:Pedagogicti")
-		) {
+		my $key = $uAttributes{$A_UCO} . ":" . $relationType;
+		$users->{$key}->{$A_UCO} = $uAttributes{$A_UCO};
+		$users->{$key}->{$A_OSB_ID_KOS} = $uAttributes{$A_OSB_ID_KOS} || '';
+		$users->{$key}->{$A_LOGIN} = $uAttributes{$A_LOGIN};
+		$users->{$key}->{'EMAIL'} = $uAttributes{$A_LOGIN}.'@vsup.cz';
+		$users->{$key}->{'TYP_ZAZN'} = $relationType;
+		$users->{$key}->{$A_TITLE_BEFORE} = $uAttributes{$A_TITLE_BEFORE} || '';
+		$users->{$key}->{$A_FIRST_NAME} = ($uAttributes{$A_ARTISTIC_FIRST_NAME} || ($uAttributes{$A_FIRST_NAME} || ''));
+		$users->{$key}->{$A_LAST_NAME} = ($uAttributes{$A_ARTISTIC_LAST_NAME} || ($uAttributes{$A_LAST_NAME} || ''));
+		$users->{$key}->{$A_TITLE_AFTER} = $uAttributes{$A_TITLE_AFTER} || '';
 
-			my @membersData = ($group->getChildElements)[1]->getChildElements;
-			foreach my $member (@membersData) {
+		$users->{$key}->{$A_BIRTH_LAST_NAME} = $uAttributes{$A_BIRTH_LAST_NAME} || '';
+		$users->{$key}->{$A_BIRTH_NUMBER} = $uAttributes{$A_BIRTH_NUMBER} || '';
+		$users->{$key}->{$A_GENDER} = $uAttributes{$A_GENDER} || '';
+		$users->{$key}->{$A_JOB} = $uAttributes{$A_JOB} || '';
 
-				my %uAttributes = attributesToHash $member->getAttributes;
-
-				## determine entry type
-				my $zazn;
-				if (($gAttributes{$A_GROUP_NAME} eq "Studenti:Aktivni") or ($gAttributes{$A_GROUP_NAME} eq "Studenti:Cekatele") or
-					($gAttributes{$A_GROUP_NAME} eq "Studenti:Cizi") or ($gAttributes{$A_GROUP_NAME} eq "Studenti:Preruseni") or
-					($gAttributes{$A_GROUP_NAME} eq "Absolventi")) {
-					$zazn = "S";
-				} elsif (($gAttributes{$A_GROUP_NAME} eq "Zamestnanci:Pedagog") or ($gAttributes{$A_GROUP_NAME} eq "Externiste:Pedagogicti") or
-					($gAttributes{$A_GROUP_NAME} eq "Studenti:Doktorandi")) {
-					$zazn = "P";
-				}
-
-				my $key = $uAttributes{$A_UCO} . ":" . $zazn;
-				$users->{$key}->{$A_UCO} = $uAttributes{$A_UCO};
-				$users->{$key}->{$A_OSB_ID_KOS} = (defined $uAttributes{$A_OSB_ID_KOS} ? $uAttributes{$A_OSB_ID_KOS} : '');
-				$users->{$key}->{$A_LOGIN} = $uAttributes{$A_LOGIN};
-				$users->{$key}->{'EMAIL'} = $uAttributes{$A_LOGIN}.'@vsup.cz';
-				$users->{$key}->{'TYP_ZAZN'} = $zazn;
-				$users->{$key}->{$A_TITLE_BEFORE} = (defined $uAttributes{$A_TITLE_BEFORE} ? $uAttributes{$A_TITLE_BEFORE} : '');
-				$users->{$key}->{$A_FIRST_NAME} = (defined $uAttributes{$A_ARTISTIC_FIRST_NAME} ? $uAttributes{$A_ARTISTIC_FIRST_NAME} : (defined $uAttributes{$A_FIRST_NAME} ? $uAttributes{$A_FIRST_NAME} : ''));
-				$users->{$key}->{$A_LAST_NAME} = (defined $uAttributes{$A_ARTISTIC_LAST_NAME} ? $uAttributes{$A_ARTISTIC_LAST_NAME} : (defined $uAttributes{$A_LAST_NAME} ? $uAttributes{$A_LAST_NAME} : ''));
-				$users->{$key}->{$A_TITLE_AFTER} = (defined $uAttributes{$A_TITLE_AFTER} ? $uAttributes{$A_TITLE_AFTER} : '');
-
-				$users->{$key}->{$A_BIRTH_LAST_NAME} = (defined $uAttributes{$A_BIRTH_LAST_NAME} ? $uAttributes{$A_BIRTH_LAST_NAME} : '');
-				$users->{$key}->{$A_BIRTH_NUMBER} = (defined $uAttributes{$A_BIRTH_NUMBER} ? $uAttributes{$A_BIRTH_NUMBER} : '');
-				$users->{$key}->{$A_GENDER} = (defined $uAttributes{$A_GENDER} ? $uAttributes{$A_GENDER} : '');
-				$users->{$key}->{$A_JOB} = (defined $uAttributes{$A_JOB} ? $uAttributes{$A_JOB} : '');
-
-				$users->{$key}->{$A_PHONE} = (defined $uAttributes{$A_PHONE} ? $uAttributes{$A_PHONE} : '');
-				$users->{$key}->{$A_EMAIL_PRIV} = (defined $uAttributes{$A_EMAIL_PRIV} ? $uAttributes{$A_EMAIL_PRIV} : '');
-				$users->{$key}->{$A_PHONE_PRIV} = (defined $uAttributes{$A_PHONE_PRIV} ? $uAttributes{$A_PHONE_PRIV} : '');
-
-			}
-
-		} else {
-			next;
-		}
+		$users->{$key}->{$A_PHONE} = $uAttributes{$A_PHONE} || '';
+		$users->{$key}->{$A_EMAIL_PRIV} = $uAttributes{$A_EMAIL_PRIV} || '';
+		$users->{$key}->{$A_PHONE_PRIV} = $uAttributes{$A_PHONE_PRIV} || '';
 
 	}
 
@@ -118,20 +91,16 @@ for my $key (@keys) {
 
 	# print attributes, which are never empty
 	print FILE $key . "\t" . $users->{$key}->{$A_UCO}. "\t" . $users->{$key}->{$A_OSB_ID_KOS} . "\t" . $users->{$key}->{$A_LOGIN} . "\t" .
-			$users->{$key}->{'EMAIL'} . "\t" . $users->{$key}->{'TYP_ZAZN'} . "\t" .
-			$users->{$key}->{$A_TITLE_BEFORE} . "\t" . $users->{$key}->{$A_FIRST_NAME} . "\t" .
-			$users->{$key}->{$A_LAST_NAME} . "\t" . $users->{$key}->{$A_TITLE_AFTER} . "\t" .
-			$users->{$key}->{$A_BIRTH_LAST_NAME} . "\t" . $users->{$key}->{$A_BIRTH_NUMBER} . "\t" .
-			$users->{$key}->{$A_GENDER} . "\t" . $users->{$key}->{$A_JOB} . "\t" .
-			$users->{$key}->{$A_PHONE} . "\t" . $users->{$key}->{$A_EMAIL_PRIV} . "\t" .
-			$users->{$key}->{$A_PHONE_PRIV} . "\n";
+		$users->{$key}->{'EMAIL'} . "\t" . $users->{$key}->{'TYP_ZAZN'} . "\t" .
+		$users->{$key}->{$A_TITLE_BEFORE} . "\t" . $users->{$key}->{$A_FIRST_NAME} . "\t" .
+		$users->{$key}->{$A_LAST_NAME} . "\t" . $users->{$key}->{$A_TITLE_AFTER} . "\t" .
+		$users->{$key}->{$A_BIRTH_LAST_NAME} . "\t" . $users->{$key}->{$A_BIRTH_NUMBER} . "\t" .
+		$users->{$key}->{$A_GENDER} . "\t" . $users->{$key}->{$A_JOB} . "\t" .
+		$users->{$key}->{$A_PHONE} . "\t" . $users->{$key}->{$A_EMAIL_PRIV} . "\t" .
+		$users->{$key}->{$A_PHONE_PRIV} . "\n";
 
 }
 
 close(FILE);
 
 perunServicesInit::finalize;
-
-sub begins_with {
-	return substr($_[0], 0, length($_[1])) eq $_[1];
-}

--- a/gen/vsup_rav
+++ b/gen/vsup_rav
@@ -42,11 +42,11 @@ foreach my $user (($data->getChildElements)[1]->getChildElements) {
 	my $uco = $uAttributes{$A_UCO};
 	$users->{$uco}->{$A_LOGIN} = $uAttributes{$A_LOGIN};
 	$users->{$uco}->{$A_VSUP_MAIL} = $uAttributes{$A_VSUP_MAIL};
-	$users->{$uco}->{$A_FIRST_NAME} = (defined $uAttributes{$A_ARTISTIC_FIRST_NAME} ? $uAttributes{$A_ARTISTIC_FIRST_NAME} : (defined $uAttributes{$A_FIRST_NAME} ? $uAttributes{$A_FIRST_NAME} : ''));
-	$users->{$uco}->{$A_LAST_NAME} = (defined $uAttributes{$A_ARTISTIC_LAST_NAME} ? $uAttributes{$A_ARTISTIC_LAST_NAME} : (defined $uAttributes{$A_LAST_NAME} ? $uAttributes{$A_LAST_NAME} : ''));
-	$users->{$uco}->{$A_TITLE_BEFORE} = (defined $uAttributes{$A_TITLE_BEFORE} ? $uAttributes{$A_TITLE_BEFORE} : '');
-	$users->{$uco}->{$A_TITLE_AFTER} = (defined $uAttributes{$A_TITLE_AFTER} ? $uAttributes{$A_TITLE_AFTER} : '');
-	$users->{$uco}->{$A_PHONE} = (defined $uAttributes{$A_PHONE} ? $uAttributes{$A_PHONE} : '');
+	$users->{$uco}->{$A_TITLE_BEFORE} = $uAttributes{$A_TITLE_BEFORE} || '';
+	$users->{$uco}->{$A_FIRST_NAME} = ($uAttributes{$A_ARTISTIC_FIRST_NAME} || ($uAttributes{$A_FIRST_NAME} || ''));
+	$users->{$uco}->{$A_LAST_NAME} = ($uAttributes{$A_ARTISTIC_LAST_NAME} || ($uAttributes{$A_LAST_NAME} || ''));
+	$users->{$uco}->{$A_TITLE_AFTER} = $uAttributes{$A_TITLE_AFTER} || '';
+	$users->{$uco}->{$A_PHONE} = $uAttributes{$A_PHONE} || '';
 
 	# if multiple, send only first one
 	if (defined $uAttributes{$A_CARD_BARCODES}) {

--- a/gen/vsup_tritius
+++ b/gen/vsup_tritius
@@ -53,13 +53,13 @@ foreach my $user (($data->getChildElements)[1]->getChildElements) {
 	my $uco = $uAttributes{$A_UCO};
 	$users->{$uco}->{$A_LOGIN} = $uAttributes{$A_LOGIN};
 	$users->{$uco}->{$A_VSUP_MAIL} = $uAttributes{$A_VSUP_MAIL};
-	$users->{$uco}->{$A_FIRST_NAME} = (defined $uAttributes{$A_ARTISTIC_FIRST_NAME} ? $uAttributes{$A_ARTISTIC_FIRST_NAME} : (defined $uAttributes{$A_FIRST_NAME} ? $uAttributes{$A_FIRST_NAME} : ''));
-	$users->{$uco}->{$A_LAST_NAME} = (defined $uAttributes{$A_ARTISTIC_LAST_NAME} ? $uAttributes{$A_ARTISTIC_LAST_NAME} : (defined $uAttributes{$A_LAST_NAME} ? $uAttributes{$A_LAST_NAME} : ''));
-	$users->{$uco}->{$A_TITLE_BEFORE} = (defined $uAttributes{$A_TITLE_BEFORE} ? $uAttributes{$A_TITLE_BEFORE} : '');
-	$users->{$uco}->{$A_TITLE_AFTER} = (defined $uAttributes{$A_TITLE_AFTER} ? $uAttributes{$A_TITLE_AFTER} : '');
-	$users->{$uco}->{$A_PHONE} = (defined $uAttributes{$A_PHONE} ? $uAttributes{$A_PHONE} : '');
-	$users->{$uco}->{$A_GENDER} = (defined $uAttributes{$A_GENDER} ? $uAttributes{$A_GENDER} : '');
-	$users->{$uco}->{$A_BIRTH_NUMBER} = (defined $uAttributes{$A_BIRTH_NUMBER} ? $uAttributes{$A_BIRTH_NUMBER} : '');
+	$users->{$uco}->{$A_TITLE_BEFORE} = $uAttributes{$A_TITLE_BEFORE} || '';
+	$users->{$uco}->{$A_FIRST_NAME} = ($uAttributes{$A_ARTISTIC_FIRST_NAME} || ($uAttributes{$A_FIRST_NAME} || ''));
+	$users->{$uco}->{$A_LAST_NAME} = ($uAttributes{$A_ARTISTIC_LAST_NAME} || ($uAttributes{$A_LAST_NAME} || ''));
+	$users->{$uco}->{$A_TITLE_AFTER} = $uAttributes{$A_TITLE_AFTER} || '';
+	$users->{$uco}->{$A_PHONE} = $uAttributes{$A_PHONE} || '';
+	$users->{$uco}->{$A_GENDER} = $uAttributes{$A_GENDER} || '';
+	$users->{$uco}->{$A_BIRTH_NUMBER} = $uAttributes{$A_BIRTH_NUMBER} || '';
 
 	# if multiple, send only first one
 	if (defined $uAttributes{$A_CARD_BARCODES}) {
@@ -75,16 +75,16 @@ foreach my $user (($data->getChildElements)[1]->getChildElements) {
 
 	if (defined $uAttributes{$A_ADDRESS_STREET_DC2}) {
 		# has address from DC2
-		$users->{$uco}->{'STREET'} = (defined $uAttributes{$A_ADDRESS_STREET_DC2} ? $uAttributes{$A_ADDRESS_STREET_DC2} : '');
-		$users->{$uco}->{'HOUSE_NUMBER'} = (defined $uAttributes{$A_ADDRESS_HOUSE_NUMBER_DC2} ? $uAttributes{$A_ADDRESS_HOUSE_NUMBER_DC2} : '');
-		$users->{$uco}->{'TOWN'} = (defined $uAttributes{$A_ADDRESS_TOWN_DC2} ? $uAttributes{$A_ADDRESS_TOWN_DC2} : '');
-		$users->{$uco}->{'POSTAL_CODE'} = (defined $uAttributes{$A_ADDRESS_POSTAL_CODE_DC2} ? $uAttributes{$A_ADDRESS_POSTAL_CODE_DC2} : '');
+		$users->{$uco}->{'STREET'} = $uAttributes{$A_ADDRESS_STREET_DC2};
+		$users->{$uco}->{'HOUSE_NUMBER'} = $uAttributes{$A_ADDRESS_HOUSE_NUMBER_DC2} ? $uAttributes{$A_ADDRESS_HOUSE_NUMBER_DC2} : '';
+		$users->{$uco}->{'TOWN'} = $uAttributes{$A_ADDRESS_TOWN_DC2} || '';
+		$users->{$uco}->{'POSTAL_CODE'} = $uAttributes{$A_ADDRESS_POSTAL_CODE_DC2} || '';
 	} elsif (defined $uAttributes{$A_ADDRESS_STREET_KOS}) {
 		# has address from KOS
-		$users->{$uco}->{'STREET'} = (defined $uAttributes{$A_ADDRESS_STREET_KOS} ? $uAttributes{$A_ADDRESS_STREET_KOS} : '');
-		$users->{$uco}->{'HOUSE_NUMBER'} = (defined $uAttributes{$A_ADDRESS_HOUSE_NUMBER_KOS} ? $uAttributes{$A_ADDRESS_HOUSE_NUMBER_KOS} : '');
-		$users->{$uco}->{'TOWN'} = (defined $uAttributes{$A_ADDRESS_TOWN_KOS} ? $uAttributes{$A_ADDRESS_TOWN_KOS} : '');
-		$users->{$uco}->{'POSTAL_CODE'} = (defined $uAttributes{$A_ADDRESS_POSTAL_CODE_KOS} ? $uAttributes{$A_ADDRESS_POSTAL_CODE_KOS} : '');
+		$users->{$uco}->{'STREET'} = $uAttributes{$A_ADDRESS_STREET_KOS};
+		$users->{$uco}->{'HOUSE_NUMBER'} = $uAttributes{$A_ADDRESS_HOUSE_NUMBER_KOS} || '';
+		$users->{$uco}->{'TOWN'} = $uAttributes{$A_ADDRESS_TOWN_KOS} || '';
+		$users->{$uco}->{'POSTAL_CODE'} = $uAttributes{$A_ADDRESS_POSTAL_CODE_KOS} || '';
 	} else {
 		# don't have address
 		$users->{$uco}->{'STREET'} = '';

--- a/gen/vsup_web
+++ b/gen/vsup_web
@@ -7,7 +7,7 @@ use perunServicesUtils;
 
 local $::SERVICE_NAME = "vsup_web";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.2";
+my $SCRIPT_VERSION = "3.0.3";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
@@ -41,6 +41,8 @@ our $A_G_CAO_ORGAN;  *A_G_CAO_ORGAN = \'urn:perun:group:attribute-def:def:caoOrg
 our $A_G_CAO_FUNKCE;  *A_G_CAO_FUNKCE = \'urn:perun:group:attribute-def:def:caoFunkce';
 our $A_G_CAO_FUNKCE_ID;  *A_G_CAO_FUNKCE_ID = \'urn:perun:group:attribute-def:def:caoFunkceId';
 
+our $A_R_RELATION_TYPE; *A_R_RELATION_TYPE = \'urn:perun:resource:attribute-def:def:relationType';
+
 # GATHER USERS
 my $users;  # $users->{$uco}->{ATTR} = $attrValue;
 # Gather CAO membership
@@ -53,6 +55,9 @@ my $ext;   #  $ext->{$uco}->{ATTR} = $attrValue;
 #
 # FOR EACH USER
 foreach my $rData ($data->getChildElements) {
+
+	my %resourceAttributes = attributesToHash $rData->getAttributes;
+	my $relationType = $resourceAttributes{$A_R_RELATION_TYPE};
 
 	my @groupsData = ($rData->getChildElements)[0]->getChildElements;
 
@@ -86,17 +91,12 @@ foreach my $rData ($data->getChildElements) {
 				$cao->{$gAttributes{$A_G_CAO_ORGAN}}->{$gAttributes{$A_G_CAO_FUNKCE}.":".$gAttributes{$A_G_CAO_FUNKCE_ID}}->{$uco} = 1;
 			}
 
-			if ("Externiste:Pedagogicti" eq $gAttributes{$A_G_NAME}) {
-				$ext->{$uco}->{"TYPE"} = "EXP";
-				$ext->{$uco}->{$A_JOB} = (defined $uAttributes{$A_JOB} ? $uAttributes{$A_JOB} : '');
-				$ext->{$uco}->{$A_JOB_ID} = (defined $uAttributes{$A_JOB_ID} ? $uAttributes{$A_JOB_ID} : '');
-				$ext->{$uco}->{$A_NS} = (defined $uAttributes{$A_NS} ? $uAttributes{$A_NS} : '');
-				$ext->{$uco}->{$A_USER_ID} = $uAttributes{$A_USER_ID};
-			} elsif ("Externiste:Ostatni" eq $gAttributes{$A_G_NAME}) {
-				$ext->{$uco}->{"TYPE"} = "EXN";
-				$ext->{$uco}->{$A_JOB} = (defined $uAttributes{$A_JOB} ? $uAttributes{$A_JOB} : '');
-				$ext->{$uco}->{$A_JOB_ID} = (defined $uAttributes{$A_JOB_ID} ? $uAttributes{$A_JOB_ID} : '');
-				$ext->{$uco}->{$A_NS} = (defined $uAttributes{$A_NS} ? $uAttributes{$A_NS} : '');
+			# external workers
+			if (defined $relationType) {
+				$ext->{$uco}->{"TYPE"} = $relationType;
+				$ext->{$uco}->{$A_JOB} = $uAttributes{$A_JOB} || '';
+				$ext->{$uco}->{$A_JOB_ID} = $uAttributes{$A_JOB_ID} || '';
+				$ext->{$uco}->{$A_NS} = $uAttributes{$A_NS} || '';
 				$ext->{$uco}->{$A_USER_ID} = $uAttributes{$A_USER_ID};
 			}
 
@@ -116,10 +116,10 @@ for my $uco (@keys) {
 
 	# print attributes, which are never empty
 	print FILE $uco . "\t" . $users->{$uco}->{$A_LOGIN} . "\t" . $users->{$uco}->{'EMAIL'} . "\t" .
-			$users->{$uco}->{$A_TITLE_BEFORE} . "\t" . $users->{$uco}->{$A_FIRST_NAME} . "\t" .
-			$users->{$uco}->{$A_LAST_NAME} . "\t" . $users->{$uco}->{$A_TITLE_AFTER} . "\t" .
-			$users->{$uco}->{$A_PHONE} . "\t" . $users->{$uco}->{$A_MOBILE} . "\t" .
-			$users->{$uco}->{$A_EMAIL_PRIV} . "\t" . $users->{$uco}->{$A_PHONE_PRIV} . "\n";
+		$users->{$uco}->{$A_TITLE_BEFORE} . "\t" . $users->{$uco}->{$A_FIRST_NAME} . "\t" .
+		$users->{$uco}->{$A_LAST_NAME} . "\t" . $users->{$uco}->{$A_TITLE_AFTER} . "\t" .
+		$users->{$uco}->{$A_PHONE} . "\t" . $users->{$uco}->{$A_MOBILE} . "\t" .
+		$users->{$uco}->{$A_EMAIL_PRIV} . "\t" . $users->{$uco}->{$A_PHONE_PRIV} . "\n";
 
 }
 
@@ -159,7 +159,7 @@ for my $uco (@ext_keys) {
 
 	# print attributes, which are never empty
 	print FILE $uco . "\t" . $ext->{$uco}->{$A_USER_ID} . "\t" . $ext->{$uco}->{"TYPE"} . "\t" .
-			$ext->{$uco}->{$A_JOB} . "\t" . $ext->{$uco}->{$A_JOB_ID} . "\t" . $ext->{$uco}->{$A_NS}  . "\n";
+		$ext->{$uco}->{$A_JOB} . "\t" . $ext->{$uco}->{$A_JOB_ID} . "\t" . $ext->{$uco}->{$A_NS}  . "\n";
 
 }
 

--- a/send/vsup_web
+++ b/send/vsup_web
@@ -246,7 +246,13 @@ close FILE;
 my @keptUcos = sort keys %{$cao};
 my $elements = join(',',@keptUcos);
 if($DEBUG == 1) { print "DELETED NOT IN ($elements)\n"; }
-$deletedCao += $dbh->do("DELETE FROM $tableName_cao WHERE VZTAH_TYP='CAO' and UCO not in ($elements)");
+if (length $elements) {
+	# delete some
+	$deletedCao += $dbh->do("DELETE FROM $tableName_cao WHERE VZTAH_TYP='CAO' and UCO not in ($elements)");
+} else {
+	# delete all
+	$deletedCao += $dbh->do("DELETE FROM $tableName_cao WHERE VZTAH_TYP='CAO'");
+}
 
 # delete invalid CAO relations for kept people
 
@@ -356,7 +362,13 @@ close FILE;
 my @keptExtUcos = sort keys %{$ext};
 my $elementsExt = join(',',@keptExtUcos);
 if($DEBUG == 1) { print "DELETED NOT IN ($elementsExt)\n"; }
-$deletedExt += $dbh->do("DELETE FROM $tableName_ext WHERE UCO not in ($elementsExt)");
+if (length $elementsExt) {
+	# delete some
+	$deletedExt += $dbh->do("DELETE FROM $tableName_ext WHERE UCO not in ($elementsExt)");
+} else {
+	# delete all
+	$deletedExt += $dbh->do("DELETE FROM $tableName_ext");
+}
 
 commit $dbh;
 $dbh->disconnect();


### PR DESCRIPTION
- Type of relation (student/employee/teacher/external) is not taken
  from a group name anymore. It's now attribute of Resource.
  This allows us to rename groups.
- It's now used for KOS (student/teacher) and WEB services
 (manages only external workers).
- Fixed deletion in web services (allow empty set - delete all).
- Rewritten all conditions for defined values from (def val) ? val : ' '
  to val1 || ' ' (KOS,RAV,TRITIUS,WEB).