### PR TITLE
Add better logging to perun-propagate script

### DIFF
--- a/other/Makefile
+++ b/other/Makefile
@@ -21,7 +21,7 @@ perun-propagate:
 	@rm -rf ./$@/debian/$@*
 	@rm -f ./$@/debian/files
 	@echo "Generate spec file for $@..."
-	@./generate_rpm.sh $@ "etc" "/etc/init.d/"
+	@./generate_rpm.sh $@ "etc" "/etc/init.d/" "log" "/etc/logrotate.d/"
 
 generic-package:
 	cd $@ && debuild -us -uc --lintian-opts --profile debian

--- a/other/perun-propagate/Makefile
+++ b/other/perun-propagate/Makefile
@@ -2,9 +2,12 @@
 
 INSTALL = install
 BINDIR = $(DESTDIR)/etc/init.d/
+LOGCONFDIR = $(DESTDIR)/etc/logrotate.d/
 
 build: ;
 
 install:
 	$(INSTALL) -d -m 755 $(BINDIR)
+	$(INSTALL) -d -m 755 $(LOGCONFDIR)
 	$(INSTALL) ./etc/* $(BINDIR)
+	$(INSTALL) -m 644 ./log/* $(LOGCONFDIR)

--- a/other/perun-propagate/debian/changelog
+++ b/other/perun-propagate/debian/changelog
@@ -1,3 +1,10 @@
+perun-propagate (3.0.4) stable; urgency=low
+
+  * use better logging of perun-propagate by logrotate and timestamp of all
+    logged information
+
+ -- Michal Stava <stavamichal@gmail.com>  Tue, 02 May 2017 13:49:00 +0200
+
 perun-propagate (3.0.3) stable; urgency=high
 
   * kinit command for MIT and heimdal kerberos was interchaged by mistake

--- a/other/perun-propagate/debian/rules
+++ b/other/perun-propagate/debian/rules
@@ -13,4 +13,4 @@
 	dh $@ 
 
 override_dh_gencontrol:
-	dh_gencontrol -- -Vmisc:Depends="bash (>= 2.05a-11), sed (>= 3.02-8), grep (>= 2.4.2-3), coreutils (>= 5.0-5), perl-base (>= 5.10.1-17), remctl-client, heimdal-clients | krb5-user, openssh-server"
+	dh_gencontrol -- -Vmisc:Depends="bash (>= 2.05a-11), sed (>= 3.02-8), grep (>= 2.4.2-3), coreutils (>= 5.0-5), perl-base (>= 5.10.1-17), remctl-client, heimdal-clients | krb5-user, openssh-server, moreutils, logrotate"

--- a/other/perun-propagate/etc/perun_propagate
+++ b/other/perun-propagate/etc/perun_propagate
@@ -19,8 +19,9 @@ PERUN_SERVER='perun.ics.muni.cz'
 #Timeout in seconds
 TIMEOUT=120
 LOG=/var/log/$NAME
-#Remove content of old log file
-> "$LOG"
+
+#Log start of propagation process
+echo "perun-propagation started" | ts >> $LOG
 
 umask 077
 
@@ -97,7 +98,7 @@ perun_propagate_start() {
 		fi
 		TMP_ERROR=`mktemp --tmpdir=/tmp/ perun-propagate.XXXXXXXXX`
 		add_on_exit "rm -f ${TMP_ERROR}"
-		remctl "${PERUN_SERVER}" perun propagate 2>&1 | tee ${TMP_ERROR} | sed "s;^;$LINE:;" >> ${LOG} &
+		remctl "${PERUN_SERVER}" perun propagate 2>&1 | tee ${TMP_ERROR} | sed "s;^;$LINE:;" | ts >> ${LOG} &
 		PID=$!
 		PID_ARRAY[$ITERATOR]=$PID
 		TMP_ERROR_ARRAY[$ITERATOR]=$TMP_ERROR
@@ -166,7 +167,11 @@ perun_propagate_start() {
 		OUT="${OUT}No destination found for propagation!"
 	fi
 
-	echo -e "${OUT}" >> "${LOG}"
+	echo -e "${OUT}" | ts >> "${LOG}"
+
+	#Log end of propagation process
+	echo "perun-propagation ends" | ts >> $LOG
+
 	[ "${EXIT_CODE}" != "0" ] && echo "${OUT}" >&2
 	return ${EXIT_CODE}
 }

--- a/other/perun-propagate/log/perun-propagate
+++ b/other/perun-propagate/log/perun-propagate
@@ -1,0 +1,8 @@
+/var/log/perun-propagate {
+  rotate 7
+  daily
+  missingok
+  notifempty
+  delaycompress
+  compress
+}

--- a/other/perun-propagate/rpm.dependencies
+++ b/other/perun-propagate/rpm.dependencies
@@ -1,1 +1,1 @@
-bash, sed, grep, perl, remctl, openssh-server, krb5-workstation
+bash, sed, grep, perl, remctl, openssh-server, krb5-workstation, moreutils, logrotate


### PR DESCRIPTION
 - do not create log always new for every run of perun-propagate, use
   the same log and add timestamp and rotation of logs
 - use moreutils for timestamp info and logrotate for rotating of logs