### PR TITLE
Allow custom pre action in generic_send

### DIFF
--- a/send/generic_send
+++ b/send/generic_send
@@ -11,10 +11,15 @@ TIMEOUT_KILL="60" # 60 sec to kill after timeout
 FACILITY_NAME=$1
 DESTINATION=$2
 DESTINATION_TYPE=$3
+KEY_PATH="`echo ~`/.ssh/id_rsa"
+
+if [ -f "/etc/perun/services/${SERVICE_NAME}/${SERVICE_NAME}.conf" ]; then
+	. "/etc/perun/services/${SERVICE_NAME}/${SERVICE_NAME}.conf"
+fi
 
 unset LC_TIME
 unset LANG
-TRANSPORT_COMMAND="ssh -o StrictHostKeyChecking=no -o GSSAPIAuthentication=no -o GSSAPIKeyExchange=no -o ConnectTimeout=5  -i `echo ~`/.ssh/id_rsa"
+TRANSPORT_COMMAND="ssh -o StrictHostKeyChecking=no -o GSSAPIAuthentication=no -o GSSAPIKeyExchange=no -o ConnectTimeout=5  -i '$KEY_PATH'"
 SLAVE_COMMAND="/opt/perun/bin/perun"
 SERVICE_FILES_BASE_DIR="`pwd`/../gen/spool"
 SERVICE_FILES_DIR="$SERVICE_FILES_BASE_DIR/$FACILITY_NAME/$SERVICE_NAME"
@@ -28,7 +33,7 @@ if [ ! -d "$SERVICE_FILES_DIR" ]; then echo '$SERVICE_FILES_DIR: '$SERVICE_FILES
 #unless specific configuration for destination exists use common configuration for all destination
 [ -d "$SERVICE_FILES_FOR_DESTINATION" ] || SERVICE_FILES_FOR_DESTINATION="$SERVICE_FILES_DIR/_destination/all"
 
-#prepare additional parametres for tar if using configuration per destination
+#prepare additional parameters for tar if using configuration per destination
 TAR_OPTIONS_CONF_PER_DESTINATION=""
 [ -d "$SERVICE_FILES_FOR_DESTINATION" ] && TAR_OPTIONS_CONF_PER_DESTINATION=" -C '${SERVICE_FILES_FOR_DESTINATION}' . "
 
@@ -84,6 +89,6 @@ else
 fi
 ERR_CODE=$?
 
-echo "Communcation with slave script ends with return code: $ERR_CODE" >&2
+echo "Communication with slave script ends with return code: $ERR_CODE" >&2
 
 exit $ERR_CODE


### PR DESCRIPTION
- Allow ssh key location customization on service level.
  by including /etc/perun/services/service_name/service_name.conf
  source file to generic_send script.
- Fixed typos.