### PR TITLE
Added new service for Zimbra mail server at VŠUP

### DIFF
--- a/gen/vsup_zimbra
+++ b/gen/vsup_zimbra
@@ -31,6 +31,7 @@ our $A_BLACKLISTED;  *A_BLACKLISTED = \'urn:perun:user_facility:attribute-def:vi
 our $A_EXPIRATION_KOS;  *A_EXPIRATION_KOS = \'urn:perun:user:attribute-def:def:expirationKos';
 our $A_EXPIRATION_DC2;  *A_EXPIRATION_DC2 = \'urn:perun:user:attribute-def:def:expirationDc2';
 our $A_EXPIRATION_MANUAL; *A_EXPIRATION_MANUAL = \'urn:perun:user:attribute-def:def:expirationManual';
+our $A_ZIMBRA_DISPLAY_NAME;  *A_ZIMBRA_DISPLAY_NAME = \'urn:perun:user:attribute-def:def:zimbraDisplayName';
 
 # Read which accounts are "system wide" => IGNORED by Perun.
 open FILE, "<" . "/etc/perun/services/$::SERVICE_NAME/vsup_zimbra_ignored_accounts";
@@ -71,30 +72,44 @@ foreach my $rData ($data->getChildElements) {
 		$users->{$uco}->{$A_LOGIN} = $uAttributes{$A_LOGIN};
 		$users->{$uco}->{'EMAIL'} = ($uAttributes{$A_EMAIL_VSUP} || $uAttributes{$A_LOGIN} . '@vsup.cz');
 
-		# determine user account type (preferred ZAM over STU)
+		# determine user account type
 		if ($relationType eq "ZAM") {
+			# prefer ZAM over anything
 			$users->{$uco}->{'TYPE'} = $relationType;
 			$users->{$uco}->{'COS'} = '0603cf86-f917-4448-bb34-57dd11a2c381';
 		} elsif ($relationType eq "STU") {
+			# prefer active STU if is also EXPIRED or not yet set
+			if ((!defined $users->{$uco}->{'TYPE'}) || $users->{$uco}->{'TYPE'} eq 'EXPIRED') {
+				$users->{$uco}->{'TYPE'} = $relationType;
+				$users->{$uco}->{'COS'} = 'e00428a1-0c00-11d9-836a-000d93afea2a';
+			}
+		} elsif ($relationType eq "EXPIRED") {
+			# mark user expired if has no other relation (STU/ZAM)
 			unless ($users->{$uco}->{'TYPE'}) {
 				$users->{$uco}->{'TYPE'} = $relationType;
 				$users->{$uco}->{'COS'} = 'e00428a1-0c00-11d9-836a-000d93afea2a';
 			}
 		}
 
-		# merge name to displayName
+		# get users name
 		my $firstName = ($uAttributes{$A_ARTISTIC_FIRST_NAME} || ($uAttributes{$A_FIRST_NAME} || ''));
 		my $lastName = ($uAttributes{$A_ARTISTIC_LAST_NAME} || ($uAttributes{$A_LAST_NAME} || ''));
-
-		my $displayName = undef;
-		if (defined $firstName and length $firstName and defined $lastName and length $lastName) {
-			$displayName = $firstName . " " . $lastName;
-		} elsif (defined $firstName and length $firstName and !(defined $lastName and length $lastName)) {
-			$displayName = $firstName;
-		} elsif (!(defined $firstName and length $firstName) and defined $lastName and length $lastName) {
-			$displayName = $lastName;
+		# use custom zimbra displayName
+		my $displayName = $uAttributes{$A_ZIMBRA_DISPLAY_NAME} || undef;
+		# if custom name not present, create it from givenName and sn
+		unless($displayName) {
+			if (defined $firstName and length $firstName and defined $lastName and length $lastName) {
+				$displayName = $firstName . " " . $lastName;
+			} elsif (defined $firstName and length $firstName and !(defined $lastName and length $lastName)) {
+				$displayName = $firstName;
+			} elsif (!(defined $firstName and length $firstName) and defined $lastName and length $lastName) {
+				$displayName = $lastName;
+			}
 		}
-		$users->{$uco}->{"NAME"} = ($displayName || '');
+
+		$users->{$uco}->{"FIRST_NAME"} = ($firstName || '');
+		$users->{$uco}->{"LAST_NAME"} = ($lastName || '');
+		$users->{$uco}->{"DISPLAY_NAME"} = ($displayName || '');
 
 		if (defined $uAttributes{$A_BLACKLISTED} and ($uAttributes{$A_BLACKLISTED} == 1)) {
 			# blacklisted users !security ban! are locked
@@ -118,8 +133,8 @@ for my $uco (@keys) {
 
 	# print attributes, which are never empty
 	print FILE $uco . "\t" . $users->{$uco}->{$A_LOGIN} . "\t" . $users->{$uco}->{'TYPE'} . "\t" .
-		$users->{$uco}->{'EMAIL'} . "\t" . $users->{$uco}->{"NAME"} . "\t" . $users->{$uco}->{"STATUS"} . "\t" .
-		$users->{$uco}->{"COS"} . "\n";
+		$users->{$uco}->{'EMAIL'} . "\t" . $users->{$uco}->{"FIRST_NAME"} . "\t" . $users->{$uco}->{"LAST_NAME"} .
+		"\t" . $users->{$uco}->{"DISPLAY_NAME"} . "\t" . $users->{$uco}->{"STATUS"} . "\t" . $users->{$uco}->{"COS"} . "\n";
 
 }
 

--- a/gen/vsup_zimbra
+++ b/gen/vsup_zimbra
@@ -5,6 +5,8 @@ use warnings;
 use perunServicesInit;
 use perunServicesUtils;
 
+sub getStatus;
+
 local $::SERVICE_NAME = "vsup_zimbra";
 local $::PROTOCOL_VERSION = "3.0.0";
 my $SCRIPT_VERSION = "3.0.0";
@@ -21,9 +23,12 @@ our $A_FIRST_NAME;  *A_FIRST_NAME = \'urn:perun:user:attribute-def:core:firstNam
 our $A_LAST_NAME;  *A_LAST_NAME = \'urn:perun:user:attribute-def:core:lastName';
 our $A_ARTISTIC_FIRST_NAME; *A_ARTISTIC_FIRST_NAME = \'urn:perun:user:attribute-def:def:artisticFirstName';
 our $A_ARTISTIC_LAST_NAME; *A_ARTISTIC_LAST_NAME = \'urn:perun:user:attribute-def:def:artisticLastName';
-
 our $A_EMAIL_VSUP;  *A_EMAIL_VSUP = \'urn:perun:user:attribute-def:def:vsupMail';
 our $A_R_RELATION_TYPE; *A_R_RELATION_TYPE = \'urn:perun:resource:attribute-def:def:relationType';
+our $A_BLACKLISTED;  *A_BLACKLISTED = \'urn:perun:user_facility:attribute-def:virt:blacklisted';
+our $A_EXPIRATION_KOS;  *A_EXPIRATION_KOS = \'urn:perun:user:attribute-def:def:expirationKos';
+our $A_EXPIRATION_DC2;  *A_EXPIRATION_DC2 = \'urn:perun:user:attribute-def:def:expirationDc2';
+our $A_EXPIRATION_MANUAL; *A_EXPIRATION_MANUAL = \'urn:perun:user:attribute-def:def:expirationManual';
 
 # GATHER USERS
 my $users;  # $users->{$uco}->{ATTR} = $attrValue;
@@ -37,7 +42,7 @@ foreach my $rData ($data->getChildElements) {
 	my %resourceAttributes = attributesToHash $rData->getAttributes;
 	my $relationType = $resourceAttributes{$A_R_RELATION_TYPE};
 
-	# Must be in a relation
+	# Users from Resource must be in a relation
 	unless ($relationType) {
 		next;
 	}
@@ -52,16 +57,36 @@ foreach my $rData ($data->getChildElements) {
 		$users->{$uco}->{$A_LOGIN} = $uAttributes{$A_LOGIN};
 		$users->{$uco}->{'EMAIL'} = ($uAttributes{$A_EMAIL_VSUP} || $uAttributes{$A_LOGIN} . '@vsup.cz');
 
-		$users->{$uco}->{$A_FIRST_NAME} = ($uAttributes{$A_ARTISTIC_FIRST_NAME} || ($uAttributes{$A_FIRST_NAME} || ''));
-		$users->{$uco}->{$A_LAST_NAME} = ($uAttributes{$A_ARTISTIC_LAST_NAME} || ($uAttributes{$A_LAST_NAME} || ''));
-
 		# determine user account type (preferred ZAM over STU)
 		if ($relationType eq "ZAM") {
 			$users->{$uco}->{'TYPE'} = $relationType;
+			$users->{$uco}->{'COS'} = '0603cf86-f917-4448-bb34-57dd11a2c381';
 		} elsif ($relationType eq "STU") {
 			unless ($users->{$uco}->{'TYPE'}) {
 				$users->{$uco}->{'TYPE'} = $relationType;
+				$users->{$uco}->{'COS'} = 'e00428a1-0c00-11d9-836a-000d93afea2a';
 			}
+		}
+
+		# merge name to displayName
+		my $firstName = ($uAttributes{$A_ARTISTIC_FIRST_NAME} || ($uAttributes{$A_FIRST_NAME} || ''));
+		my $lastName = ($uAttributes{$A_ARTISTIC_LAST_NAME} || ($uAttributes{$A_LAST_NAME} || ''));
+
+		my $displayName = undef;
+		if (defined $firstName and length $firstName and defined $lastName and length $lastName) {
+			$displayName = $firstName . " " . $lastName;
+		} elsif (defined $firstName and length $firstName and !(defined $lastName and length $lastName)) {
+			$displayName = $firstName;
+		} elsif (!(defined $firstName and length $firstName) and defined $lastName and length $lastName) {
+			$displayName = $lastName;
+		}
+		$users->{$uco}->{"NAME"} = ($displayName || '');
+
+		if (defined $uAttributes{$A_BLACKLISTED} and ($uAttributes{$A_BLACKLISTED} == 1)) {
+			# blacklisted users !security ban! are locked
+			$users->{$uco}->{"STATUS"} = 'locked';
+		} else {
+			$users->{$uco}->{"STATUS"} = getStatus();
 		}
 
 	}
@@ -79,10 +104,21 @@ for my $uco (@keys) {
 
 	# print attributes, which are never empty
 	print FILE $uco . "\t" . $users->{$uco}->{$A_LOGIN} . "\t" . $users->{$uco}->{'TYPE'} . "\t" .
-		$users->{$uco}->{'EMAIL'} . "\t" . $users->{$uco}->{$A_FIRST_NAME} . "\t" . $users->{$uco}->{$A_LAST_NAME} . "\n";
+		$users->{$uco}->{'EMAIL'} . "\t" . $users->{$uco}->{"NAME"} . "\t" . $users->{$uco}->{"STATUS"} . "\t" .
+		$users->{$uco}->{"COS"} . "\n";
 
 }
 
 close(FILE);
 
 perunServicesInit::finalize;
+
+#
+# active - výchozí stav, netřeba nastavovat při vytváření schránky, pouze pokud byl účet předtím v jiném stavu
+# locked - uzamčen pro přihlašování, maily jsou doručovány
+# closed - nelze se přihlásit, maily nejsou doručovány - soft-delete
+#
+sub getStatus() {
+	# TODO - implement logic
+	return 'active';
+}

--- a/gen/vsup_zimbra
+++ b/gen/vsup_zimbra
@@ -4,6 +4,8 @@ use strict;
 use warnings;
 use perunServicesInit;
 use perunServicesUtils;
+use File::Copy;
+use Time::Piece;
 
 sub getStatus;
 
@@ -30,6 +32,13 @@ our $A_EXPIRATION_KOS;  *A_EXPIRATION_KOS = \'urn:perun:user:attribute-def:def:e
 our $A_EXPIRATION_DC2;  *A_EXPIRATION_DC2 = \'urn:perun:user:attribute-def:def:expirationDc2';
 our $A_EXPIRATION_MANUAL; *A_EXPIRATION_MANUAL = \'urn:perun:user:attribute-def:def:expirationManual';
 
+# Read which accounts are "system wide" => IGNORED by Perun.
+open FILE, "<" . "/etc/perun/services/$::SERVICE_NAME/vsup_zimbra_ignored_accounts";
+my @ignoredAccountsList = <FILE>;
+close FILE;
+chomp(@ignoredAccountsList);
+my %ignoredAccounts = map { $_ => 1 } @ignoredAccountsList;
+
 # GATHER USERS
 my $users;  # $users->{$uco}->{ATTR} = $attrValue;
 
@@ -52,6 +61,11 @@ foreach my $rData ($data->getChildElements) {
 	foreach my $member (@membersData) {
 
 		my %uAttributes = attributesToHash $member->getAttributes;
+
+		# SKIP MEMBERS WHICH SUPOSSED TO BE SYSTEM WIDE ACCOUNTS => IGNORED BY PERUN
+		if (exists $ignoredAccounts{$uAttributes{$A_LOGIN}}) {
+			next;
+		}
 
 		my $uco = $uAttributes{$A_UCO};
 		$users->{$uco}->{$A_LOGIN} = $uAttributes{$A_LOGIN};
@@ -86,7 +100,7 @@ foreach my $rData ($data->getChildElements) {
 			# blacklisted users !security ban! are locked
 			$users->{$uco}->{"STATUS"} = 'locked';
 		} else {
-			$users->{$uco}->{"STATUS"} = getStatus();
+			$users->{$uco}->{"STATUS"} = getStatus($uAttributes{$A_EXPIRATION_KOS},$uAttributes{$A_EXPIRATION_DC2},$uAttributes{$A_EXPIRATION_MANUAL});
 		}
 
 	}
@@ -111,6 +125,11 @@ for my $uco (@keys) {
 
 close(FILE);
 
+#
+# Copy ignored accounts
+#
+copy("/etc/perun/services/$::SERVICE_NAME/vsup_zimbra_ignored_accounts", "$DIRECTORY/vsup_zimbra_ignored_accounts") or die "Couldn't copy file of ignored Zimbra accounts.";
+
 perunServicesInit::finalize;
 
 #
@@ -119,6 +138,56 @@ perunServicesInit::finalize;
 # closed - nelze se přihlásit, maily nejsou doručovány - soft-delete
 #
 sub getStatus() {
-	# TODO - implement logic
-	return 'active';
+
+	# read input
+	my $expirationKos = shift;
+	my $expirationDc2 = shift;
+	my $expirationMan = shift;
+	# parse to time or undef
+	my $expirationKosTime = ($expirationKos) ? Time::Piece->strptime($expirationKos,"%Y-%m-%d") : undef;
+	my $expirationDc2Time = ($expirationDc2) ? Time::Piece->strptime($expirationDc2,"%Y-%m-%d") : undef;
+	my $expirationManTime = ($expirationMan) ? Time::Piece->strptime($expirationMan,"%Y-%m-%d") : undef;
+
+	my @expirations = ();
+	if (defined $expirationKosTime) { push(@expirations, $expirationKosTime->epoch); }
+	if (defined $expirationDc2Time) { push(@expirations, $expirationDc2Time->epoch); }
+	if (defined $expirationManTime) { push(@expirations, $expirationManTime->epoch); }
+
+	# sort all expirations
+	my @sorted_expirations = sort { $a <=> $b } @expirations;
+
+	my $latest_expiration = $sorted_expirations[$#sorted_expirations];
+	my $currentDate = Time::Piece->strptime(localtime->ymd,"%Y-%m-%d");
+
+	if (!defined $expirationKos and !defined $expirationDc2 and !defined $expirationMan) {
+		# if no expiration set in source data - take as "never"
+		return 'active';
+	}
+
+	if ($latest_expiration > $currentDate->epoch) {
+		return 'active';
+	}
+
+	# (will) expire by studies - add 7 days grace period
+	if ($expirationKosTime and ($latest_expiration == $expirationKosTime->epoch)) {
+
+		# within 7 days grace period - still active
+		if (($latest_expiration + (7*24*60*60)) > $currentDate->epoch) {
+			return 'active';
+		} else {
+			# is within 30 days period
+			if (($latest_expiration + (30*24*60*60)) > $currentDate->epoch) {
+				return 'locked';
+			}
+			return 'closed'
+		}
+
+	} else {
+		# Expired by employment or manual
+		if (($latest_expiration + (30*24*60*60)) > $currentDate->epoch) {
+			return 'locked';
+		}
+		return 'closed';
+	}
+
 }

--- a/gen/vsup_zimbra
+++ b/gen/vsup_zimbra
@@ -1,0 +1,88 @@
+#!/usr/bin/perl
+use feature "switch";
+use strict;
+use warnings;
+use perunServicesInit;
+use perunServicesUtils;
+
+local $::SERVICE_NAME = "vsup_zimbra";
+local $::PROTOCOL_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.0";
+
+perunServicesInit::init;
+my $DIRECTORY = perunServicesInit::getDirectory;
+my $fileName = "$DIRECTORY/$::SERVICE_NAME".".csv";
+my $data = perunServicesInit::getHierarchicalData;
+
+# Constants
+our $A_LOGIN; *A_LOGIN = \'urn:perun:user_facility:attribute-def:virt:login';
+our $A_UCO; *A_UCO = \'urn:perun:user:attribute-def:def:ucoVsup';
+our $A_FIRST_NAME;  *A_FIRST_NAME = \'urn:perun:user:attribute-def:core:firstName';
+our $A_LAST_NAME;  *A_LAST_NAME = \'urn:perun:user:attribute-def:core:lastName';
+our $A_ARTISTIC_FIRST_NAME; *A_ARTISTIC_FIRST_NAME = \'urn:perun:user:attribute-def:def:artisticFirstName';
+our $A_ARTISTIC_LAST_NAME; *A_ARTISTIC_LAST_NAME = \'urn:perun:user:attribute-def:def:artisticLastName';
+
+our $A_EMAIL_VSUP;  *A_EMAIL_VSUP = \'urn:perun:user:attribute-def:def:vsupMail';
+our $A_R_RELATION_TYPE; *A_R_RELATION_TYPE = \'urn:perun:resource:attribute-def:def:relationType';
+
+# GATHER USERS
+my $users;  # $users->{$uco}->{ATTR} = $attrValue;
+
+#
+# AGGREGATE DATA
+#
+# FOR EACH USER
+foreach my $rData ($data->getChildElements) {
+
+	my %resourceAttributes = attributesToHash $rData->getAttributes;
+	my $relationType = $resourceAttributes{$A_R_RELATION_TYPE};
+
+	# Must be in a relation
+	unless ($relationType) {
+		next;
+	}
+
+	my @membersData = $rData->getChildElements;
+
+	foreach my $member (@membersData) {
+
+		my %uAttributes = attributesToHash $member->getAttributes;
+
+		my $uco = $uAttributes{$A_UCO};
+		$users->{$uco}->{$A_LOGIN} = $uAttributes{$A_LOGIN};
+		$users->{$uco}->{'EMAIL'} = ($uAttributes{$A_EMAIL_VSUP} || $uAttributes{$A_LOGIN} . '@vsup.cz');
+
+		$users->{$uco}->{$A_FIRST_NAME} = ($uAttributes{$A_ARTISTIC_FIRST_NAME} || ($uAttributes{$A_FIRST_NAME} || ''));
+		$users->{$uco}->{$A_LAST_NAME} = ($uAttributes{$A_ARTISTIC_LAST_NAME} || ($uAttributes{$A_LAST_NAME} || ''));
+
+		# determine user account type (preferred ZAM over STU)
+		if ($relationType eq "ZAM") {
+			$users->{$uco}->{'TYPE'} = $relationType;
+		} elsif ($relationType eq "STU") {
+			unless ($users->{$uco}->{'TYPE'}) {
+				$users->{$uco}->{'TYPE'} = $relationType;
+			}
+		}
+
+	}
+}
+
+#
+# PRINT user data
+#
+open FILE,">$fileName" or die "Cannot open $fileName: $! \n";
+binmode FILE, ":utf8";
+
+# print personal info
+my @keys = sort keys %{$users};
+for my $uco (@keys) {
+
+	# print attributes, which are never empty
+	print FILE $uco . "\t" . $users->{$uco}->{$A_LOGIN} . "\t" . $users->{$uco}->{'TYPE'} . "\t" .
+		$users->{$uco}->{'EMAIL'} . "\t" . $users->{$uco}->{$A_FIRST_NAME} . "\t" . $users->{$uco}->{$A_LAST_NAME} . "\n";
+
+}
+
+close(FILE);
+
+perunServicesInit::finalize;

--- a/send/vsup_zimbra
+++ b/send/vsup_zimbra
@@ -1,0 +1,4 @@
+#!/bin/bash
+SERVICE_NAME="vsup_zimbra"
+
+. generic_send

--- a/slave/process-vsup-zimbra/bin/process-vsup_zimbra.sh
+++ b/slave/process-vsup-zimbra/bin/process-vsup_zimbra.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Script for managing users in Zimbra mail server
+
+PROTOCOL_VERSION='3.1.0'
+
+function process {
+
+	EXECSCRIPT="${LIB_DIR}/${SERVICE}/process-vsup_zimbra.pl"
+
+	create_lock
+
+	FROM_PERUN="${WORK_DIR}/vsup_zimbra.csv"
+	IGNORED="${WORK_DIR}/vsup_zimbra_ignored_accounts"
+
+	perl $EXECSCRIPT $FROM_PERUN $IGNORED
+
+	exit $?
+}

--- a/slave/process-vsup-zimbra/bin/process-vsup_zimbra.sh
+++ b/slave/process-vsup-zimbra/bin/process-vsup_zimbra.sh
@@ -2,7 +2,7 @@
 
 # Script for managing users in Zimbra mail server
 
-PROTOCOL_VERSION='3.1.0'
+PROTOCOL_VERSION='3.0.0'
 
 function process {
 

--- a/slave/process-vsup-zimbra/changelog
+++ b/slave/process-vsup-zimbra/changelog
@@ -1,0 +1,5 @@
+perun-slave-process-vsup-zimbra (3.0.0) stable; urgency=low
+
+  * New package version for perun-slave-process-vsup-zimbra
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Wed, 31 May 2017 06:40:00 +0200

--- a/slave/process-vsup-zimbra/dependencies
+++ b/slave/process-vsup-zimbra/dependencies
@@ -1,0 +1,1 @@
+perun-slave-base

--- a/slave/process-vsup-zimbra/lib/process-vsup_zimbra.pl
+++ b/slave/process-vsup-zimbra/lib/process-vsup_zimbra.pl
@@ -1,0 +1,290 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+sub getAllAccounts;
+sub createAccount;
+sub updateAccount;
+sub createAccounts;
+sub updateAccounts;
+sub compareAndUpdateAttribute;
+sub logMessage;
+
+my $perunAccounts;  # $perunAccounts->{login}->{MAILBOX|COS|STATUS|NAME}=value
+my $zimbraAccounts;  # $zimbraAccounts->{login}->{MAILBOX|COS|STATUS|NAME}=value
+
+# read input files path
+my $accountsFilePath = shift;
+my $ignoredFilePath = shift;
+
+#
+# Read accounts sent from Perun
+#
+open FILE, "<" . $accountsFilePath;
+my @lines = <FILE>;
+close FILE;
+
+foreach my $line ( @lines ) {
+
+	my @parts = split /\t/, $line;
+	chomp(@parts);
+
+	$perunAccounts->{$parts[1]}->{'MAILBOX'} = $parts[3];
+	$perunAccounts->{$parts[1]}->{'displayName'} = (($parts[4] ne '') ? $parts[4] : undef);
+	$perunAccounts->{$parts[1]}->{'zimbraAccountStatus'} = (($parts[5] ne '') ? $parts[5] : undef);
+	$perunAccounts->{$parts[1]}->{'zimbraCOSid'} = (($parts[6] ne '') ? $parts[6] : undef);
+
+}
+
+#
+# Read which accounts are supposed to be IGNORED by Perun
+#
+open FILE, "<" . $ignoredFilePath;
+my @ignoredAccountsList = <FILE>;
+close FILE;
+chomp(@ignoredAccountsList);
+my %ignoredAccounts = map { $_ => 1 } @ignoredAccountsList;
+
+#
+# Read existing accounts from Zimbra
+#
+$zimbraAccounts = getAllAccounts();
+
+createAccounts();
+updateAccounts();
+
+exit 0;
+
+#####################
+#
+# HELPING METHODS
+#
+#####################
+
+#
+# Read all accounts from Zimbra mail server
+# Exit script with ret.code = 1 if contacting Zimbra fails.
+#
+sub getAllAccounts() {
+
+	my $existingAccounts; # $existingAccounts->{login}->{MAILBOX|COS|STATUS|NAME}=value
+	my $currentLogin;     # current step in output parsing
+
+	# read versbose output of all accounts in zimbra
+	my @output = `sudo /opt/zimbra/bin/zmprov -l gaa -v vsup.cz`;
+	my $ret = $?; # get ret.code of backticks command
+	$ret = ($ret >> 8); # shift 8 bits to get original return code
+
+	if ($ret != 0) {
+		print "Unable to read all accounts from Zimbra, err.code: $ret, output: @output";
+		logMessage("Unable to read all accounts from Zimbra, err.code: $ret, output: @output");
+		exit 1;
+	}
+
+	chomp(@output);
+
+	foreach my $line (@output) {
+
+		if ($line =~ m/^# name (.*\@vsup.cz)(.*)$/) {
+			$currentLogin = ($line =~ m/^# name (.*)\@vsup.cz(.*)$/)[0];
+			my $currentMailbox = ($line =~ m/^# name (.*\@vsup.cz)(.*)$/)[0];
+			$existingAccounts->{$currentLogin}->{"MAILBOX"} = $currentMailbox;
+			# expect COS is default for each entry if not present
+			$existingAccounts->{$currentLogin}->{"zimbraCOSId"} = "e00428a1-0c00-11d9-836a-000d93afea2a";
+		}
+
+		if ($line =~ m/^zimbraAccountStatus: (.*)$/) {
+			my $currentStatus = ($line =~ m/^zimbraAccountStatus: (.*)$/)[0];
+			$existingAccounts->{$currentLogin}->{"zimbraAccountStatus"}=$currentStatus;
+		}
+
+		# replace default COS with actuall value if present
+		if ($line =~ m/^zimbraCOSId: (.*)$/) {
+			my $currentCos = ($line =~ m/^zimbraCOSId: (.*)$/)[0];
+			$existingAccounts->{$currentLogin}->{"zimbraCOSId"} = $currentCos;
+		}
+
+		if ($line =~ m/^displayName: (.*)$/) {
+			my $currentName = ($line =~ m/^displayName: (.*)$/)[0];
+			$existingAccounts->{$currentLogin}->{"displayName"} = $currentName;
+		}
+
+	}
+
+	return $existingAccounts;
+
+}
+
+#
+# Create new accounts in Zimbra.
+# only 'active' and not ignored accounts are created.
+#
+sub createAccounts() {
+
+	print "Create accounts\n--------------\n";
+
+	foreach my $login (sort keys %$perunAccounts) {
+		unless (exists $zimbraAccounts->{$login}) {
+
+			# try to create new account
+
+			if (exists $ignoredAccounts{$login}) {
+				# skip IGNORED accounts
+				print $perunAccounts->{$login}->{"MAILBOX"} . " ignored.\n";
+				logMessage("WARN: " . $perunAccounts->{$login}->{"MAILBOX"} . " not created. Belongs to ignored.");
+				next;
+			}
+
+			if ($perunAccounts->{$login}->{"zimbraAccountStatus"} eq 'active') {
+
+				# create new account
+				createAccount($perunAccounts->{$login});
+
+			} else {
+
+				# not-active accounts are not created in Zimbra again !
+				print $perunAccounts->{$login}->{"MAILBOX"} . " skipped.\n";
+				logMessage("WARN: " . $perunAccounts->{$login}->{"MAILBOX"} . " not created - is not in active state and was probably manually deleted from Zimbra.");
+
+			}
+
+		}
+	}
+
+}
+
+#
+# Iterate through Zimbra and Perun accounts and update changed attributes
+# also 'close' accounts left in Zimbra which are missing in Perun.
+#
+sub updateAccounts() {
+
+	print "Update accounts\n--------------\n";
+
+	foreach my $login (sort keys %$zimbraAccounts) {
+
+		if (exists $ignoredAccounts{$login}) {
+			print $zimbraAccounts->{$login}->{"MAILBOX"} . " ignored.\n";
+			logMessage("Mailbox: " . $zimbraAccounts->{$login}->{"MAILBOX"} . " not updated. Belongs to ignored.");
+			next;
+		}
+
+		if (exists $perunAccounts->{$login}) {
+
+			# compare and update each attribute
+			compareAndUpdateAttribute($perunAccounts->{$login}, $zimbraAccounts->{$login}, "zimbraCOSid");
+			compareAndUpdateAttribute($perunAccounts->{$login}, $zimbraAccounts->{$login}, "displayName");
+			compareAndUpdateAttribute($perunAccounts->{$login}, $zimbraAccounts->{$login}, "zimbraAccountStatus");
+
+		} else {
+
+			# is missing from perun but present in zimbra => 'closed', in future delete !!
+
+			if ($zimbraAccounts->{$login}->{"STATUS"} ne 'closed') {
+				my $ret = updateAccount($zimbraAccounts->{$login}->{"MAILBOX"}, "zimbraAccountStatus", 'closed');
+				if ($ret != 0) {
+					print "ERROR: " . $zimbraAccounts->{$login}->{"MAILBOX"} . " not closed.\n";
+					logMessage("ERROR: ".$zimbraAccounts->{$login}->{"MAILBOX"}." not closed, ret.code: ".$ret);
+				} else {
+					print $zimbraAccounts->{$login}->{"MAILBOX"}." closed.\n";
+					logMessage($zimbraAccounts->{$login}->{"MAILBOX"}." closed.");
+				}
+			} else {
+				logMessage($zimbraAccounts->{$login}->{"MAILBOX"}." already is closed - skipped.");
+			}
+
+		}
+
+	}
+
+}
+
+#
+# Compare Zimbra account attribute between Zimbra and Perun version
+# and perform update if necessary
+#
+# 1. param: hash reference of perun account
+# 2. param: hash reference of zimbra account
+# 3. param: name of attribute
+#
+sub compareAndUpdateAttribute() {
+
+	my $perunAccount = shift;
+	my $zimbraAccount = shift;
+	my $attrName = shift;
+
+	if ($perunAccount->{$attrName} ne $zimbraAccount->{$attrName}) {
+		my $ret = updateAccount($perunAccount->{"MAILBOX"}, $attrName, $perunAccount->{$attrName});
+		if ($ret != 0) {
+			print "ERROR: " . $perunAccount->{"MAILBOX"} . " update of $attrName failed.\n";
+			logMessage("ERROR: " . $perunAccount->{"MAILBOX"} . " update of $attrName failed, ret.code: " . $ret);
+		} else {
+			print $perunAccount->{"MAILBOX"} . " $attrName updated '$zimbraAccount->{$attrName}'=>'$perunAccount->{$attrName}'.\n";
+			logMessage($perunAccount->{"MAILBOX"} . " $attrName updated '$zimbraAccount->{$attrName}'=>'$perunAccount->{$attrName}'.\n");
+		}
+	}
+
+}
+
+#
+# Create single account in Zimbra and print/log the output
+#
+# 1. param: hash reference of account to be created
+#
+sub createAccount() {
+
+	my $account = shift;
+
+	my $output = `sudo -u zimbra /opt/zimbra/bin/zmprov ca $account->{"MAILBOX"} '' zimbraCOSid $account->{"zimbraCOSid"}`;
+	my $ret = $?; # get ret.code of backticks command
+	$ret = ($ret >> 8); # shift 8 bits to get original return code
+
+	if ($ret != 0) {
+		print "ERROR: $account->{'MAILBOX'} not created, ret.code: $ret, output: $output.\n";
+		logMessage("ERROR: $account->{'MAILBOX'} not created, ret.code: $ret, output: $output.\n");
+	} else {
+		print "$account->{'MAILBOX'} created.\n";
+		logMessage("$account->{'MAILBOX'} created, ret.code: $ret, output: $output.\n");
+	}
+
+}
+
+#
+# Update account single attribute in Zimbra
+#
+# 1. param: hash reference of account to be created
+# 2. param: name of Zimbra attribute to update
+# 3. param: value of Zimbra attribute to update
+#
+# Return: return code of zmprov command
+#
+sub updateAccount() {
+
+	my $account = shift;
+	my $attrName = shift;
+	my $value = shift;
+
+	my $output = `sudo -u zimbra /opt/zimbra/bin/zmprov ma $account->{"MAILBOX"} $attrName $value`;
+	my $ret = $?; # get ret.code of backticks command
+	$ret = ($ret >> 8); # shift 8 bits to get original return code
+
+	# only for logging verbose output
+	if ($ret != 0) {
+		logMessage("ERROR: $account->{'MAILBOX'} attribute $attrName not updated, ret.code: $ret, output: $output.\n");
+	}
+
+	return $ret;
+
+}
+
+#
+# Log message to local file /home/perun/vsup_zimbra.log
+#
+# 1. param Message to log
+#
+sub logMessage() {
+	my $message = shift;
+	open(LOGFILE, ">>/home/perun/vsup_zimbra.log");
+	print LOGFILE (localtime(time) . ": " . $message . "\n");
+	close(LOGFILE);
+}

--- a/slave/process-vsup-zimbra/rpm.dependencies
+++ b/slave/process-vsup-zimbra/rpm.dependencies
@@ -1,0 +1,1 @@
+perun-slave-base

--- a/slave/process-vsup-zimbra/short_desc
+++ b/slave/process-vsup-zimbra/short_desc
@@ -1,0 +1,1 @@
+Package for perun service - Zimbra mail server at VŠUP


### PR DESCRIPTION
- Create, update and disable accounts in Zimbra using zmprov CLI tool.
- In future, support delete account.
- Expired or disabled users are switched to 'closed', banned to 'locked'.
- Script prevents account creation on sync race condition in perun, hence
  expired users are not created or switched to 'active'.