### PR TITLE
Fix typo in slave skript sshkeys

### DIFF
--- a/slave/process-sshkeys/bin/process-sshkeys.sh
+++ b/slave/process-sshkeys/bin/process-sshkeys.sh
@@ -46,7 +46,7 @@ function process {
 
 		if [ -f "$SSH_AUTHORIZED_KEYS" ]; then
 			catch_error E_MERGE_SSH_KEYS sort -u "$SSH_AUTHORIZED_KEYS" "$FROM_PERUN_AUTHORIZED_KEYS" > "$TMP_FILE"
-			sync_mv "$TMP_FILE" "$FROM_PERUN_AUTHORIZED_KEYS"
+			mv_sync "$TMP_FILE" "$FROM_PERUN_AUTHORIZED_KEYS"
 		else
 			touch "$SSH_AUTHORIZED_KEYS" || log_msg E_IO
 			USER_PRIMARY_GROUP_ID=`id -g $USER` || log_msg E_PRIMARY_GROUP_ID_NOT_FOUND

--- a/slave/process-sshkeys/changelog
+++ b/slave/process-sshkeys/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-sshkeys (3.1.6) stable; urgency=high
+
+  * Fixed typo of method "sync_mv" to "mv_sync"
+
+ -- Michal Stava <stavamichal@gmail.com>  Sun, 02 Jul 2017 22:36:00 +0200
+
 perun-slave-process-sshkeys (3.1.5) stable; urgency=high
 
   * Fixed wrong dependency on perun-slave-base (3.7.1 -> 3.1.7)


### PR DESCRIPTION
 - there was typo in function "sync_mv", there should be "mv_sync"
   instead