### PR TITLE
Fixed wrong dependency on perun-slave-base 3.7.1

### DIFF
--- a/slave/process-sshkeys/changelog
+++ b/slave/process-sshkeys/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-sshkeys (3.1.5) stable; urgency=high
+
+  * Fixed wrong dependency on perun-slave-base (3.7.1 -> 3.1.7)
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Fri, 30 Jun 2017 09:43:00 +0200
+
 perun-slave-process-sshkeys (3.1.4) stable; urgency=high
 
   * Use new sync for specific files by perl library instead of whole

--- a/slave/process-sshkeys/dependencies
+++ b/slave/process-sshkeys/dependencies
@@ -1,1 +1,1 @@
-perun-slave-base (>= 3.7.1)
+perun-slave-base (>= 3.1.7)

--- a/slave/process-sshkeys/rpm.dependencies
+++ b/slave/process-sshkeys/rpm.dependencies
@@ -1,1 +1,1 @@
-perun-slave-base >= 3.7.1-1
+perun-slave-base >= 3.1.7-1

--- a/slave/process-sympa-cesnet/changelog
+++ b/slave/process-sympa-cesnet/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-sympa-cesnet (3.1.5) stable; urgency=high
+
+  * Fixed wrong dependency on perun-slave-base (3.7.1 -> 3.1.7)
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Fri, 30 Jun 2017 09:43:00 +0200
+
 perun-slave-process-sympa-cesnet (3.1.4) stable; urgency=high
 
   * Use new sync for specific files by perl library instead of whole

--- a/slave/process-sympa-cesnet/dependencies
+++ b/slave/process-sympa-cesnet/dependencies
@@ -1,1 +1,1 @@
-perun-slave-base (>= 3.7.1)
+perun-slave-base (>= 3.1.7)

--- a/slave/process-sympa-cesnet/rpm.dependencies
+++ b/slave/process-sympa-cesnet/rpm.dependencies
@@ -1,1 +1,1 @@
-perun-slave-base >= 3.7.1-1
+perun-slave-base >= 3.1.7-1

--- a/slave/process-sympa/changelog
+++ b/slave/process-sympa/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-sympa (3.1.5) stable; urgency=high
+
+  * Fixed wrong dependency on perun-slave-base (3.7.1 -> 3.1.7)
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Fri, 30 Jun 2017 09:43:00 +0200
+
 perun-slave-process-sympa (3.1.4) stable; urgency=high
 
   * Use new sync for specific files by perl library instead of whole

--- a/slave/process-sympa/dependencies
+++ b/slave/process-sympa/dependencies
@@ -1,1 +1,1 @@
-perun-slave-base (>= 3.7.1)
+perun-slave-base (>= 3.1.7)

--- a/slave/process-sympa/rpm.dependencies
+++ b/slave/process-sympa/rpm.dependencies
@@ -1,1 +1,1 @@
-perun-slave-base >= 3.7.1-1
+perun-slave-base >= 3.1.7-1


### PR DESCRIPTION
- ssh_keys, sympa and sympa-cesnet were wrongly dependant on
  perun-slave-base version 3.7.1 instead of 3.1.7.
  Dependency, changelog, package version were updated.