### PR TITLE
Fix mismatch protocol version for voms-dirac service

### DIFF
--- a/gen/voms_dirac
+++ b/gen/voms_dirac
@@ -8,7 +8,7 @@ use Text::Unidecode;
 use XML::Simple;
 
 local $::SERVICE_NAME = "voms_dirac";
-local $::PROTOCOL_VERSION = "3.0.0";
+local $::PROTOCOL_VERSION = "3.1.0";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;


### PR DESCRIPTION
 - slave script started at version 3.1.0 but gen started at version
   3.0.0 so we need to change one of them to be able to work together
 - in this case is easier to increase version of gen script to 3.1.0