### PR TITLE
Implemented cross-distro compatible locking in slave scripts

### DIFF
--- a/slave/Makefile
+++ b/slave/Makefile
@@ -32,6 +32,7 @@ $(processes):
 	@cd $@ && NAME=$(subst process-,,$@) envsubst < ../templates/Makefile > Makefile
 	@cd $@ && if [ $@ != $(base_package_name) ]; then cat ../templates/makefile_conf_part >> Makefile; fi
 	@cd $@ && if [ -d lib ]; then cat ../templates/makefile_lib_part >> Makefile; fi
+	@cd $@ && if [ -d tmpfiles.d ]; then cat ../templates/makefile_tmpfiles.d_part >> Makefile; fi
 	cd $@ && DEBEMAIL=$(maintainer_email) DEBFULLNAME=$(maintainer_name) dh_make -i -y -n -p "$(package_prefix_name)$@_`head -n 1 changelog | sed -e 's/.*\([0-9]\+[.][0-9]\+[.][0-9]\+\).*/\1/'`" -t "$(realpath templates/dh_make)" --createorig
 	@cd $@/debian && rm *.ex *.EX README.*
 	@cd $@ && if [ -s changelog ]; then cp changelog ./debian/; fi
@@ -43,7 +44,7 @@ $(processes):
 	@cd $@ && if [ -s short_desc -a -s long_desc ]; then sed 's/^/ /g' long_desc >> debian/control; fi
 	@echo $(format) > $@/debian/source/format
 	cd $@ && debuild -us -uc
-	@echo "Cleaing after $@ building process..."
+	@echo "Cleaning after $@ building process..."
 	@rm -rf "$@/"{Makefile,debian}
 	@rm -f "$(package_prefix_name)$@_"*.{build,changes,dsc,tar.gz,tar.xz}
 	@echo "Generate spec file for $@..."

--- a/slave/base/bin/perun
+++ b/slave/base/bin/perun
@@ -5,7 +5,7 @@ LIB_DIR='/opt/perun/lib/'
 CACHE_DIR='/var/lib/perun/'
 CUSTOM_SCRIPTS_DIR="/etc/perun/"
 OLD_CUSTOM_SCRIPTS_DIR="/opt/perun/bin/"
-LOCK_DIR=${LOCK_DIR:=/var/lock}
+LOCK_DIR=${LOCK_DIR:=/var/lock/perun}
 SERVICE_BLACKLIST=()	# syntax: (item1 item2 item3)
 SERVICE_WHITELIST=()
 
@@ -150,7 +150,7 @@ function diff_mv_sync {
 	RET=$?;
 	sync
 
-	return $RET;                                                                                
+	return $RET;
 }
 
 function diff_mv {
@@ -246,7 +246,7 @@ function diff_update {
 
 # If lock file exits, recover all existing files
 #
-# Recover only those files, which are represented in new 
+# Recover only those files, which are represented in new
 # list of files to backup (need to know path to recovering files)
 #
 # If lock not exists, remove everything from backup directory and
@@ -259,7 +259,7 @@ function diff_update {
 function backup_and_recover_files {
 	FILES="$@"
 	SERVICE_LOCK_FILE="${BACKUP_DIR}/lock"
-	
+
 	#If backup dir for service not exists, create it
 	if [ ! -d "${BACKUP_DIR}" ]; then
 		catch_error E_BACKUP_DIR mkdir -p "${BACKUP_DIR}"
@@ -273,7 +273,7 @@ function backup_and_recover_files {
 			LOCAL=`echo $FILE | sed -e 's/^.*\///'`
 			if [ -f "${BACKUP_DIR}/${LOCAL}" ]; then
 				catch_error E_FILE_CANT_RECOVER  diff_mv_sync "${BACKUP_DIR}/${LOCAL}" "${FILE}"
-				log_msg I_FILE_RECOVERED	
+				log_msg I_FILE_RECOVERED
 			else
 				#if not, skip it and info about it
 				log_msg I_FILE_CANT_RECOVER
@@ -341,7 +341,7 @@ WARN_USING_OLD_PATH_FOR_SCRIPTS="Warning: Old configuration dir ${OLD_CUSTOM_SCR
 ls "${OLD_CUSTOM_SCRIPTS_DIR}/${SERVICE}.d/" 2>/dev/null | grep '^pre_\|^post_\|^mid_' 1>/dev/null && echo "${WARN_USING_OLD_PATH_FOR_SCRIPTS}" 1>&2
 
 DNS_ALIAS_OK=0
-# check if perun send via allowed hostname 
+# check if perun send via allowed hostname
 if [ "${#DNS_ALIAS_WHITELIST[@]}" -gt 0  ]; then
 	if in_array "${SEND_TO_HOSTNAME}" "${DNS_ALIAS_WHITELIST[@]}"; then
 		DNS_ALIAS_OK=1
@@ -376,7 +376,7 @@ if [ "${#SERVICE_BLACKLIST[@]}" -gt 0  ]; then
 fi
 
 SERVICE_PROCESS_FILE="${SCRIPTS_DIR}/process-${SERVICE}.sh";
-catch_error E_UNSUPPORTED_SERVICE [ -r "$SERVICE_PROCESS_FILE" ] 
+catch_error E_UNSUPPORTED_SERVICE [ -r "$SERVICE_PROCESS_FILE" ]
 
 . "$SERVICE_PROCESS_FILE"
 

--- a/slave/base/changelog
+++ b/slave/base/changelog
@@ -1,3 +1,14 @@
+perun-slave-base (3.1.7) stable; urgency=low
+
+  * Added tmpfiles.d/perun.conf which define new folder for locking
+    as /var/lock/perun/ instead of /var/lock/.
+    This solution solves compatibility issues with CentOS, where
+    unprivileged users can't create locks in /var/lock/.
+    Local admin can modify this configuration by placing same file
+    to /etc/tmpfiles.d/.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Wed, 07 Jun 2017 13:27:00 +0200
+
 perun-slave-base (3.1.6) stable; urgency=low
 
   * Export perun variables with service name and path to directories (like
@@ -28,9 +39,9 @@ perun-slave-base (3.1.3) stable; urgency=low
 
 perun-slave-base (3.1.2) stable; urgency=low
 
-  * Use also the old path for {service}.d (pre, mid, post) scripts. Old path 
-    is /opt/perun/bin/{service}.d/ and the new path is 
-    /etc/perun/{service}.d/. Same files in both paths has higher priority from 
+  * Use also the old path for {service}.d (pre, mid, post) scripts. Old path
+    is /opt/perun/bin/{service}.d/ and the new path is
+    /etc/perun/{service}.d/. Same files in both paths has higher priority from
     old path (take these).
   * Info to stderr if old path with scrips is still used (there are some
     scripts)

--- a/slave/base/tmpfiles.d/perun.conf
+++ b/slave/base/tmpfiles.d/perun.conf
@@ -1,0 +1,5 @@
+# Create shared locking directory to prevent concurrent service provisioning from Perun.
+# Folder must be writable by all, since perun might connect under different users for each managed service.
+#
+# Type Path               Mode UID  GID  Age Argument
+d     /var/lock/perun/   1777 root root - -

--- a/slave/generate_rpm.sh
+++ b/slave/generate_rpm.sh
@@ -13,6 +13,7 @@ CHANGELOG_FILE="$GENERATE_RPM_FOR_SERVICE/changelog"
 BIN_DIR="$GENERATE_RPM_FOR_SERVICE/bin/"
 CONF_DIR="$GENERATE_RPM_FOR_SERVICE/conf/"
 LIB_DIR="$GENERATE_RPM_FOR_SERVICE/lib"
+TMPFILES_DIR="$GENERATE_RPM_FOR_SERVICE/tmpfiles.d"
 DEPENDENCIES="$GENERATE_RPM_FOR_SERVICE/rpm.dependencies"
 
 if [ ! $GENERATE_RPM_FOR_SERVICE ]; then
@@ -36,6 +37,11 @@ if [ -d "$LIB_DIR" ]; then
 	WITH_LIB=1
 fi
 
+WITH_TMPFILES=0
+if [ -d "$TMPFILES_DIR" ]; then
+	WITH_TMPFILES=1
+fi
+
 #tar everything in directory of concrete perun-service
 
 
@@ -55,7 +61,7 @@ BUILDROOT="%{_tmppath}/%{name}-%{version}-build"
 DESCRIPTION="Perun slave script $GENERATE_RPM_FOR_SERVICE"
 
 # load dependencies
-if [ -f "$DEPENDENCIES" ]; then 
+if [ -f "$DEPENDENCIES" ]; then
 	REQUIRES=`sed -e '$ ! s/$/,/' $DEPENDENCIES | tr '\n' ' '`
 	REQUIRES="Requires: ${REQUIRES}";
 fi
@@ -74,6 +80,14 @@ mkdir -p %{buildroot}/opt/perun/lib/${CONF_SERVICE_NAME}/
 cp -r lib/* %{buildroot}/opt/perun/lib/${CONF_SERVICE_NAME}/"
   CUSTOM_FILE_DATA="$CUSTOM_FILE_DATA
 /opt/perun/lib/${CONF_SERVICE_NAME}/"
+fi
+# Append /usr/lib/tmpfiles.d/
+if [ $WITH_TMPFILES == 1 ]; then
+  CUSTOM_CONF="$CUSTOM_CONF
+mkdir -p %{buildroot}/usr/lib/tmpfiles.d/
+cp tmpfiles.d/perun.conf %{buildroot}/usr/lib/tmpfiles.d/"
+  CUSTOM_FILE_DATA="$CUSTOM_FILE_DATA
+/usr/lib/tmpfiles.d/perun.conf"
 fi
 
 # generate spec file

--- a/slave/templates/Makefile
+++ b/slave/templates/Makefile
@@ -5,6 +5,7 @@ CONFDIR = $(DESTDIR)/etc/perun/$(subst -,_,${NAME}).d
 BINDIR = $(DESTDIR)/opt/perun/bin
 LIBDIR = $(DESTDIR)/opt/perun/lib/$(subst -,_,${NAME})
 CACHEDIR = $(DESTDIR)/var/lib/perun/$(subst -,_,${NAME})
+TMPFILESDIR = $(DESTDIR)/usr/lib/tmpfiles.d/
 
 build: ;
 

--- a/slave/templates/makefile_tmpfiles.d_part
+++ b/slave/templates/makefile_tmpfiles.d_part
@@ -1,0 +1,2 @@
+	$(INSTALL) -d -m 755 $(TMPFILESDIR)
+	$(INSTALL) ./tmpfiles.d/perun.conf $(TMPFILESDIR)


### PR DESCRIPTION
- Base package will install also /usr/lib/tmpfiles.d/perun.conf
  which defines new folder /var/lock/perun/, which is generally
  writable for all users.
  This solve case, when slave script was running under normal user
  and didn't have privileges to create lock in /var/lock/ on CentOS host.
- Locking directory changed to /var/lock/perun/