### PR TITLE
[process-voms*] Pre-normalize DNs in Perun exports

### DIFF
--- a/slave/process-voms-dirac/changelog
+++ b/slave/process-voms-dirac/changelog
@@ -1,3 +1,10 @@
+perun-slave-process-voms-dirac (1.0.1) stable; urgency=high
+
+  * working around inconsistent normalization of DNs in voms-admin
+    by pre-normalizing perun exports using the same pattern
+
+ -- Zdenek Sustr <sustr4@cesnet.cz>  Mon Jul 17 17:36:21 CEST 2017
+
 perun-slave-process-voms-dirac (1.0.0) stable; urgency=medium
 
   * New slave forked from process-voms, enhanced with "nickname" attribute handling

--- a/slave/process-voms-dirac/lib/process-voms_dirac.pl
+++ b/slave/process-voms-dirac/lib/process-voms_dirac.pl
@@ -40,6 +40,26 @@ sub getCN {
 	return $cn;
 }
 
+### normalizeEmail applies the same normalization replacement on user DNs as voms-admin itself
+#   Calling normalizeEmail() works around bugs in voms-admin wherein the normalization function
+#   is not called in some cases
+#       DN      DN to process
+sub normalizeEmail {
+        my $normalized = shift;
+        $normalized =~ s/\/(E|e|((E|e|)(mail|mailAddress|mailaddress|MAIL|MAILADDRESS)))=/\/Email=/;
+        return $normalized
+}
+
+### normalizeUID applies the same normalization replacement on user DNs as voms-admin itself
+#   Calling normalizeUID() works around bugs in voms-admin wherein the normalization function
+#   is not called in some cases
+#       DN      DN to process
+sub normalizeUID {
+        my $normalized = shift;
+        $normalized =~ s/\/(UserId|USERID|userId|userid|uid|Uid)=/\/UID=/;
+        return $normalized
+}
+
 ### listToHashes accepts a three-column CSV and produces an array of hashes with the following structure:
 #	DN	VO Member DN
 #	CA	Certificate Authority that vouches for the member
@@ -197,7 +217,7 @@ foreach my $vo (@{$vos->{'vo'}}) { # Iterating through individual VOs in the XML
 	my @roles_toBe = ( "VO-Admin" );# Desired list of roles, plus the default VO-Admin role
 	foreach $user (@{$vo->{'users'}->{'user'}}) {
 		next unless knownCA(\@cas, $user->{'CA'});
-		my %theUser= ( 'CA' => "$user->{'CA'}",'DN' => "$user->{'DN'}", 'CN' => getCN($user->{'DN'}), 'email' => "$user->{'email'}" );
+		my %theUser= ( 'CA' => "$user->{'CA'}",'DN' => normalizeUID(normalizeEmail($user->{'DN'})), 'CN' => getCN($user->{'DN'}), 'email' => "$user->{'email'}" );
 		if($user->{'nickname'}) {
 			my %userAttributes = ( 'CA' => "$user->{'CA'}",'DN' => "$user->{'DN'}", 'name' => 'nickname', 'value' => "$user->{'nickname'}" );
 			push(@attributes_toBe, \%userAttributes);

--- a/slave/process-voms/changelog
+++ b/slave/process-voms/changelog
@@ -1,3 +1,10 @@
+perun-slave-process-voms (3.1.7) stable; urgency=high
+
+  * working around inconsistent normalization of DNs in voms-admin
+    by pre-normalizing perun exports using the same pattern
+
+ -- Zdenek Sustr <sustr4@cesnet.cz>  Mon Jul 17 17:36:21 CEST 2017
+
 perun-slave-process-voms (3.1.6) stable; urgency=high
 
   * fixing error output for list-roles and list-cas operations

--- a/slave/process-voms/lib/process-voms.pl
+++ b/slave/process-voms/lib/process-voms.pl
@@ -35,6 +35,26 @@ sub getCN {
 	return $cn;
 }
 
+### normalizeEmail applies the same normalization replacement on user DNs as voms-admin itself
+#   Calling normalizeEmail() works around bugs in voms-admin wherein the normalization function
+#   is not called in some cases
+#	DN	DN to process
+sub normalizeEmail {
+	my $normalized = shift;
+	$normalized =~ s/\/(E|e|((E|e|)(mail|mailAddress|mailaddress|MAIL|MAILADDRESS)))=/\/Email=/;
+	return $normalized
+}
+
+### normalizeUID applies the same normalization replacement on user DNs as voms-admin itself
+#   Calling normalizeUID() works around bugs in voms-admin wherein the normalization function
+#   is not called in some cases
+#	DN	DN to process
+sub normalizeUID {
+	my $normalized = shift;
+	$normalized =~ s/\/(UserId|USERID|userId|userid|uid|Uid)=/\/UID=/;
+	return $normalized
+}
+
 ### listToHashes accepts a three-column CSV and produces an array of hashes with the following structure:
 #	DN	VO Member DN
 #	CA	Certificate Authority that vouches for the member
@@ -164,7 +184,7 @@ foreach my $vo (@{$vos->{'vo'}}) { # Iterating through individual VOs in the XML
 	my @roles_toBe = ( "VO-Admin" );# Desired list of roles, plus the default VO-Admin role
 	foreach $user (@{$vo->{'users'}->{'user'}}) {
 		next unless knownCA($user->{'CA'});
-		my %theUser= ( 'CA' => "$user->{'CA'}",'DN' => "$user->{'DN'}", 'CN' => getCN($user->{'DN'}), 'email' => "$user->{'email'}" );
+		my %theUser= ( 'CA' => "$user->{'CA'}",'DN' => normalizeUID(normalizeEmail($user->{'DN'})), 'CN' => getCN($user->{'DN'}), 'email' => "$user->{'email'}" );
 		push( @{$groupMembers_toBe{"/$name"}}, \%theUser ); #Add user to root group (make them a member)
 		foreach $group (@{$user->{'groups'}->{'group'}}){
 			push(@groups_toBe, "/$name/$group->{'name'}") unless grep{$_ eq "/$name/$group->{'name'}"} @groups_toBe;


### PR DESCRIPTION
* This fix works around inconsistent DN normalization in voms-admin
* Uses the same search&replace patterns as voms-admin [1], [2] and also recommended by [3].
* Already tested. Please deploy.

Search&Replace patterns taken from:
[1] https://github.com/italiangrid/voms-admin-server/blob/master/voms-admin-server/src/main/java/org/glite/security/voms/admin/util/DNUtil.java#L57
[2] https://github.com/italiangrid/voms-admin-server/blob/master/voms-admin-server/src/main/java/org/glite/security/voms/admin/util/DNUtil.java#L63
[3] https://ggus.eu/?mode=ticket_info&ticket_id=129557#update#2