### PR TITLE
Removed single quotes from $KEY_PATH variable in generic send command

### DIFF
--- a/send/generic_send
+++ b/send/generic_send
@@ -21,7 +21,7 @@ fi
 export LC_TIME="C"
 export LANG="C"
 
-TRANSPORT_COMMAND="ssh -o StrictHostKeyChecking=no -o GSSAPIAuthentication=no -o GSSAPIKeyExchange=no -o ConnectTimeout=5  -i '$KEY_PATH'"
+TRANSPORT_COMMAND="ssh -o StrictHostKeyChecking=no -o GSSAPIAuthentication=no -o GSSAPIKeyExchange=no -o ConnectTimeout=5  -i $KEY_PATH"
 SLAVE_COMMAND="/opt/perun/bin/perun"
 SERVICE_FILES_BASE_DIR="`pwd`/../gen/spool"
 SERVICE_FILES_DIR="$SERVICE_FILES_BASE_DIR/$FACILITY_NAME/$SERVICE_NAME"


### PR DESCRIPTION
 - Because of command (variables) joining, path to key was resolved
   including single quotes as string - part of the path - and not as quoted param.
   It resulted in non-existing path to the specific key, falling-back to generic, which
   was not working in connection.