### PR TITLE
Support accountExpires in ad_user_vsup service

### DIFF
--- a/gen/ad_user_vsup
+++ b/gen/ad_user_vsup
@@ -228,9 +228,9 @@ sub calculateExpiration() {
 	my $expirationManTime = ($expirationMan) ? Time::Piece->strptime($expirationMan,"%Y-%m-%d") : undef;
 
 	my @expirations = ();
-	if ($expirationKosTime) { push(@expirations, $expirationKosTime->epoch); }
-	if ($expirationDc2Time) { push(@expirations, $expirationDc2Time->epoch); }
-	if ($expirationManTime) { push(@expirations, $expirationManTime->epoch); }
+	if (defined $expirationKosTime) { push(@expirations, $expirationKosTime->epoch); }
+	if (defined $expirationDc2Time) { push(@expirations, $expirationDc2Time->epoch); }
+	if (defined $expirationManTime) { push(@expirations, $expirationManTime->epoch); }
 
 	# sort all expirations
 	my @sorted_expirations = sort { $a <=> $b } @expirations;
@@ -239,6 +239,11 @@ sub calculateExpiration() {
 	my $currentDate = Time::Piece->strptime(localtime->ymd,"%Y-%m-%d");
 
 	my $result;
+
+	if (!defined $expirationKos and !defined $expirationDc2 and !defined $expirationMan) {
+		# if no expiration set in source data - take as "never"
+		return 0;
+	}
 
 	if ($latest_expiration > $currentDate->epoch) {
 

--- a/gen/ad_user_vsup
+++ b/gen/ad_user_vsup
@@ -4,10 +4,13 @@ use strict;
 use warnings;
 use perunServicesInit;
 use perunServicesUtils;
+use Time::Piece;
+
+sub calculateExpiration;
 
 local $::SERVICE_NAME = "ad_user_vsup";
 local $::PROTOCOL_VERSION = "3.0.1";
-my $SCRIPT_VERSION = "3.0.2";
+my $SCRIPT_VERSION = "3.0.3";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
@@ -34,6 +37,9 @@ our $A_TITLE_AFTER;  *A_TITLE_AFTER = \'urn:perun:user:attribute-def:core:titleA
 our $A_PHONE;  *A_PHONE = \'urn:perun:user:attribute-def:def:phoneDc2';
 our $A_CARD_BARCODES;  *A_CARD_BARCODES = \'urn:perun:user:attribute-def:def:cardBarCodes';
 our $A_CARD_CHIP_NUMBERS;  *A_CARD_CHIP_NUMBERS = \'urn:perun:user:attribute-def:def:cardCodes';
+our $A_EXPIRATION_KOS;  *A_EXPIRATION_KOS = \'urn:perun:user:attribute-def:def:expirationKos';
+our $A_EXPIRATION_DC2;  *A_EXPIRATION_DC2 = \'urn:perun:user:attribute-def:def:expirationDc2';
+our $A_EXPIRATION_MANUAL;  *A_EXPIRATION_MANUAL = \'urn:perun:user:attribute-def:def:expirationManual';
 
 # CHECK ON FACILITY ATTRIBUTES
 my %facilityAttributes = attributesToHash $data->getAttributes;
@@ -97,6 +103,9 @@ foreach my $user (($data->getChildElements)[1]->getChildElements) {
 		$users->{$login}->{$A_PHONE} = $uAttributes{$A_PHONE};
 		$users->{$login}->{$A_CARD_BARCODES} = $uAttributes{$A_CARD_BARCODES};
 		$users->{$login}->{$A_CARD_CHIP_NUMBERS} = $uAttributes{$A_CARD_CHIP_NUMBERS};
+		$users->{$login}->{$A_EXPIRATION_KOS} = $uAttributes{$A_EXPIRATION_KOS};
+		$users->{$login}->{$A_EXPIRATION_DC2} = $uAttributes{$A_EXPIRATION_DC2};
+		$users->{$login}->{$A_EXPIRATION_MANUAL} = $uAttributes{$A_EXPIRATION_MANUAL};
 
 	}
 
@@ -120,6 +129,9 @@ for my $login (@logins) {
 	print FILE "userPrincipalName: " . $login . "\@" . $domain . "\n";
 	# enable accounts (if not) using service propagation
 	print FILE "userAccountControl: " . $uac . "\n";
+
+	my $expiration = calculateExpiration($users->{$login}->{$A_EXPIRATION_KOS}, $users->{$login}->{$A_EXPIRATION_DC2}, $users->{$login}->{$A_EXPIRATION_MANUAL});
+	print FILE "accountExpires: " . $expiration . "\n";
 
 	# skip attributes which are empty and LDAP can't handle it (FIRST_NAME,...)
 	my $sn = $users->{$login}->{$A_LAST_NAME};
@@ -191,3 +203,66 @@ for my $login (@logins) {
 close(FILE);
 
 perunServicesInit::finalize;
+
+#
+# Calculate later from three expiration dates based on users relations on VŠUP.
+#
+# 1. param - expiration in KOS (studies)
+# 2. param - expiration in DC2 (employees)
+# 3. param - manually set expiration
+#
+# Returns Windows FILETIME timestamp of users account expiration
+# - in case of expiration on 1.1.4000 -> Zero is returned as "expiration = never".
+# - in case of any other exact date, pick the largest (future). If it comes from study system (KOS),
+#   add 7 days grace period.
+#
+sub calculateExpiration() {
+
+	# read input
+	my $expirationKos = shift;
+	my $expirationDc2 = shift;
+	my $expirationMan = shift;
+	# parse to time or undef
+	my $expirationKosTime = ($expirationKos) ? Time::Piece->strptime($expirationKos,"%Y-%m-%d") : undef;
+	my $expirationDc2Time = ($expirationDc2) ? Time::Piece->strptime($expirationDc2,"%Y-%m-%d") : undef;
+	my $expirationManTime = ($expirationMan) ? Time::Piece->strptime($expirationMan,"%Y-%m-%d") : undef;
+
+	my @expirations = ();
+	if ($expirationKosTime) { push(@expirations, $expirationKosTime->epoch); }
+	if ($expirationDc2Time) { push(@expirations, $expirationDc2Time->epoch); }
+	if ($expirationManTime) { push(@expirations, $expirationManTime->epoch); }
+
+	# sort all expirations
+	my @sorted_expirations = sort { $a <=> $b } @expirations;
+
+	my $latest_expiration = $sorted_expirations[$#sorted_expirations];
+	my $currentDate = Time::Piece->strptime(localtime->ymd,"%Y-%m-%d");
+
+	my $result;
+
+	if ($latest_expiration > $currentDate->epoch) {
+
+		# case expiration "never" = 1.1.4000
+		if ($latest_expiration == Time::Piece->strptime("4000-01-01","%Y-%m-%d")->epoch) {
+			# return without specified expiration date
+			return 0;
+		}
+
+	}
+
+	# (will) expire by studies - add 7 days grace period
+	if ($expirationKosTime and ($latest_expiration == $expirationKosTime->epoch)) {
+		$result = $latest_expiration + (7*24*60*60);
+	} else {
+		# Expired by employment or manual - push exact date
+		$result = $latest_expiration;
+	}
+
+	# add seconds before 1.1.1970 since Windows epoch starts at 1601-01-01T00:00:00Z
+	$result = $result + 11644473600;
+	# convert seconds to 100-nano seconds (hundreds of nano seconds)
+	$result = $result * 10000000;
+
+	return $result;
+
+}

--- a/gen/vsup_google_groups
+++ b/gen/vsup_google_groups
@@ -1,9 +1,11 @@
 #!/usr/bin/perl
-
 use strict;
 use warnings;
 use perunServicesInit;
 use perunServicesUtils;
+use Time::Piece;
+
+sub isExpired;
 
 our $SERVICE_NAME     = "vsup_google_groups";
 our $PROTOCOL_VERSION = "3.0.0";
@@ -22,6 +24,9 @@ our $A_U_FIRST_NAME; 			*A_U_FIRST_NAME =			\'urn:perun:user:attribute-def:core:
 our $A_U_LAST_NAME; 			*A_U_LAST_NAME =			\'urn:perun:user:attribute-def:core:lastName';
 our $A_U_ARTISTIC_FIRST_NAME; 	*A_U_ARTISTIC_FIRST_NAME = 	\'urn:perun:user:attribute-def:def:artisticFirstName';
 our $A_U_ARTISTIC_LAST_NAME; 	*A_U_ARTISTIC_LAST_NAME = 	\'urn:perun:user:attribute-def:def:artisticLastName';
+our $A_EXPIRATION_KOS;  *A_EXPIRATION_KOS = \'urn:perun:user:attribute-def:def:expirationKos';
+our $A_EXPIRATION_DC2;  *A_EXPIRATION_DC2 = \'urn:perun:user:attribute-def:def:expirationDc2';
+our $A_EXPIRATION_MANUAL;  *A_EXPIRATION_MANUAL = \'urn:perun:user:attribute-def:def:expirationManual';
 
 # Global data structure
 
@@ -65,6 +70,7 @@ foreach my $rData ($data->getChildElements) {
 		# create user entry
 		$users->{$login}->{$A_U_FIRST_NAME} = ($uAttributes{$A_U_ARTISTIC_FIRST_NAME} || ($uAttributes{$A_U_FIRST_NAME} || ''));
 		$users->{$login}->{$A_U_LAST_NAME} = ($uAttributes{$A_U_ARTISTIC_LAST_NAME} || ($uAttributes{$A_U_LAST_NAME} || ''));
+		$users->{$login}->{"suspended"} = (isExpired($uAttributes{$A_EXPIRATION_KOS}, $uAttributes{$A_EXPIRATION_DC2}, $uAttributes{$A_EXPIRATION_MANUAL}) == 1) ? "suspended" : "";
 
 		# put member in a group
 		if (defined $groupName and length $groupName) {
@@ -92,7 +98,7 @@ binmode FILE, ":utf8";
 
 my @keys = sort keys %{$users};
 for my $key (@keys) {
-	print FILE $key . "\@" . $domainName . ";" . $users->{$key}->{$A_U_FIRST_NAME} . ";" . $users->{$key}->{$A_U_LAST_NAME} . ";" . "\n";
+	print FILE $key . "\@" . $domainName . ";" . $users->{$key}->{$A_U_FIRST_NAME} . ";" . $users->{$key}->{$A_U_LAST_NAME} . ";" . $users->{$key}->{"suspended"} . "\n";
 }
 close(FILE) or die "Cannot close $usersFileName: $! \n";
 
@@ -111,3 +117,49 @@ for my $key (@groupKeys) {
 close(FILE) or die "Cannot close $groupsFileName: $! \n";
 
 perunServicesInit::finalize;
+
+#
+# Calculate if user is expired or not.
+#
+# 1. param - expiration in KOS (studies)
+# 2. param - expiration in DC2 (employees)
+# 3. param - manually set expiration
+#
+# Returns 1 if expired, 0 if not or can't be determined
+#
+sub isExpired() {
+
+	# read input
+	my $expirationKos = shift;
+	my $expirationDc2 = shift;
+	my $expirationMan = shift;
+	# parse to time or undef
+	my $expirationKosTime = ($expirationKos) ? Time::Piece->strptime($expirationKos,"%Y-%m-%d") : undef;
+	my $expirationDc2Time = ($expirationDc2) ? Time::Piece->strptime($expirationDc2,"%Y-%m-%d") : undef;
+	my $expirationManTime = ($expirationMan) ? Time::Piece->strptime($expirationMan,"%Y-%m-%d") : undef;
+
+	my @expirations = ();
+	if (defined $expirationKosTime) { push(@expirations, $expirationKosTime->epoch); }
+	if (defined $expirationDc2Time) { push(@expirations, $expirationDc2Time->epoch); }
+	if (defined $expirationManTime) { push(@expirations, $expirationManTime->epoch); }
+
+	# sort all expirations
+	my @sorted_expirations = sort { $a <=> $b } @expirations;
+
+	my $latest_expiration = $sorted_expirations[$#sorted_expirations];
+	my $currentDate = Time::Piece->strptime(localtime->ymd,"%Y-%m-%d");
+
+	if (!defined $expirationKos and !defined $expirationDc2 and !defined $expirationMan) {
+		# if no expiration set in source data - take as "never"
+		return 0;
+	}
+
+	if ($latest_expiration > $currentDate->epoch) {
+		# not expired yet
+		return 0;
+	}
+
+	# is expired
+	return 1;
+
+}

--- a/send/ad_user_vsup
+++ b/send/ad_user_vsup
@@ -66,7 +66,7 @@ ldap_bind($ldap, $conf[1], $conf[2]);
 
 # load all data
 my @perun_entries = load_perun($service_files_dir . "/" . $service_name . ".ldif");
-my @ad_entries = load_ad($ldap, $base_dn, $filter, ['cn','displayName','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','userAccountControl','samAccountName']);
+my @ad_entries = load_ad($ldap, $base_dn, $filter, ['cn','displayName','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','userAccountControl','samAccountName','accountExpires']);
 
 # put it in a mep to speed processing
 my %ad_entries_map = ();
@@ -181,7 +181,7 @@ sub process_update() {
 			my $ad_entry = $ad_entries_map{$login};
 
 			# attrs without cn since it's part of DN to be updated
-			my @attrs = ('displayName','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber');
+			my @attrs = ('displayName','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','accountExpires');
 
 			# stored log messages to check if entry should be updated
 			my @entry_changed = ();

--- a/send/ad_user_vsup
+++ b/send/ad_user_vsup
@@ -281,7 +281,7 @@ sub get_entry_by_login() {
 	my $response = $ldap->search( base => $top_dn ,
 		scope => 'sub' ,
 		filter => $filter ,
-		attrs => ['cn','displayName','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','userAccountControl','samAccountName']
+		attrs => ['cn','displayName','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','userAccountControl','samAccountName','accountExpires']
 	);
 
 	unless ($response->is_error()) {


### PR DESCRIPTION
- Calculate users expiration date from values from KOS,DC2 and manual.
- For students, add 7 days grace period.
- For expiration never (1.1.4000) use 0 in AD.
- Attribute is updated by standard update method
  (was added in attribute list in send script).
- Entry is still disabled only, when is missing from input data and enabled
  even if expired - expired account can't be used for access to services, so
  it's like disabled in such case.