### PR TITLE
ldap_ad_ceitec reimplemented as ad_ceitec

### DIFF
--- a/gen/ad_ceitec
+++ b/gen/ad_ceitec
@@ -5,7 +5,7 @@ use warnings;
 use perunServicesInit;
 use perunServicesUtils;
 
-local $::SERVICE_NAME = "ldap_ad_ceitec";
+local $::SERVICE_NAME = "ad_ceitec";
 local $::PROTOCOL_VERSION = "3.0.0";
 my $SCRIPT_VERSION = "3.0.0";
 
@@ -14,43 +14,71 @@ my $DIRECTORY = perunServicesInit::getDirectory;
 my $fileName = "$DIRECTORY/$::SERVICE_NAME".".ldif";
 my $fileNameGroups = "$DIRECTORY/$::SERVICE_NAME"."_groups.ldif";
 my $baseDnFileName = "$DIRECTORY/baseDN";
+my $baseDnFileNameService = "$DIRECTORY/baseDNService";
 my $baseDnFileNameGroups = "$DIRECTORY/baseDNGroups";
 
 my $data = perunServicesInit::getHierarchicalData;
 
-#Constants
-our $A_F_BASE_DN;  *A_F_BASE_DN = \'urn:perun:facility:attribute-def:def:ldapBaseDN';
+# Constants
+our $A_F_BASE_DN;  *A_F_BASE_DN = \'urn:perun:facility:attribute-def:def:adBaseDN'; # previously f:d:ldapBaseDN
+our $A_F_SERV_BASE_DN;  *A_F_SERV_BASE_DN = \'urn:perun:facility:attribute-def:def:adServiceBaseDN';
+our $A_F_GROUP_BASE_DN;  *A_F_GROUP_BASE_DN = \'urn:perun:facility:attribute-def:def:adGroupBaseDN';
+our $A_F_DOMAIN;  *A_F_DOMAIN = \'urn:perun:facility:attribute-def:def:adDomain';
+our $A_F_UAC;  *A_F_UAC = \'urn:perun:facility:attribute-def:def:adUAC';
+our $A_F_UAC_SERV;  *A_F_UAC_SERV = \'urn:perun:facility:attribute-def:def:adServiceUAC';
+# Resources = Groups
+our $A_R_GROUP_NAME;  *A_R_GROUP_NAME = \'urn:perun:resource:attribute-def:def:adGroupName'; # previously r:d:secGroupCnCeitecAD
 
 # User attributes
 our $A_FIRST_NAME;  *A_FIRST_NAME = \'urn:perun:user:attribute-def:core:firstName';
 our $A_LAST_NAME;  *A_LAST_NAME = \'urn:perun:user:attribute-def:core:lastName';
 our $A_MAIL;  *A_MAIL = \'urn:perun:user:attribute-def:def:preferredMail';
-#our $A_EPPN;  *A_EPPN = \'urn:perun:user:attribute-def:def:preferredEduPersonPrincipalName';
 our $A_EPPNS; *A_EPPNS = \'urn:perun:user:attribute-def:virt:eduPersonPrincipalNames';
 our $A_O; *A_O = \'urn:perun:member:attribute-def:def:organization';
 our $A_LOGIN; *A_LOGIN = \'urn:perun:user:attribute-def:def:login-namespace:ceitec';
 our $A_CN; *A_CN = \'urn:perun:user:attribute-def:def:cnCeitecAD';
-our $A_R_SEC_GROUP_CN; *A_R_SEC_GROUP_CN = \'urn:perun:resource:attribute-def:def:secGroupCnCeitecAD';
+our $A_IS_SERVICE; *A_IS_SERVICE = \'urn:perun:user:attribute-def:core:serviceUser';
 
 # GATHER USERS
 my $users;  # $users->{$login}->{ATTR} = $attrValue;
 # GATHER USERS FROM RESOURCES
-my $usersByResource;  # $usersByResource->{$A_R_SEC_GROUP_CN}->{users DN} = 1
+my $usersByResource;  # $usersByResource->{$A_R_GROUP_NAME}->{users DN} = 1
 
 # CHECK ON FACILITY ATTRIBUTES
 my %facilityAttributes = attributesToHash $data->getAttributes;
+
 if (!defined($facilityAttributes{$A_F_BASE_DN})) {
+	exit 1;
+}
+if (!defined($facilityAttributes{$A_F_SERV_BASE_DN})) {
+	exit 1;
+}
+if (!defined($facilityAttributes{$A_F_GROUP_BASE_DN})) {
+	exit 1;
+}
+if (!defined($facilityAttributes{$A_F_DOMAIN})) {
+	exit 1;
+}
+if (!defined($facilityAttributes{$A_F_UAC})) {
+	exit 1;
+}
+if (!defined($facilityAttributes{$A_F_UAC_SERV})) {
 	exit 1;
 }
 
 #
 # PRINT BASE_DN FILEs
 #
-my $baseDNUsers = "OU=Users,".$facilityAttributes{$A_F_BASE_DN};
-my $baseDNGroups = "OU=Security Groups,".$facilityAttributes{$A_F_BASE_DN};
+my $baseDNUsers = $facilityAttributes{$A_F_BASE_DN};
+my $baseDNService = $facilityAttributes{$A_F_SERV_BASE_DN};
+my $baseDNGroups = $facilityAttributes{$A_F_GROUP_BASE_DN};
 
 open FILE,">:encoding(UTF-8)","$baseDnFileName" or die "Cannot open $baseDnFileName: $! \n";
 print FILE $baseDNUsers;
+close(FILE);
+
+open FILE,">:encoding(UTF-8)","$baseDnFileNameService" or die "Cannot open $baseDnFileNameService: $! \n";
+print FILE $baseDNService;
 close(FILE);
 
 open FILE,">:encoding(UTF-8)","$baseDnFileNameGroups" or die "Cannot open $baseDnFileNameGroups: $! \n";
@@ -88,9 +116,19 @@ foreach my $rData (@resourcesData) {
 		$users->{$login}->{$A_EPPNS} = $mAttributes{$A_EPPNS};
 		$users->{$login}->{$A_O} = $mAttributes{$A_O};
 		$users->{$login}->{$A_CN} = $mAttributes{$A_CN};
+		$users->{$login}->{$A_IS_SERVICE} = $mAttributes{$A_IS_SERVICE};
 
 		# store which users (their DN) are on this resource
-		$usersByResource->{$rAttributes{$A_R_SEC_GROUP_CN}}->{"CN=" . $mAttributes{$A_CN} . "," . $baseDNUsers} = 1
+
+		if (defined $mAttributes{$A_IS_SERVICE} and ($mAttributes{$A_IS_SERVICE} == 1)) {
+			# service users
+			$users->{$login}->{"DN"} = "cn=" . $mAttributes{$A_CN} . "," . $baseDNService;
+			$usersByResource->{$rAttributes{$A_R_GROUP_NAME}}->{"CN=" . $mAttributes{$A_CN} . "," . $baseDNService} = 1
+		} else {
+			# normal users
+			$users->{$login}->{"DN"} = "cn=" . $mAttributes{$A_CN} . "," . $baseDNUsers;
+			$usersByResource->{$rAttributes{$A_R_GROUP_NAME}}->{"CN=" . $mAttributes{$A_CN} . "," . $baseDNUsers} = 1
+		}
 
 	}
 
@@ -133,12 +171,12 @@ for my $login (@logins) {
 	my $cn = "$users->{$login}->{$A_CN}";
 
 	# Localy defined attributes
-	my $userPrincipalName = "$login\@ceitec.local";
+	my $userPrincipalName = "$login\@$facilityAttributes{$A_F_DOMAIN}";
 	my $samAccountName = $login;
 	my $displayName = "$users->{$login}->{$A_LAST_NAME} $users->{$login}->{$A_FIRST_NAME}";
 
 	# print attributes, which are never empty
-	print FILE "dn: cn=" . $cn . "," . $baseDNUsers . "\n";
+	print FILE "dn: " . $users->{$login}->{"DN"} . "\n";
 	print FILE "cn: " . $cn . "\n";
 
 	# skip attributes which are empty and LDAP can't handle it (FIRST_NAME, EMAIL)
@@ -147,6 +185,7 @@ for my $login (@logins) {
 	my $mail = $users->{$login}->{$A_MAIL};
 	my $eppns = $users->{$login}->{$A_EPPNS};
 	my $o = $users->{$login}->{$A_O};
+	my $service = $users->{$login}->{$A_IS_SERVICE};
 
 	if (defined $displayName and length $displayName) {
 		print FILE "displayName: " . $displayName . "\n";
@@ -174,8 +213,11 @@ for my $login (@logins) {
 	}
 
 	# Set userAccountControl to 66048 which means Normal account + Password never expires + enabled
-	# ONLY FOR CEITEC
-	print FILE "userAccountControl: 66048\n";
+	if (defined $service and ($service == 1)) {
+		print FILE "userAccountControl: $facilityAttributes{$A_F_UAC_SERV}\n";
+	} else {
+		print FILE "userAccountControl: $facilityAttributes{$A_F_UAC}\n";
+	}
 
 	# print classes
 	print FILE "objectclass: top\n";

--- a/send/ad_ceitec
+++ b/send/ad_ceitec
@@ -23,7 +23,7 @@ sub process_disable;
 sub process_groups;
 
 # define service
-my $service_name = "ldap_ad_ceitec";
+my $service_name = "ad_ceitec";
 
 # GEN folder location
 my $facility_name = $ARGV[0];
@@ -36,6 +36,12 @@ open my $file, '<', "$service_files_dir/baseDN";
 my $base_dn = <$file>;
 chomp($base_dn);
 close $file;
+
+# BASE DN for Service accounts
+open my $file_s, '<', "$service_files_dir/baseDNService";
+my $base_dn_service = <$file_s>;
+chomp($base_dn_service);
+close $file_s;
 
 # BASE DN for Groups
 open my $file_g, '<', "$service_files_dir/baseDNGroups";
@@ -77,7 +83,13 @@ my @perun_entries = load_perun($service_files_dir . "/" . $service_name . ".ldif
 my @perun_entries_groups = load_perun($service_files_dir . "/" . $service_name . "_groups.ldif");
 
 # previously take entries only with 'samAccountName' now if they have 'cn'
+
+# load normal user entries
 my @ad_entries = load_ad($ldap, $base_dn, $filter, ['displayName','cn','sn','givenName','mail','company','eduPersonPrincipalNames','samAccountName','userPrincipalName','userAccountControl']);
+# load service user entries
+my @ad_entries_service = load_ad($ldap, $base_dn_service, $filter, ['displayName','cn','sn','givenName','mail','company','eduPersonPrincipalNames','samAccountName','userPrincipalName','userAccountControl']);
+# group them together
+push (@ad_entries, @ad_entries_service);
 
 my %ad_entries_map = ();
 my %perun_entries_map = ();
@@ -176,7 +188,7 @@ sub process_update() {
 			my $ad_entry = $ad_entries_map{$perun_entry->get_value('samAccountName')};
 
 			# attrs without cn since it's part of DN to be updated
-			my @attrs = ('displayName','sn','givenName','mail','company','eduPersonPrincipalNames','userAccountControl');
+			my @attrs = ('displayName','sn','givenName','mail','company','eduPersonPrincipalNames');
 			# stored log messages to check if entry should be updated
 			my @entry_changed = ();
 
@@ -192,6 +204,21 @@ sub process_update() {
 						$attr => \@perun_val
 					);
 				}
+			}
+
+			# check UAC
+			my $ad_entry_uac = $ad_entry->get_value('userAccountControl');
+
+			# if disabled -> enable it
+			unless (is_uac_enabled($ad_entry_uac) == 1) {
+
+				my $original_ad_entry_uac = $ad_entry_uac;
+				my $new_ad_entry_uac = enable_uac($ad_entry_uac);
+				push( @entry_changed, "userAccountControl | $original_ad_entry_uac => $new_ad_entry_uac" );
+				$ad_entry->replace(
+					'userAccountControl' => $new_ad_entry_uac
+				);
+
 			}
 
 			if (@entry_changed) {
@@ -236,16 +263,22 @@ sub process_update() {
 #
 # Disable entries in AD
 #
+#
+# Disable user entries in AD which are not present in Perun
+#
 sub process_disable() {
 
 	foreach my $ad_entry (@ad_entries) {
-
 		my $login = $ad_entry->get_value('samAccountName');
 		unless (exists $perun_entries_map{$login}) {
 
-			unless ($ad_entry->get_value('userAccountControl') == 66050) {
+			my $ad_entry_uac = $ad_entry->get_value('userAccountControl');
+
+			# if enabled -> disable it
+			if (is_uac_enabled($ad_entry_uac) == 1) {
+
 				# disable entry in AD
-				$ad_entry->replace( userAccountControl => 66050 );
+				$ad_entry->replace( userAccountControl => disable_uac($ad_entry_uac) );
 				my $response = $ad_entry->update($ldap);
 				unless ($response->is_error()) {
 					ldap_log($service_name, "Disabled entry: " . $ad_entry->dn());
@@ -295,6 +328,7 @@ sub process_groups() {
 				$ad_entry->replace(
 					'member' => \@per_val
 				);
+
 				# Update entry in AD
 				my $response = $ad_entry->update($ldap);
 
@@ -310,7 +344,6 @@ sub process_groups() {
 						ldap_log($service_name, $ad_entry->ldif());
 					}
 				}
-
 			} else {
 				# FAIL (to get group from AD)
 				$counter_group_failed++;


### PR DESCRIPTION
- Renamed service.
- Use shared facility attributes for all AD services.
- Correctly set enabled/disabled flag for UAC.
- Support also service users in own OU.