### PR TITLE
Fix error report content in process-voms

### DIFF
--- a/slave/process-voms/changelog
+++ b/slave/process-voms/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-voms (3.1.6) stable; urgency=high
+
+  * fixing error output for list-roles and list-cas operations
+
+ -- Zdenek Sustr <sustr4@cesnet.cz>  Thu, 1 Jun 2017 15:28:00 +0200
+
 perun-slave-process-voms (3.1.5) stable; urgency=high
 
   * escaping input from perun to voms

--- a/slave/process-voms/lib/process-voms.pl
+++ b/slave/process-voms/lib/process-voms.pl
@@ -126,8 +126,8 @@ foreach my $vo (@{$vos->{'vo'}}) { # Iterating through individual VOs in the XML
 
 	my @roles_current=`voms-admin --vo \Q${name}\E list-roles`;
 	if ( $? != 0 ) {
-		syslog LOG_ERR, "Failed listing roles in VO \"$name\". Error Code $?, original message from voms-admin: @groups_current";
-		print STDERR "Failed listing roles in VO \"$name\". Error Code $?, original message from voms-admin: @groups_current\n";
+		syslog LOG_ERR, "Failed listing roles in VO \"$name\". Error Code $?, original message from voms-admin: @roles_current";
+		print STDERR "Failed listing roles in VO \"$name\". Error Code $?, original message from voms-admin: @roles_current\n";
 		$retval = 1;
 		next;
 	}
@@ -136,8 +136,8 @@ foreach my $vo (@{$vos->{'vo'}}) { # Iterating through individual VOs in the XML
 
 	our @cas=`voms-admin --vo \Q${name}\E list-cas`;
 	if ( $? != 0 ) {
-		syslog LOG_ERR, "Failed listing known CAs for VO \"$name\". Error Code $?, original message from voms-admin: @groups_current";
-		print STDERR "Failed listing known CAs for VO \"$name\". Error Code $?, original message from voms-admin: @groups_current\n";
+		syslog LOG_ERR, "Failed listing known CAs for VO \"$name\". Error Code $?, original message from voms-admin: @cas";
+		print STDERR "Failed listing known CAs for VO \"$name\". Error Code $?, original message from voms-admin: @cas\n";
 		$retval = 1;
 		next;
 	}


### PR DESCRIPTION
On certain occasions `list-groups` and might perhaps pass but following calls fail. Use the most recent error output in reports. 
This is a quick fix. May merge.