### PR TITLE
Add true or false to json export format instead of text

### DIFF
--- a/gen/opennebula_egi
+++ b/gen/opennebula_egi
@@ -78,7 +78,7 @@ sub processMemberData {
 		#basic attributes
 		$dataByUser->{$login}->{"email"} = $memberAttributes{$A_USER_MAIL};
 		$dataByUser->{$login}->{"display_name"} = $memberAttributes{$A_USER_DISPLAY_NAME};
-		$dataByUser->{$login}->{"banned"} = defined($memberAttributes{$A_U_F_BLACKLISTED}) ? 'true' : 'false';
+		$dataByUser->{$login}->{"banned"} = defined($memberAttributes{$A_U_F_BLACKLISTED}) ? \1 : \0;
 		#For egi this identifier is the new fedcloud unique person ID
 		#Empty groups
 		$dataByUser->{$login}->{"groups"} = {};

--- a/gen/opennebula_meta
+++ b/gen/opennebula_meta
@@ -76,7 +76,7 @@ sub processMemberData {
 		#basic attributes
 		$dataByUser->{$login}->{"email"} = $memberAttributes{$A_USER_MAIL};
 		$dataByUser->{$login}->{"display_name"} = $memberAttributes{$A_USER_DISPLAY_NAME};
-		$dataByUser->{$login}->{"banned"} = defined($memberAttributes{$A_U_F_BLACKLISTED}) ? 'true' : 'false';
+		$dataByUser->{$login}->{"banned"} = defined($memberAttributes{$A_U_F_BLACKLISTED}) ? \1 : \0;
 		#For egi this identifier is the new fedcloud unique person ID
 		#Empty groups
 		$dataByUser->{$login}->{"groups"} = {};


### PR DESCRIPTION
 - before this change we were using "true" and "false" text strings
 - now we are using \1 and \0 as true and false in json format (better
   for parsing)