### PR TITLE
[process-voms*] Remove duplicate entries on input

### DIFF
--- a/slave/process-voms-dirac/changelog
+++ b/slave/process-voms-dirac/changelog
@@ -1,3 +1,11 @@
+perun-slave-process-voms (1.0.1) stable; urgency=high
+
+  * Actively check the setting of property voms.skip_ca_check and remove
+    duplicate user entries that only differ in CA before attempting to
+    create/handle duplicate VOMS accounts.
+
+ -- Zdenek Sustr <sustr4@cesnet.cz>  Tue Jul 18 17:19:34 CEST 2017
+
 perun-slave-process-voms-dirac (1.0.0) stable; urgency=medium
 
   * New slave forked from process-voms, enhanced with "nickname" attribute handling

--- a/slave/process-voms-dirac/changelog
+++ b/slave/process-voms-dirac/changelog
@@ -1,12 +1,17 @@
-perun-slave-process-voms-dirac (1.0.1) stable; urgency=high
+perun-slave-process-voms-dirac (1.0.2) stable; urgency=high
 
   * Actively check the setting of property voms.skip_ca_check and remove
     duplicate user entries that only differ in CA before attempting to
     create/handle duplicate VOMS accounts.
+
+ -- Zdenek Sustr <sustr4@cesnet.cz>  Tue Jul 18 17:19:34 CEST 2017
+
+perun-slave-process-voms-dirac (1.0.1) stable; urgency=high
+
   * working around inconsistent normalization of DNs in voms-admin
     by pre-normalizing perun exports using the same pattern
 
- -- Zdenek Sustr <sustr4@cesnet.cz>  Tue Jul 18 17:19:34 CEST 2017
+ -- Zdenek Sustr <sustr4@cesnet.cz>  Mon Jul 17 17:36:21 CEST 2017
 
 perun-slave-process-voms-dirac (1.0.0) stable; urgency=medium
 

--- a/slave/process-voms-dirac/lib/process-voms_dirac.pl
+++ b/slave/process-voms-dirac/lib/process-voms_dirac.pl
@@ -47,9 +47,9 @@ sub getCN {
 #   is not called in some cases
 #       DN      DN to process
 sub normalizeEmail {
-        my $normalized = shift;
-        $normalized =~ s/\/(E|e|((E|e|)(mail|mailAddress|mailaddress|MAIL|MAILADDRESS)))=/\/Email=/;
-        return $normalized
+	my $normalized = shift;
+	$normalized =~ s/\/(E|e|((E|e|)(mail|mailAddress|mailaddress|MAIL|MAILADDRESS)))=/\/Email=/;
+	return $normalized
 }
 
 ### normalizeUID applies the same normalization replacement on user DNs as voms-admin itself
@@ -57,9 +57,9 @@ sub normalizeEmail {
 #   is not called in some cases
 #       DN      DN to process
 sub normalizeUID {
-        my $normalized = shift;
-        $normalized =~ s/\/(UserId|USERID|userId|userid|uid|Uid)=/\/UID=/;
-        return $normalized
+	my $normalized = shift;
+	$normalized =~ s/\/(UserId|USERID|userId|userid|uid|Uid)=/\/UID=/;
+	return $normalized
 }
 
 ### listToHashes accepts a three-column CSV and produces an array of hashes with the following structure:
@@ -138,19 +138,19 @@ sub readProperties {
 	$path = shift;
 	my %properties;
 	if (open(INI, "$path")) {
-                syslog LOG_DEBUG, "Reading config file \"$path\".";
-                print STDERR "Reading config file \"$path\".\n";
-	        while (<INI>) {
+		syslog LOG_DEBUG, "Reading config file \"$path\".";
+		print STDERR "Reading config file \"$path\".\n";
+		while (<INI>) {
 			chomp;
 			if (/^(\S*)\s*=\s*(\S*)(#.*)?$/) {
 				$properties{"$1"} = "$2";
 			}
 		}
-                close (INI);
+		close (INI);
 	}
 	else {
-                syslog LOG_WARN, "Could not open config file \"$path\". No way to read VO properties";
-                print STDERR "Could not open config file \"$path\". No way to read VO properties\n";
+		syslog LOG_WARN, "Could not open config file \"$path\". No way to read VO properties";
+		print STDERR "Could not open config file \"$path\". No way to read VO properties\n";
 	}
 	return %properties;
 }
@@ -183,7 +183,7 @@ foreach my $vo (@{$vos->{'vo'}}) { # Iterating through individual VOs in the XML
 	$name = $vo->{'name'};
 
 	my %properties = readProperties("$etcDir/$name/$etcPropertyFilename");
-	my $checkCA = $properties{"voms.skip_ca_check"} eq "True" ? 0 : 1;
+	my $checkCA = $properties{"voms.skip_ca_check"} ne "True";
 	syslog LOG_DEBUG, "voms.skip_ca_check: " . $properties{"voms.skip_ca_check"} . ", $checkCA\n";
 	print STDERR "voms.skip_ca_check: " . $properties{"voms.skip_ca_check"} . ", $checkCA\n";
 
@@ -237,7 +237,7 @@ foreach my $vo (@{$vos->{'vo'}}) { # Iterating through individual VOs in the XML
 		#Role Membership
 		foreach $role (@roles_current) {
 			$groupRoles_current{"$group"}{"$role"}=listToHashes(\@cas, `voms-admin --vo \Q${name}\E list-users-with-role \Q${group}\E \Q${role}\E`);
-	        }
+		}
 	}
 
 	$attributeStatusFile = $attributeStatusFilePrefix.$name.".xml";

--- a/slave/process-voms/changelog
+++ b/slave/process-voms/changelog
@@ -1,3 +1,11 @@
+perun-slave-process-voms (3.1.7) stable; urgency=high
+
+  * Actively check the setting of property voms.skip_ca_check and remove
+    duplicate user entries that only differ in CA before attempting to
+    create/handle duplicate VOMS accounts.
+
+ -- Zdenek Sustr <sustr4@cesnet.cz>  Tue Jul 18 17:19:34 CEST 2017
+
 perun-slave-process-voms (3.1.6) stable; urgency=high
 
   * fixing error output for list-roles and list-cas operations

--- a/slave/process-voms/changelog
+++ b/slave/process-voms/changelog
@@ -1,12 +1,17 @@
-perun-slave-process-voms (3.1.7) stable; urgency=high
+perun-slave-process-voms (3.1.8) stable; urgency=high
 
   * Actively check the setting of property voms.skip_ca_check and remove
     duplicate user entries that only differ in CA before attempting to
     create/handle duplicate VOMS accounts.
+
+ -- Zdenek Sustr <sustr4@cesnet.cz>  Tue Jul 18 17:19:34 CEST 2017
+
+perun-slave-process-voms (3.1.7) stable; urgency=high
+
   * working around inconsistent normalization of DNs in voms-admin
     by pre-normalizing perun exports using the same pattern
 
- -- Zdenek Sustr <sustr4@cesnet.cz>  Tue Jul 18 17:19:34 CEST 2017
+ -- Zdenek Sustr <sustr4@cesnet.cz>  Mon Jul 17 17:36:21 CEST 2017
 
 perun-slave-process-voms (3.1.6) stable; urgency=high
 

--- a/slave/process-voms/lib/process-voms.pl
+++ b/slave/process-voms/lib/process-voms.pl
@@ -13,6 +13,9 @@ my $vos = XMLin( '-',
 	KeyAttr => [] );
 my $csv = Text::CSV->new({ sep_char => ',' });
 
+my $etcDir = "/etc/voms-admin";
+my $etcPropertyFilename = "service.properties";
+
 ### serialize is used to turn an array of hash references into a manageable structure
 sub serialize {
     JSON::XS->new->relaxed(0)->ascii(1)->canonical(1)->encode($_[0]);
@@ -101,6 +104,45 @@ sub knownCA {
 	}
 }
 
+### readProperties reads VO properties file into an array
+#      $path           Path to the file
+sub readProperties {
+       $path = shift;
+       my %properties;
+       if (open(INI, "$path")) {
+                syslog LOG_DEBUG, "Reading config file \"$path\".";
+                print STDERR "Reading config file \"$path\".\n";
+               while (<INI>) {
+                       chomp;
+                       if (/^(\S*)\s*=\s*(\S*)(#.*)?$/) {
+                               $properties{"$1"} = "$2";
+                       }
+               }
+                close (INI);
+       }
+       else {
+                syslog LOG_WARN, "Could not open config file \"$path\". No way to read VO properties";
+                print STDERR "Could not open config file \"$path\". No way to read VO properties\n";
+       }
+       return %properties;
+}
+
+### uniqueDN checks if the user's DN already exists in a list of DNs seen
+#      $user_ref       User structure reference
+#      $seen_ref       List of DNs for comparison
+sub uniqueDN {
+       $seen_ref = $_[1];
+       $user_ref = $_[0];
+
+       if(grep {$_ eq "$user_ref->{'DN'}"} @$seen_ref) {
+               syslog LOG_ERR, "Duplicate user \"" . $user_ref->{'DN'} .
+                       "\" dropped with CA \"" . $user_ref->{'CA'} . "\"";
+               print STDERR "Duplicate user \"" . $user_ref->{'DN'} .
+                       "\" dropped with CA \"" . $user_ref->{'CA'} . "\"\n";
+               return 0;
+       }
+       return 1;
+}
 
 # This is the actual start.
 
@@ -112,6 +154,10 @@ my $retval = 0;
 foreach my $vo (@{$vos->{'vo'}}) { # Iterating through individual VOs in the XML
 	$name = $vo->{'name'};
 
+	my %properties = readProperties("$etcDir/$name/$etcPropertyFilename");
+	my $checkCA = $properties{"voms.skip_ca_check"} eq "True" ? 0 : 1;
+	syslog LOG_DEBUG, "voms.skip_ca_check: " . $properties{"voms.skip_ca_check"} . ", $checkCA\n";
+	print STDERR "voms.skip_ca_check: " . $properties{"voms.skip_ca_check"} . ", $checkCA\n";
 
 	#Collect lists from voms-admin
 	my @groups_current=`voms-admin --vo \Q${name}\E list-groups`;
@@ -162,9 +208,12 @@ foreach my $vo (@{$vos->{'vo'}}) { # Iterating through individual VOs in the XML
 	my %groupMembers_toBe;		# Desired membership in groups (pure, disregarding roles)
 	my @groups_toBe = ( "/$name" );	# Desired list of groups
 	my @roles_toBe = ( "VO-Admin" );# Desired list of roles, plus the default VO-Admin role
+	my @DNs_Seen;                   # DNs already included
 	foreach $user (@{$vo->{'users'}->{'user'}}) {
 		next unless knownCA($user->{'CA'});
 		my %theUser= ( 'CA' => "$user->{'CA'}",'DN' => "$user->{'DN'}", 'CN' => getCN($user->{'DN'}), 'email' => "$user->{'email'}" );
+		next unless ($checkCA || uniqueDN(\%theUser, \@DNs_Seen));
+		push(@DNs_Seen, $theUser{'DN'});
 		push( @{$groupMembers_toBe{"/$name"}}, \%theUser ); #Add user to root group (make them a member)
 		foreach $group (@{$user->{'groups'}->{'group'}}){
 			push(@groups_toBe, "/$name/$group->{'name'}") unless grep{$_ eq "/$name/$group->{'name'}"} @groups_toBe;


### PR DESCRIPTION
- Actively check the setting of property voms.skip_ca_check,
- Remove duplicate user entries that only differ in CA
- Avoid attempting to create/handle duplicate VOMS accounts.

Tested adequately for deployment on voms2.