### PR TITLE
Fix lib path for some packages with long names

### DIFF
--- a/slave/generate_rpm.sh
+++ b/slave/generate_rpm.sh
@@ -70,10 +70,10 @@ if ls -A conf/* > /dev/null 2>&1 ; then cp -r conf/* %{buildroot}/etc/perun/${CO
 fi
 if [ $WITH_LIB == 1 ]; then
   CUSTOM_CONF="$CUSTOM_CONF
-mkdir -p %{buildroot}/opt/perun/lib/${SERVICE_NAME}/
-cp -r lib/* %{buildroot}/opt/perun/lib/${SERVICE_NAME}/"
+mkdir -p %{buildroot}/opt/perun/lib/${CONF_SERVICE_NAME}/
+cp -r lib/* %{buildroot}/opt/perun/lib/${CONF_SERVICE_NAME}/"
   CUSTOM_FILE_DATA="$CUSTOM_FILE_DATA
-/opt/perun/lib/${SERVICE_NAME}/"
+/opt/perun/lib/${CONF_SERVICE_NAME}/"
 fi
 
 # generate spec file

--- a/slave/process-kypo-portal/changelog
+++ b/slave/process-kypo-portal/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-kypo-portal (3.0.9) stable; urgency=high
+
+  * Set correct path for lib dir (use '_' instead '-')
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 11 May 2017 15:51:00 +0200
+
 perun-slave-process-kypo-portal (3.0.8) stable; urgency=medium
 
   * Updated process-kypo_portal.py to parse new attribute login-namespace:mu

--- a/slave/process-ldap-vsb-vi/changelog
+++ b/slave/process-ldap-vsb-vi/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-ldap-vsb-vi (3.1.4) stable; urgency=high
+
+  * Set correct path for lib dir (use '_' instead '-')
+
+ -- Michal Stava <stavamichal@gmail.com>  Thu, 11 May 2017 15:51:00 +0200
+
 perun-slave-process-ldap-vsb-vi (3.1.3) stable; urgency=medium
 
   * Change service name in /etc/perun/{service}.d/ to match real service

--- a/slave/templates/Makefile
+++ b/slave/templates/Makefile
@@ -3,8 +3,8 @@
 INSTALL = install
 CONFDIR = $(DESTDIR)/etc/perun/$(subst -,_,${NAME}).d
 BINDIR = $(DESTDIR)/opt/perun/bin
-LIBDIR = $(DESTDIR)/opt/perun/lib/${NAME}
-CACHEDIR = $(DESTDIR)/var/lib/perun/${NAME}
+LIBDIR = $(DESTDIR)/opt/perun/lib/$(subst -,_,${NAME})
+CACHEDIR = $(DESTDIR)/var/lib/perun/$(subst -,_,${NAME})
 
 build: ;
 


### PR DESCRIPTION
 - if service has longer name than one word (using '_' instead spaces),
   than we need to replace these '_' in path to '-' because we are still
   using service_name from SERVICE file where is old name with '_'
 - create changelog for affected services