### PR TITLE
New workflow of o365_mu service

### DIFF
--- a/gen/o365_mu
+++ b/gen/o365_mu
@@ -1,0 +1,161 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use perunServicesInit;
+use perunServicesUtils;
+use Data::Dumper;
+
+sub processMember;
+sub processResource;
+sub processGroup;
+
+our $SERVICE_NAME     = "o365_mu";
+our $PROTOCOL_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.0";
+
+perunServicesInit::init;
+my $DIRECTORY = perunServicesInit::getDirectory;
+my $data      = perunServicesInit::getDataWithGroups;
+
+#Constants
+our $A_GR_AD_NAME;                *A_GR_AD_NAME =                \'urn:perun:group_resource:attribute-def:def:adName';
+our $A_F_DOMAIN_NAME;             *A_F_DOMAIN_NAME =             \'urn:perun:facility:attribute-def:def:o365-domainName';
+our $A_MR_O365_SEND_AS;           *A_MR_O365_SEND_AS =           \'urn:perun:member_group:attribute-def:def:o365SendAs';
+our $A_UF_LOGIN;                  *A_UF_LOGIN =                  \'urn:perun:user_facility:attribute-def:virt:login';
+our $A_UF_O365_MAIL_FORWARD;      *A_UF_O365_MAIL_FORWARD =      \'urn:perun:user_facility:attribute-def:def:o365MailForward';
+our $A_UF_O365_ARCHIVE;           *A_UF_O365_ARCHIVE =           \'urn:perun:user_facility:attribute-def:def:o365MailInPlaceArchive';
+our $A_UF_O365_STORE_AND_FORWARD; *A_UF_O365_STORE_AND_FORWARD = \'urn:perun:user_facility:attribute-def:def:o365MailStoreAndForward';
+our $A_R_IS_FOR_O365_GROUP;       *A_R_IS_FOR_O365_GROUP =       \'urn:perun:resource:attribute-def:def:isForO365Group';
+our $A_U_LANGUAGE;                *A_U_LANGUAGE =                \'urn:perun:user:attribute-def:def:preferredLanguage';
+our $A_F_ID;                      *A_F_ID =                      \'urn:perun:facility:attribute-def:core:id';
+
+our $UPN_TEXT = "UPN";
+our $MAIL_FORWARD_TEXT = "mailForward";
+our $ARCHIVE_TEXT = "archive";
+our $STORE_AND_FORWARD_TEXT = "storeAndForward";
+our $LANGUAGE_TEXT = "language";
+our $LANGUAGE_EN = "en-US";
+our $LANGUAGE_CZ = "cs-CZ";
+
+#Global data structure
+our $users = {};
+our $groups = {};
+
+my %facilityAttributes = attributesToHash $data->getAttributes;
+
+my $facilityId = $facilityAttributes{$A_F_ID};
+unless($facilityId) { die "Facility id can't be empty, it is used to find directory with cache and active users from AD!\n"; }
+my $domainName = $facilityAttributes{$A_F_DOMAIN_NAME};
+unless($domainName) { die "Domain name can't be empty for service o365_mu!\n"; }
+
+foreach my $resourceData ( $data->getChildElements ) {
+	processResource $resourceData	
+}
+
+#Save data to the files (separate groups and users)
+my $usersFileName = "$DIRECTORY/$::SERVICE_NAME-users";
+my $groupsFileName = "$DIRECTORY/$::SERVICE_NAME-groups";
+my $facilityIdFileName = "$DIRECTORY/$::SERVICE_NAME-facilityId";
+
+#save data about users as user per line
+open FILE, ">$usersFileName" or die "Cannot open $usersFileName: $! \n";
+foreach my $UCO (sort keys %$users) {
+	print FILE $users->{$UCO}->{'UPN'} . "\t" . $users->{$UCO}->{'mailForward'} . "\t" . $users->{$UCO}->{'archive'} . "\t" . $users->{$UCO}->{'storeAndForward'} . "\t" . $users->{$UCO}->{'language'} . "\n";
+}
+close(FILE) or die "Cannot close $usersFileName: $! \n";
+
+#save data about groups as group per line
+open FILE, ">$groupsFileName" or die "Cannot open $groupsFileName: $! \n";
+foreach my $adName (sort keys %$groups) {
+	my $contacts = join " ", sort keys %{$groups->{$adName}};
+	unless($contacts) { $contacts = ""; }
+	print FILE $adName . "\t" . $contacts . "\n";
+}
+close(FILE) or die "Cannot close $groupsFileName: $! \n";
+
+#save id of this facility to the file
+open FILE, ">$facilityIdFileName" or die "Cannot open $facilityIdFileName: $! \n";
+print FILE $facilityId . "\n";
+close(FILE) or die "Cannot close $facilityIdFileName: $! \n";
+
+perunServicesInit::finalize;
+#End of main part of code
+
+### SUBS for processing objects
+
+#Name: processResource
+#Description:
+# - take resource data and process groups and members assigned to it
+# - groups are processed only if resource is set for them, members always
+sub processResource {
+	my $resourceData = shift;
+	
+	my %resourceAttributes = attributesToHash $resourceData->getAttributes;
+	my $isForO365Group = $resourceAttributes{$A_R_IS_FOR_O365_GROUP};
+
+	foreach my $memberData(($resourceData->getChildElements)[1]->getChildElements) {
+		processMember $memberData;	
+	}	
+		
+	if($isForO365Group) {
+		foreach my $groupData (($resourceData->getChildElements)[0]->getChildElements){
+			processGroup $groupData;
+		}
+	}
+}
+
+#Name: processGroup
+#Description:
+# - take group data and add record to the map of all groups with
+#   specific attributes
+sub processGroup {
+	my $groupData = shift;
+	
+	my %groupAttributes = attributesToHash $groupData->getAttributes;
+	my $membersElement = ($groupData->getChildElements)[1];
+	
+	if($groupAttributes{$A_GR_AD_NAME}) {
+		my $groupADName = $groupAttributes{$A_GR_AD_NAME};
+		$groups->{$groupADName} = undef;
+
+		foreach my $memberData($membersElement->getChildElements) {
+			my %memberAttributes = attributesToHash $memberData->getAttributes;
+			my $UCO = $memberAttributes{$A_UF_LOGIN};
+			my $UPN = $users->{$UCO}->{$UPN_TEXT};
+			my $sendAsGroup = $memberAttributes{$A_MR_O365_SEND_AS};
+			if($sendAsGroup) { $groups->{$groupADName}->{$UPN} = 1; }
+		}
+	}
+}
+
+#Name: processMember
+#Description:
+# - take member data and add record to the map of all users with
+#   specific attributes
+sub processMember {
+	my $memberData = shift;
+	my %memberAttributes = attributesToHash $memberData->getAttributes;
+
+	my $UCO = $memberAttributes{$A_UF_LOGIN};
+	my $mailForward = $memberAttributes{$A_UF_O365_MAIL_FORWARD};
+	my $archive = $memberAttributes{$A_UF_O365_ARCHIVE};
+	my $storeAndForward = $memberAttributes{$A_UF_O365_STORE_AND_FORWARD};
+	my $language = $memberAttributes{$A_U_LANGUAGE};
+
+	unless($users->{$UCO}) {
+		$users->{$UCO}->{$UPN_TEXT} = $UCO . "@" . $domainName;
+		$users->{$UCO}->{$MAIL_FORWARD_TEXT} = $mailForward ? $mailForward : "";
+		$users->{$UCO}->{$ARCHIVE_TEXT} = $archive ? "1" : "0";
+		$users->{$UCO}->{$STORE_AND_FORWARD_TEXT} = $storeAndForward ? "1" : "0";
+		unless($language) {
+			$users->{$UCO}->{$LANGUAGE_TEXT} = $LANGUAGE_EN;
+		} else {
+			if($language =~ /cs/) { 
+				$users->{$UCO}->{$LANGUAGE_TEXT} = $LANGUAGE_CZ;
+			} else {
+				$users->{$UCO}->{$LANGUAGE_TEXT} = $LANGUAGE_EN;
+			}
+		}
+	}
+}

--- a/gen/o365_mu
+++ b/gen/o365_mu
@@ -20,23 +20,19 @@ my $data      = perunServicesInit::getDataWithGroups;
 
 #Constants
 our $A_GR_AD_NAME;                *A_GR_AD_NAME =                \'urn:perun:group_resource:attribute-def:def:adName';
-our $A_F_DOMAIN_NAME;             *A_F_DOMAIN_NAME =             \'urn:perun:facility:attribute-def:def:o365-domainName';
+our $A_F_DOMAIN_NAME;             *A_F_DOMAIN_NAME =             \'urn:perun:facility:attribute-def:def:o365DomainName';
 our $A_MR_O365_SEND_AS;           *A_MR_O365_SEND_AS =           \'urn:perun:member_group:attribute-def:def:o365SendAs';
 our $A_UF_LOGIN;                  *A_UF_LOGIN =                  \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_UF_O365_MAIL_FORWARD;      *A_UF_O365_MAIL_FORWARD =      \'urn:perun:user_facility:attribute-def:def:o365MailForward';
 our $A_UF_O365_ARCHIVE;           *A_UF_O365_ARCHIVE =           \'urn:perun:user_facility:attribute-def:def:o365MailInPlaceArchive';
 our $A_UF_O365_STORE_AND_FORWARD; *A_UF_O365_STORE_AND_FORWARD = \'urn:perun:user_facility:attribute-def:def:o365MailStoreAndForward';
 our $A_R_IS_FOR_O365_GROUP;       *A_R_IS_FOR_O365_GROUP =       \'urn:perun:resource:attribute-def:def:isForO365Group';
-our $A_U_LANGUAGE;                *A_U_LANGUAGE =                \'urn:perun:user:attribute-def:def:preferredLanguage';
 our $A_F_ID;                      *A_F_ID =                      \'urn:perun:facility:attribute-def:core:id';
 
 our $UPN_TEXT = "UPN";
 our $MAIL_FORWARD_TEXT = "mailForward";
 our $ARCHIVE_TEXT = "archive";
 our $STORE_AND_FORWARD_TEXT = "storeAndForward";
-our $LANGUAGE_TEXT = "language";
-our $LANGUAGE_EN = "en-US";
-our $LANGUAGE_CZ = "cs-CZ";
 
 #Global data structure
 our $users = {};
@@ -61,7 +57,7 @@ my $facilityIdFileName = "$DIRECTORY/$::SERVICE_NAME-facilityId";
 #save data about users as user per line
 open FILE, ">$usersFileName" or die "Cannot open $usersFileName: $! \n";
 foreach my $UCO (sort keys %$users) {
-	print FILE $users->{$UCO}->{'UPN'} . "\t" . $users->{$UCO}->{'mailForward'} . "\t" . $users->{$UCO}->{'archive'} . "\t" . $users->{$UCO}->{'storeAndForward'} . "\t" . $users->{$UCO}->{'language'} . "\n";
+	print FILE $users->{$UCO}->{'UPN'} . "\t" . $users->{$UCO}->{'mailForward'} . "\t" . $users->{$UCO}->{'archive'} . "\t" . $users->{$UCO}->{'storeAndForward'} . "\n";
 }
 close(FILE) or die "Cannot close $usersFileName: $! \n";
 
@@ -116,7 +112,8 @@ sub processGroup {
 	my $membersElement = ($groupData->getChildElements)[1];
 	
 	if($groupAttributes{$A_GR_AD_NAME}) {
-		my $groupADName = $groupAttributes{$A_GR_AD_NAME};
+		#all groups for mu should have specific part of name
+		my $groupADName = $groupAttributes{$A_GR_AD_NAME} . '_group.muni.cz';
 		$groups->{$groupADName} = undef;
 
 		foreach my $memberData($membersElement->getChildElements) {
@@ -141,21 +138,11 @@ sub processMember {
 	my $mailForward = $memberAttributes{$A_UF_O365_MAIL_FORWARD};
 	my $archive = $memberAttributes{$A_UF_O365_ARCHIVE};
 	my $storeAndForward = $memberAttributes{$A_UF_O365_STORE_AND_FORWARD};
-	my $language = $memberAttributes{$A_U_LANGUAGE};
 
 	unless($users->{$UCO}) {
 		$users->{$UCO}->{$UPN_TEXT} = $UCO . "@" . $domainName;
 		$users->{$UCO}->{$MAIL_FORWARD_TEXT} = $mailForward ? $mailForward : "";
 		$users->{$UCO}->{$ARCHIVE_TEXT} = $archive ? "1" : "0";
 		$users->{$UCO}->{$STORE_AND_FORWARD_TEXT} = $storeAndForward ? "1" : "0";
-		unless($language) {
-			$users->{$UCO}->{$LANGUAGE_TEXT} = $LANGUAGE_EN;
-		} else {
-			if($language =~ /cs/) { 
-				$users->{$UCO}->{$LANGUAGE_TEXT} = $LANGUAGE_CZ;
-			} else {
-				$users->{$UCO}->{$LANGUAGE_TEXT} = $LANGUAGE_EN;
-			}
-		}
 	}
 }

--- a/send/o365-connector.pl
+++ b/send/o365-connector.pl
@@ -1,0 +1,874 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Getopt::Long qw(:config no_ignore_case);
+use LWP::UserAgent;
+use HTTP::Request;
+use HTTP::Headers;
+use JSON;
+use Data::Dumper;
+
+#We want to have data in UTF8 on output
+binmode STDOUT, ':utf8';
+
+#This also set Data Dumper to UTF8
+local $Data::Dumper::Useqq = 1;
+{ no warnings 'redefine';
+	sub Data::Dumper::qquote {
+		my $s = shift;
+		return "'$s'";
+	}
+}
+
+### Examples of possible commands with parameters
+=c
+./o365-connector.pl -s o365_mu -S develMU -c checkIfEmailExists -i jan@izydorczyk.cz
+./o365-connector.pl -s o365_mu -S develMU -c getMuniContactByEmail -i jan@izydorczyk.cz
+./o365-connector.pl -s o365_mu -S develMU -c getGroupByEmail -i test-lab-crocs@mandragora.onmicrosoft.com
+./o365-connector.pl -s o365_mu -S develMU -c getO365GroupByEmail -i oss@ics.muni.cz
+./o365-connector.pl -s o365_mu -S develMU -c getMuniMailboxByEmail -i 255920@mandragora.muni.cz
+./o365-connector.pl -s o365_mu -S develMU -c getMuniShareboxByEmail -i jan@izydorczyk.cz
+./o365-connector.pl -s o365_mu -S develMU -c setMuniGroup -i test-lab-crocs@mandragora.onmicrosoft.com -t 255920@mandragora.muni.cz 465818@mandragora.muni.cz
+./o365-connector.pl -s o365_mu -S develMU -c setMuniMailbox -i 255920@mandragora.muni.cz -a 1 -d 0 -l "en-US" -f slavek@ics.muni.cz
+=cut
+
+#-----------------------------CONSTANTS------------------------------------
+#DEBUG has 3 levels (0 = no debug, 1 = some important debug messages, 2 = all debug messages)
+our $DEBUG=0;
+#Maximum time to wait on server response (after that it tries the same time to get result)
+#Time to get result is 2xMAX_WAIT_SEC sec
+our $MAX_WAIT_SEC=20;
+our $MAX_WAIT_MSEC = $MAX_WAIT_SEC * 1000;
+
+#Mandatory settings to be able to call server as authorized user
+our $URL;
+our $USERNAME;
+our $PASSWORD;
+our $HOST;
+our $PORT;
+our $PSWS_HOST;
+
+#All possible exceptions
+our $ERROR_UNKNOWN_RETURNED_CODE      = "Unknown returned code get from status of call. This is an internal script error!\n";
+our $ERROR_ISS_COM_PROBLEM            = "Communication problem with ISS server, before processing command itself!\n";
+our $ERROR_WRONG_ISS_EXECUTION        = "Wrong executing on ISS server site, probably bad request!\n";
+our $ERROR_O365_OR_PS_ERROR           = "Error on the site of o365 or PS scripts!\n";
+our $ERROR_UNKNOWN_STATUS             = "Unknown status of call. We don't know how to process this one!\n";
+our $ERROR_UNKNOWN_COMMAND            = "Unknown parameter command.\n";
+our $ERROR_UNSUPPORTED_COMMAND        = "Unsupported command, we don't know how to resolve it!\n";
+our $ERROR_UNSUPPORTED_COMMAND_STATUS = "Unsupported command status, we don't know how to resolve it!\n";
+our $ERROR_MANDATORY_OBJECT_IS_EMPTY  = "Mandatory object in parameter of method is empty!\n";
+our $ERROR_MISSING_PARAMETER          = "Manadatory parameter is missing!\n";
+our $ERROR_OBJECT_NOT_FOUND           = "Object you are looking for not found by identifier!\n";
+our $ERROR_CANNOT_FOUND_CONFIGURATION = "Configuration of REST server is missing, can't found it!\n";
+our $ERROR_SET_METHOD_END_WITH_NOOK   = "Set method returned NoOK status!\n";
+our $ERROR_HARD_TIMEOUT               = "Timeout expired!\n";
+
+#Types of command processing
+our $COMMAND_STATUS_SET = 'SET';
+our $COMMAND_STATUS_RESOLVE = 'RESOLVE';
+
+#All possible commands to call
+our $COMMAND_PING_EMAIL = "checkIfEmailExists";
+our $COMMAND_GET_CONTACT = "getMuniContactByEmail";
+our $COMMAND_GET_GROUP = "getGroupByEmail";
+our $COMMAND_GET_O365_GROUP = "getO365GroupByEmail";
+our $COMMAND_GET_MAILBOX = "getMuniMailboxByEmail";
+our $COMMAND_GET_SHAREBOX = "getMuniShareboxByEmail";
+our $COMMAND_SET_GROUP = "setMuniGroup";
+our $COMMAND_SET_MAILBOX = "setMuniMailbox";
+
+#Basic content of every call
+our %content = (
+  "OutputFormat" => "json",
+  "WaitMsec" => $MAX_WAIT_MSEC
+);
+
+#Global needed variables
+our $actualCommand = "";
+our $finalJsonOutput = {};
+
+#Method with information about possible parameters of this script
+sub help {
+	return qq{
+Call selected method to proceed on O365 REST API.
+Return help + exit 1 if help is needed.
+Return STDOUT + exit 0 if everything is ok.
+Return STDERR + exit >0 if error happens.
+Available commands with mandatory options:
+ --command "$COMMAND_SET_MAILBOX" -i "emailOfMailbox" -a 1|0 -d 1|0 -l "language" -f "email"
+ --command "$COMMAND_SET_GROUP" -i "nameOfGroup" -t contact1 contact2 ...
+ --command "$COMMAND_PING_EMAIL" -i "emailToPing"
+ --command "$COMMAND_GET_CONTACT" -i "nameOfContact"
+ --command "$COMMAND_GET_GROUP" -i "nameOfGroup"
+ --command "$COMMAND_GET_MAILBOX" -i "emailOfMailbox"
+ --command "$COMMAND_GET_O365_GROUP" -i "nameOfGroup"
+ --command "$COMMAND_GET_SHAREBOX" -i "emailOfSharebox"
+---------------------------------------------------------
+Other options:
+ --help        | -h prints this help
+All methods mandatory options:
+ --serviceName | -s name of service for which we will be connecting server
+ --serverName  | -S name of server to get authorization data for
+ --command     | -c command to call
+ --identifier  | -i main identifier of object (most often email)
+SetMailbox mandatory options:
+ --language    | -l language to use for mailbox, "en-US" is default
+ --archiving   | -a enable or disable archiving, values 1=enable, 0=disable, disabled by default
+ --delivering  | -d enable or disable delivering to mailbox, values 1=enable, 0=disable, disabled by default
+ --forwarding  | -f forward to email address for mailing list
+SetGroup mandatory options:
+ --contacts    | -t list of contacts to be able to send email as group\n
+};
+}
+
+#-------------------------------------------------------------------------
+#----------------------------------MAIN CODE------------------------------
+#-------------------------------------------------------------------------
+
+#Get parameters of script and assign them to variables
+my $inputCommand = $0;
+foreach my $argument (@ARGV) { $inputCommand .= " " . $argument; }
+my ($service, $server, $argIdent, $argCommand, $argLang, $argArch, $argDeliv, $argForw, @argContacts);
+GetOptions("help|h"	=> sub {
+		print help;
+		exit 1;
+	},
+	"service|s=s"     => \$service,
+	"server|S=s"      => \$server,
+	"command|c=s"     => \$argCommand,
+	"identifier|i=s"  => \$argIdent,
+	"language|l=s"    => \$argLang,
+	"archiving|a=i"   => \$argArch,
+	"delivering|d=i"  => \$argDeliv,
+	"forwarding|f=s"  => \$argForw,
+	'contacts|t=s@{1,}' => \@argContacts ) || die help;
+
+#Check existence of mandatory parameters
+unless (defined $service) { diePretty ( $ERROR_MISSING_PARAMETER, "Service is required parameter\n" ); }
+unless (defined $server) { diePretty ( $ERROR_MISSING_PARAMETER, "Server is required parameter\n" ); }
+unless (defined $argCommand) { diePretty ( $ERROR_MISSING_PARAMETER, "Command is required parameter\n" ); }
+unless (defined $argIdent) { diePretty ( $ERROR_MISSING_PARAMETER, "Identifier is required parameter\n" ); }
+
+#Read configuration form configuration file
+my $configPath = "/etc/perun/services/$service/$server";
+open FILE, $configPath or die "Could not open config file $configPath: $!";
+while(my $line = <FILE>) {
+	chomp( $line );
+	if($line =~ /^username: .*/) {
+		$USERNAME = ($line =~ /^username: (.*)$/)[0];
+	} elsif($line =~ /^password: .*/) {                                                         
+		$PASSWORD = ($line =~ /^password: (.*)$/)[0];
+	} elsif($line =~ /^url: .*/) {
+		$URL = ($line =~ /^url: (.*)$/)[0];
+	} elsif($line =~ /^host: .*/) {
+		$HOST = ($line =~ /^host: (.*)$/)[0];
+	} elsif($line =~ /^port: .*/) {
+		$PORT = ($line =~ /^port: (.*)$/)[0];
+	}
+}
+
+#Check mandatory configuration
+if(!defined($PASSWORD) || !defined($USERNAME) || !defined($URL) || !defined($HOST) || !defined($PORT)) {
+	diePretty ( $ERROR_CANNOT_FOUND_CONFIGURATION, "Path to find: $configPath \n" );
+}
+
+#Choose and set command by parameter
+if($argCommand eq $COMMAND_SET_MAILBOX) {
+	unless (defined $argArch) { $argArch = 0; }
+	unless (defined $argDeliv) { $argDeliv = 0; }
+	unless (defined $argLang) { $argLang = "en-US"; }
+	setMailbox ( $COMMAND_STATUS_SET, undef, $argIdent, $argDeliv, $argArch, $argForw, $argLang );
+} elsif ($argCommand eq $COMMAND_SET_GROUP) {
+	setGroup ( $COMMAND_STATUS_SET, undef, $argIdent, \@argContacts);
+} elsif ($argCommand eq $COMMAND_PING_EMAIL) {
+	pingEmail ( $COMMAND_STATUS_SET, undef, $argIdent);	
+} elsif ($argCommand eq $COMMAND_GET_CONTACT) {
+	getContact ( $COMMAND_STATUS_SET, undef, $argIdent );	
+} elsif ($argCommand eq $COMMAND_GET_GROUP) {
+	getGroup ( $COMMAND_STATUS_SET, undef, $argIdent);	
+} elsif ($argCommand eq $COMMAND_GET_MAILBOX) {
+	getMailbox ( $COMMAND_STATUS_SET, undef, $argIdent);	
+} elsif ($argCommand eq $COMMAND_GET_O365_GROUP) {
+	getO365Group ( $COMMAND_STATUS_SET, undef, $argIdent);	
+} elsif ($argCommand eq $COMMAND_GET_SHAREBOX) {
+	getSharebox ( $COMMAND_STATUS_SET, undef, $argIdent);	
+} else {
+	diePretty ( $ERROR_UNKNOWN_COMMAND, "Unknown command $argCommand!\n");
+}
+
+#Start calling and return result or die
+my $jsonResult = startSession();
+if($jsonResult) { print JSON->new->utf8->encode( $jsonResult ); }
+
+#End with 0 if everything goes well
+exit 0;
+
+#-------------------------------------------------------------------------
+#------------------------------COMMAND-SUBS-------------------------------
+#-------------------------------------------------------------------------
+
+#Name:
+# setGroup
+#-----------------------
+#Parameters: 
+# status     - status of command, do we want to set this command or resolve it
+# jsonOutput - json output from the server as hash in perl, undef if there is no such output yet
+# groupEmail - identifier of group in o365
+# sendAs     - list of contacts which can use this group as own mail
+#-----------------------
+#Returns: void with exit status 0 = OK, error with exit status > 0 = not OK
+#-----------------------
+#Description: 
+# For existing group in o365 set all possible addresses, which can use this group mail as it's own.
+#-----------------------
+sub setGroup {
+	my $status = shift;
+	my $jsonOutput = shift;
+	my $groupEmail = shift;
+	my $sendAs = shift;
+
+	if(defined($jsonOutput->{"ErrorType"})) {
+		diePretty ( $ERROR_O365_OR_PS_ERROR , "Some HARD internal message error in method call -> " . $jsonOutput->{"ErrorMessage"} . "\n" );
+	}
+
+	if($status eq $COMMAND_STATUS_SET) {
+		$actualCommand = $COMMAND_SET_GROUP;
+		unless($groupEmail) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To set command $actualCommand we need to have not empty group email object!\n") };
+		unless($sendAs) { $sendAs = []; }
+		my $group = ();
+		$group->{'groupName'} = $groupEmail;
+		$group->{'sendAs'} = $sendAs;
+		my $jsonGroup = JSON->new->utf8->encode( $group );
+		$content{"Command"} = "Set-MuniGroup -DataJson '$jsonGroup'";
+		return 1;
+	} elsif ($status eq $COMMAND_STATUS_RESOLVE) {
+		if($jsonOutput->{'Status'} eq 'OK') {
+			return 0;
+		} else {
+			diePretty ( $ERROR_SET_METHOD_END_WITH_NOOK, "Status of output is: " . $jsonOutput->{'Status'} . "\n" );
+		}
+	} else {
+		diePretty ( $ERROR_UNSUPPORTED_COMMAND_STATUS, "Unsupported status $status\n" );
+	}
+}
+
+#Name: 
+# setMailbox
+#-----------------------
+#Parameters:
+# status           - status of command, do we want to set this command or resolve it
+# json output      - json output from the server as hash in perl, undef if there is no such output yet
+# upn              - identifier of user in o365 (email)
+# deliverToMailbox - if delivering is set to true or false
+# archive          - if archiving is set to true or false
+# forwardTo        - address for forwaring all emails to
+# language         - o365 mailbox language
+#-----------------------
+#Returns: void with exit status 0 = OK, error with exit status > 0 = not OK
+#-----------------------
+#Description: 
+# For existing mailbox in o365 set some parameters.
+#-----------------------
+sub setMailbox {
+	my $status = shift;
+	my $jsonOutput = shift;
+	my $upn = shift;
+	my $deliverToMailbox = shift;
+	my $archive = shift;
+	my $forwardTo = shift;
+	my $language = shift;
+
+	if(defined($jsonOutput->{"ErrorType"})) {
+		diePretty ( $ERROR_O365_OR_PS_ERROR , "Some HARD internal message error in method call -> " . $jsonOutput->{"ErrorMessage"} . "\n" );
+	}
+
+	if($status eq $COMMAND_STATUS_SET) {
+		$actualCommand = $COMMAND_SET_MAILBOX;
+		unless($upn) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To set command $actualCommand we need to have not empty user identifier object!\n") };
+		my $user = ();
+		$user->{'upn'} = $upn;
+		$user->{'language'} = $language;
+		$user->{'forwardingSmtpAddress'} = $forwardTo ? $forwardTo : JSON::null;
+		$user->{'deliverToMailboxAndForward'} = $deliverToMailbox ? JSON::true : JSON::false;
+		$user->{'archive'} = $archive ? JSON::true : JSON::false;
+		my $jsonUser = encode_json( $user );
+		$content{"Command"} = "Set-MuniMailbox -DataJson '$jsonUser'";
+		return 1;
+	} elsif ($status eq $COMMAND_STATUS_RESOLVE) {
+		if($jsonOutput->{'Status'} eq 'OK') {
+			return 0;
+		} else {
+			diePretty ( $ERROR_SET_METHOD_END_WITH_NOOK, "Status of method  output is: " . $jsonOutput->{'Status'} . "\n" );
+		}
+	} else {
+		diePretty ( $ERROR_UNSUPPORTED_COMMAND_STATUS, "Unsupported status $status\n" );
+	}
+}
+
+#Name:
+# getSharebox
+#-----------------------
+#Parameters: 
+# status     - status of command, do we want to set this command or resolve it
+# jsonOutput - json output from the server as hash in perl, undef if there is no such output yet
+# email      - identifier of sharebox email address in o365
+#-----------------------
+#Returns: JSON object sharebox with specific parameters and exit status 0 = OK, error with exit status > 0 = not OK
+#-----------------------
+#Description: 
+# Get json object sharebox by identifier if exists in o365.
+#-----------------------
+sub getSharebox {
+	my $status = shift;
+	my $jsonOutput = shift;
+	my $email = shift;
+
+	if(defined($jsonOutput->{"ErrorType"})) {
+		diePretty ( $ERROR_O365_OR_PS_ERROR , "Some HARD internal message error in method call -> " . $jsonOutput->{"ErrorMessage"} . "\n" );
+	}
+
+	if($status eq $COMMAND_STATUS_SET) {
+		$actualCommand = $COMMAND_GET_SHAREBOX;
+		unless($email) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To set command $actualCommand we need to have not empty email object!\n") };
+		$content{"Command"} = "Get-MuniSharedMailbox $email -property '*'";
+		return 1;
+	} elsif ($status eq $COMMAND_STATUS_RESOLVE) {
+		unless($jsonOutput) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To resolve command $actualCommand we need to have not empty JSON output object!\n") };
+		return $jsonOutput;
+	} else {
+		diePretty ( $ERROR_UNSUPPORTED_COMMAND_STATUS, "Unsupported status $status\n" );
+	}
+}
+
+#Name:
+# getMailbox
+#-----------------------
+#Parameters: 
+# status     - status of command, do we want to set this command or resolve it
+# jsonOutput - json output from the server as hash in perl, undef if there is no such output yet
+# email      - identifier of mailbox email address in o365
+#-----------------------
+#Returns: JSON object mailbox with specific parameters and exit status 0 = OK, error with exit status > 0 = not OK
+#-----------------------
+#Description: 
+# Get json object mailbox by identifier if exists in o365.
+#-----------------------
+sub getMailbox {
+	my $status = shift;
+	my $jsonOutput = shift;
+	my $email = shift;
+
+	if(defined($jsonOutput->{"ErrorType"})) {
+		diePretty ( $ERROR_O365_OR_PS_ERROR , "Some HARD internal message error in method call -> " . $jsonOutput->{"ErrorMessage"} . "\n" );
+	}
+
+	if($status eq $COMMAND_STATUS_SET) {
+		$actualCommand = $COMMAND_GET_MAILBOX;
+		unless($email) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To set command $actualCommand we need to have not empty email object!\n") };
+		$content{"Command"} = "Get-MuniMailbox $email -property 'forwardingSmtpAddress,deliverToMailboxAndForward,ArchiveStatus,Languages,userprincipalname'";
+		return 1;
+	} elsif ($status eq $COMMAND_STATUS_RESOLVE) {
+		unless($jsonOutput) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To resolve command $actualCommand we need to have not empty JSON output object!\n") };
+		return $jsonOutput;
+	} else {
+		diePretty ( $ERROR_UNSUPPORTED_COMMAND_STATUS, "Unsupported status $status\n" );
+	}
+}
+
+#Name:
+# getGroup
+#-----------------------
+#Parameters: 
+# status     - status of command, do we want to set this command or resolve it
+# jsonOutput - json output from the server as hash in perl, undef if there is no such output yet
+# email      - identifier of group email address in o365
+#-----------------------
+#Returns: JSON object group with specific parameters and exit status 0 = OK, error with exit status > 0 = not OK
+#-----------------------
+#Description: 
+# Get json object group by identifier if exists in o365.
+#-----------------------
+sub getGroup {
+	my $status = shift;
+	my $jsonOutput = shift;
+	my $email = shift;
+
+	if(defined($jsonOutput->{"ErrorType"})) {
+		diePretty ( $ERROR_O365_OR_PS_ERROR , "Some HARD internal message error in method call -> " . $jsonOutput->{"ErrorMessage"} . "\n" );
+	}
+
+	if($status eq $COMMAND_STATUS_SET) {
+		$actualCommand = $COMMAND_GET_GROUP;
+		unless($email) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To set command $actualCommand we need to have not empty email object!\n") };
+		$content{"Command"} = "Get-MuniGroup $email -property 'EmailAddresses, members, TrusteeSendAs'";
+		return 1;
+	} elsif ($status eq $COMMAND_STATUS_RESOLVE) {
+		unless($jsonOutput) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To resolve command $actualCommand we need to have not empty JSON output object!\n") };
+		return $jsonOutput;
+	} else {
+		diePretty ( $ERROR_UNSUPPORTED_COMMAND_STATUS, "Unsupported status $status\n" );
+	}
+}
+
+#Name:
+# getO365Group
+#-----------------------
+#Parameters: 
+# status     - status of command, do we want to set this command or resolve it
+# jsonOutput - json output from the server as hash in perl, undef if there is no such output yet
+# email      - identifier of O365Group email address in o365 (special group type different from normal group)
+#-----------------------
+#Returns: JSON object O365Group with specific parameters and exit status 0 = OK, error with exit status > 0 = not OK
+#-----------------------
+#Description: 
+# Get json object O365Group by identifier if exists in o365.
+#-----------------------
+
+sub getO365Group {
+	my $status = shift;
+	my $jsonOutput = shift;
+	my $email = shift;
+
+	if(defined($jsonOutput->{"ErrorType"})) {
+		diePretty ( $ERROR_O365_OR_PS_ERROR , "Some HARD internal message error in method call -> " . $jsonOutput->{"ErrorMessage"} . "\n" );
+	}
+
+	if($status eq $COMMAND_STATUS_SET) {
+		$actualCommand = $COMMAND_GET_O365_GROUP;
+		unless($email) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To set command $actualCommand we need to have not empty email object!\n") };
+		$content{"Command"} = "Get-MuniGroup $email -property 'EmailAddresses, members'";
+		return 1;
+	} elsif ($status eq $COMMAND_STATUS_RESOLVE) {
+		unless($jsonOutput) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To resolve command $actualCommand we need to have not empty JSON output object!\n") };
+		return $jsonOutput;
+	} else {
+		diePretty ( $ERROR_UNSUPPORTED_COMMAND_STATUS, "Unsupported status $status\n" );
+	}
+}
+
+#Name:
+# pingEmail
+#-----------------------
+#Parameters: 
+# status     - status of command, do we want to set this command or resolve it
+# jsonOutput - json output from the server as hash in perl, undef if there is no such output yet
+# email      - identifier of email address in o365
+#-----------------------
+#Returns: void and exit status 0 = OK, error with exit status > 0 = not OK
+#-----------------------
+#Description: 
+# Information about existence specific email in o365.
+#-----------------------
+sub pingEmail {
+	my $status = shift;
+	my $jsonOutput = shift;
+	my $email = shift;
+
+	if(defined($jsonOutput->{"ErrorType"})) {
+		diePretty ( $ERROR_O365_OR_PS_ERROR , "Some HARD internal message error in method call -> " . $jsonOutput->{"ErrorMessage"} . "\n" );
+	}
+
+	if($status eq $COMMAND_STATUS_SET) {
+		unless($email) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To set command $actualCommand we need to have not empty email object!\n") };
+		$actualCommand = $COMMAND_PING_EMAIL;
+		$content{"Command"} = "ping-muniemailaddress $email -short";
+		return 1;
+	} elsif ($status eq $COMMAND_STATUS_RESOLVE) {
+		unless($jsonOutput) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To resolve command $actualCommand we need to have not empty JSON output object!\n") };
+		my $emailExists = $jsonOutput->{'EmailExists'};
+		if($emailExists eq 'True') {
+			if($DEBUG>0) { print "Email exists in the system!\n"; }
+			return 0;
+		} else {
+			if($DEBUG>0) { print "Email NOT exists in the system!\n"; }
+			diePretty ( $ERROR_OBJECT_NOT_FOUND, "Email not exists in the system!\n" );
+		}
+	} else {
+		diePretty ( $ERROR_UNSUPPORTED_COMMAND_STATUS, "Unsupported status $status\n" );
+	}
+}
+
+#Name:
+# getContact
+#-----------------------
+#Parameters: 
+# status     - status of command, do we want to set this command or resolve it
+# jsonOutput - json output from the server as hash in perl, undef if there is no such output yet
+# email      - identifier of email concatc address (user) in o365
+#-----------------------
+#Returns: JSON object contact with specific parameters and exit status 0 = OK, error with exit status > 0 = not OK
+#-----------------------
+#Description: 
+# Get json object contact by identifier if exists in o365.
+#-----------------------
+sub getContact {
+	my $status = shift;
+	my $jsonOutput = shift;
+	my $email = shift;
+
+	if(defined($jsonOutput->{"ErrorType"})) {
+		diePretty ( $ERROR_O365_OR_PS_ERROR , "Some HARD internal message error in method call -> " . $jsonOutput->{"ErrorMessage"} . "\n"  );
+	}
+
+	if($status eq $COMMAND_STATUS_SET) {
+		unless($email) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To set command $actualCommand we need to have not empty email object!\n") };
+		$actualCommand = $COMMAND_GET_CONTACT;
+		$content{"Command"} = "Get-MuniContact $email -property 'DisplayName,EmailAddress'";
+		return 1;
+	} elsif ($status eq $COMMAND_STATUS_RESOLVE) {
+		unless($jsonOutput) { diePretty ( $ERROR_MANDATORY_OBJECT_IS_EMPTY, "To resolve command $actualCommand we need to have not empty JSON output object!\n") };
+		return $jsonOutput;
+	} else {
+		diePretty ( $ERROR_UNSUPPORTED_COMMAND_STATUS, "Unsupported status $status\n" );
+	}
+}
+
+#-------------------------------------------------------------------------
+#-----------------------------------SUBS----------------------------------
+#-------------------------------------------------------------------------
+
+#Name:
+# startSession
+#-----------------------
+#Parameters: 
+# There is no parameter, but one of commands need to be set before calling this method.
+#-----------------------
+#Returns: result of calling if any exists in hash structure (as json format)
+#         exit status 0 means everything is OK, die in any other situation
+#-----------------------
+#Description: 
+# This method starts whole session of calling o365 REST API.
+# It takes care about maximum waiting time to get answer for server.
+# After timeout, it ends with error.
+#-----------------------
+sub startSession {
+	my $sessionNumber = int rand(1000000);
+	if($DEBUG>0) { 
+		print "#######################################################################################\n";
+		print "Session number $sessionNumber: START\n"; 
+	}
+	#First call of command
+	my $urlToRepeat = callServer( $URL, 'POST', \%content );
+
+	#When there is something nasty (soft error or maxwait) then repeat till error or done
+	my $waitingInSec = 0;
+	while($urlToRepeat) {
+		if($waitingInSec == $MAX_WAIT_SEC) { diePretty ( $ERROR_HARD_TIMEOUT , "Timeout was longer than 2x$MAX_WAIT_SEC seconds.\n"); };
+		if($urlToRepeat eq $URL) {
+			#Problem with soft error
+			if($DEBUG>0) { print "Need to repeat calling because of soft error: $urlToRepeat\n"; }
+			$urlToRepeat = callServer( $urlToRepeat, 'POST', \%content );
+		} else {
+			#Problem with executing state
+			if($DEBUG>0) { print "Need to repeat calling because of timeout on execution maxWait: $urlToRepeat\n"; }
+			sleep 1;
+			$urlToRepeat = callServer( $urlToRepeat, 'GET', {} );
+		}
+		$waitingInSec++;
+	}
+
+	my $result = resolveOutputByCommandName ( $finalJsonOutput );
+	if($DEBUG>0) { print "RESULT IS: " . Dumper($result); }
+
+	#everything is ok
+	if($DEBUG>0) { 
+		print "Session number $sessionNumber: DONE SUCCESSFULLY\n"; 
+		print "#######################################################################################\n";
+	}
+
+	return $result;
+}
+
+#Name:
+# callServer
+#-----------------------
+#Parameters: 
+# url     - url of server and method address to call
+# type    - GET or PUT
+# content - hash content of request, will be encoded to json output
+#-----------------------
+#Returns: 
+# resolved status of call
+# 0 means everything is ok and done
+# text means URL address to call again (because of soft error or maxwait timeout)
+# die in other case (hard error, server error or other error)
+#-----------------------
+#Description: 
+# This method calls specific url with get or put connection type and predefined content in json.
+# After that it check response, if there is correct answer or error.
+# If there is no server error, it returns resolved status of this call.
+#-----------------------
+sub callServer {
+	my $url = shift;
+	my $type = shift;
+	my $content = shift;
+
+	my $serverResponse = createConnection( $url, $type, JSON->new->utf8->encode( $content ) );
+	my $serverResponseJson = checkServerResponse( $serverResponse );
+	#Just for debug purposes print whole information about json object
+	printJsonOutput( $serverResponseJson );
+	return resolveStatusOfCall( $serverResponseJson );
+}
+
+#Name:
+# createConnection
+#-----------------------
+#Parameters: 
+# url     - url of server and method address to call
+# type    - GET or PUT
+# content - hash content of request, will be encoded to json output
+#-----------------------
+#Returns: Response of server on our request.
+#-----------------------
+#Description: 
+# This method just takes all parameters and creates connection to the server.
+# Then returns it's repsonse.
+#-----------------------
+sub createConnection {
+	my $url = shift;
+	my $type = shift;
+	my $content = shift;
+
+	my $address = $HOST . ":" . $PORT;
+	my $domain = $HOST;
+	
+	my $headers = HTTP::Headers->new;
+	$headers->header('Content-Type' => 'application/json');
+	$headers->header('Accept' => 'application/json,text/json');
+
+	my $ua = LWP::UserAgent->new;
+	$ua->credentials( $address, $domain, $USERNAME, $PASSWORD ); 
+	my $request = HTTP::Request->new( $type, $url, $headers, $content );
+
+	return $ua->request($request);
+}
+
+#Name:
+# checkServerResponse
+#-----------------------
+#Parameters: 
+# response - response from server in JSON format
+#-----------------------
+#Returns: decoded json respons if response is success, die if response of server is not success
+#-----------------------
+#Description: 
+# This method checks if response of server was success. If yes, return decoded json response,
+# if not, die with error.
+#-----------------------
+sub checkServerResponse {
+	my $response = shift;
+	my $responseJson;
+
+	if ($response->is_success) {
+		$PSWS_HOST = $response->header( "psws-host" );
+		$responseJson = JSON->new->utf8->decode( $response->content );
+	} else {
+		my $responseInfo = $response->status_line . "\n" . $response->decoded_content . "\n";
+		diePretty( $ERROR_ISS_COM_PROBLEM, $responseInfo ); 
+	}
+	return $responseJson;
+}
+
+#Name:
+# getOutputInJson
+#-----------------------
+#Parameters: 
+# responseJson = server response in decoded json format (hash in perl)
+#-----------------------
+#Returns: decoded json output (part of response of the server - there is json output as part of json response)
+#-----------------------
+#Description: 
+# Parse and return json output (if any exists) from the server response
+#-----------------------
+sub getOutputInJson {
+	my $responseJson = shift;
+	my $outputJson = {};
+	if ($responseJson->{'Output'}) { 
+		$outputJson = JSON->new->decode( $responseJson->{'Output'} ); 
+	} 
+	return $outputJson; 
+}
+
+#Name:
+# printJsonOutput
+#-----------------------
+#Parameters: 
+# responseJson - decoded response from server (hash in perl)
+#-----------------------
+#Returns:
+# void
+#-----------------------
+#Description: 
+# This method is only for information purpose (debuging).
+# It prints all interesting information from server response (including json output)
+#-----------------------
+sub printJsonOutput {
+	my $responseJson = shift;
+	if($DEBUG<2) { return 1 };
+
+	my $outputJson = getOutputInJson( $responseJson );
+
+	print "\n------------------------------------------\n";
+	print "RESPONSE:\n";
+	print "------------------------------------------\n";
+	print "COMMAND = " . $responseJson->{'Command'} . "\n";
+	print "HOST    = " . $HOST . "\n";
+	print "PSWS_HOST = " . $PSWS_HOST . "\n";
+	print "URL     = " . $URL . "\n";
+	print "STATUS  = " . $responseJson->{'Status'} . "\n";
+	print "ERRORS  = " . Dumper($responseJson->{'Errors'});
+	print "FORMAT  = " . $responseJson->{'OutputFormat'} . "\n";
+	print "OUTPUT  = " . Dumper($outputJson);
+	print "-------------------------------------------\n\n";
+}
+
+#Name:
+# checkStatusOfCall
+#-----------------------
+#Parameters: 
+# responseJson - server decoded json response (hash in perl)
+#-----------------------
+#Returns:
+# "ERROR" if there is some server error in response
+# "HARD"  if there hard application error in response
+# "SOFT"  if there is only soft application error in response (we should try calling again after some time)
+# "OK"    if no errors are in server response, everything shoudl be ok
+#-----------------------
+#Description: 
+# This method checks if there is any error in the server response.
+#-----------------------
+sub checkStatusOfCall {
+	my $responseJson = shift;
+	my $SERVER_ERR = "ERROR";
+	my $SOFT_ERR = "SOFT";
+	my $HARD_ERR = "HARD";
+	my $STATUS_OK = "OK";
+
+	my $outputJson = getOutputInJson( $responseJson );
+	if ($responseJson->{'Output'}) { $outputJson = JSON->new->decode($responseJson->{'Output'}); }
+
+	if(@{$responseJson->{'Errors'}}) {
+		return $SERVER_ERR;
+	}
+
+	if($outputJson->{"ErrorType"}) {
+		if($outputJson->{"ErrorType"} eq $SOFT_ERR) {
+			return $SOFT_ERR;
+		} else {
+			return $HARD_ERR;
+		}
+	}
+	
+	return $STATUS_OK;
+}
+
+#Name:
+# resolveStatusOfCall
+#-----------------------
+#Parameters: 
+# responseJson - server decoded json response (hash in perl)
+#-----------------------
+#Returns:
+# If There is no error and task was completed - return 0
+# If there is no error, but task is still in execution - return URL to check status of call
+# If there is some soft application error - return URL to try call again
+# If there is some server error - die 
+# If there is some hard application error - die
+#-----------------------
+#Description: 
+# This method checks and then resolve status of server response.
+# If there is need to check status again or repeat calling, it return url address for this purpose.
+#-----------------------
+sub resolveStatusOfCall {
+	my $responseJson = shift;
+
+	my $returnedCode = checkStatusOfCall( $responseJson );
+
+	if($returnedCode eq "OK") {
+		if($responseJson->{'Status'} eq 'Completed') {
+			$finalJsonOutput = getOutputInJson( $responseJson );
+			return 0;
+		} elsif ($responseJson->{'Status'} eq 'Executing') {
+			my $newURL = $URL;
+			if($HOST ne $PSWS_HOST) {
+				$HOST = $PSWS_HOST;
+				$newURL =~ s/$HOST/$PSWS_HOST/g;
+			}
+			return $newURL . "(guid'" . $responseJson->{"ID"} . "')";
+		} else {
+			diePretty( $ERROR_UNKNOWN_STATUS, "Unknown status = " . $responseJson->{'Status'} . "\n" ) ;
+		}
+	} elsif( $returnedCode eq "ERROR" ) {
+		diePretty( $ERROR_WRONG_ISS_EXECUTION, Dumper($responseJson->{'Errors'}) . "\n" );
+	}	elsif ($returnedCode eq "SOFT" ) {
+			return $URL;
+	} elsif ($returnedCode eq "HARD" ) {
+		$finalJsonOutput = getOutputInJson( $responseJson );
+		return 0;
+	} else {
+		diePretty( $ERROR_UNKNOWN_RETURNED_CODE, "No more info, internal Error.\n" );
+	}
+}
+
+#Name:
+# diePretty
+#-----------------------
+#Parameters: 
+# errorMessage  - basic error information (one of predefined errors)
+# moreErrorInfo - more specific information about basic error
+#-----------------------
+#Returns:
+#-----------------------
+#Description: 
+# This is just exit with error with more information and human readable text formating.
+#-----------------------
+sub diePretty {
+	my $errorMessage = shift;
+	my $moreErrorInfo = shift;
+	my $rowDelimeter = "------------------------------------------------------------------------\n";
+	my $status =       "               STATUS = ERROR\n";
+	my $forCommand = "INPUT COMMAND: " . $inputCommand . "\n";
+
+	$errorMessage = $rowDelimeter . $status . $rowDelimeter . $errorMessage . $rowDelimeter . $moreErrorInfo  . $rowDelimeter . $forCommand . $rowDelimeter;
+
+	die $errorMessage;
+}
+
+#Name:
+# resolveOtuputByCommandName
+#-----------------------
+#Parameters: 
+# jsonOutput - decoded json output from server response (hash in perl)
+#-----------------------
+#Returns:
+# output of choosed command method with resolve status
+#-----------------------
+#Description: 
+# This method just call resolving on specific method defined by choosed command.
+# It returns output of one of these methods or die if such command is not known yet.
+#-----------------------
+sub resolveOutputByCommandName {
+	my $jsonOutput = shift;	
+	if($actualCommand eq $COMMAND_PING_EMAIL) {
+		return pingEmail( $COMMAND_STATUS_RESOLVE, $jsonOutput );
+	} elsif ($actualCommand eq $COMMAND_GET_CONTACT) {
+		return getContact ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
+	} elsif ($actualCommand eq $COMMAND_GET_O365_GROUP) {
+		return getO365Group ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
+	} elsif ($actualCommand eq $COMMAND_GET_GROUP) {
+		return getGroup ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
+	} elsif ($actualCommand eq $COMMAND_GET_SHAREBOX) {
+		return getSharebox ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
+	} elsif ($actualCommand eq $COMMAND_GET_MAILBOX) {
+		return getMailbox ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
+	} elsif ($actualCommand eq $COMMAND_SET_GROUP) {
+		return setGroup ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
+	} elsif ($actualCommand eq $COMMAND_SET_MAILBOX) {
+		return setMailbox ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
+	} else {
+		diePretty( $ERROR_UNSUPPORTED_COMMAND, "Command with number $actualCommand not known.\n" );
+	}
+}

--- a/send/o365_mu
+++ b/send/o365_mu
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+SERVICE_NAME="o365_mu"
+EXECSCRIPT="./o365_mu_process.pl"
+
+FACILITY_NAME=$1
+DESTINATION=$2
+DESTINATION_TYPE=$3
+
+#Test if destination is in not empty and in the correct format
+if [ -z "$DESTINATION" ]; then
+	echo "Missing Destination argument (Name of instance there)" >&2
+	exit 258
+else
+	if echo "$DESTINATION" | grep "[^A-Za-z_0-9-]"; then
+		echo "Bad fromat of destination!" >&2
+		exit 257
+	fi
+fi
+
+#Test if destination type is not empty and it is defined as service-specific (mandatory settings)
+if [ -z "$DESTINATION_TYPE" ]; then
+	echo "Destination type can't be empty!" >&2
+	exit 245
+else
+	if [ "$DESTINATION_TYPE" != "service-specific" ]; then
+		echo "Destination type need to be defined as service specific!" >&2
+		exit 244
+	fi
+fi
+
+#Test if name of facility is not empty
+if [ -z "$FACILITY_NAME" ]; then
+	echo "Missing FacilityName argument" >&2
+	exit 256
+fi
+
+#Destination is name of instance (name of file with other information like authorization etc.)
+INSTANCE_NAME=$DESTINATION
+
+#Basic path to find data from gen service
+SERVICE_FILES_BASE_DIR="`pwd`/../gen/spool"
+SERVICE_FILES_DIR="$SERVICE_FILES_BASE_DIR/$FACILITY_NAME/$SERVICE_NAME"
+#Just safety check. This should not happen
+if [ ! -d "$SERVICE_FILES_DIR" ]; then echo '$SERVICE_FILES_DIR: '$SERVICE_FILES_DIR' is not a directory' >&2 ; exit 1; fi
+
+#Create lock to disallow calling more than once at time (method similar to locks in slave scripts)
+LOCK_DIR=${LOCK_DIR:=/var/lock}
+LOCK_FILE="${LOCK_DIR}/perun-${SERVICE_NAME}-$INSTANCE_NAME.lock"
+LOCK_PIDFILE="$LOCK_FILE/pid"
+function create_lock {
+	if mkdir "${LOCK_FILE}"; then
+		trap 'rm -r -f "${LOCK_FILE}"' EXIT
+		echo $$ > "$LOCK_PIDFILE";
+		if [ $? -ne 0 ]; then
+			echo "Can't create lock file." >&2
+			exit 250
+		fi
+	else
+		# lock file exists, check for existence of concurrent process
+		if ps | grep "$SERVICE_NAME" | sed 's/^\([0-9]\+\).*/\1/' | grep "\(^\| \)`cat $LOCK_PIDFILE`\( \|$\)"; then
+		# concurrent process is running - this skript must terminate
+			echo "Concuret process $SERVICE_NAME is running" >&2
+			exit 249
+		else
+		# lock is not valid; it should be deleted
+			rm -r "$LOCK_FILE"
+			if [ $? -ne 0 ]; then
+				echo "Can't remove not valid lock file." >&2
+				exit 248
+			fi
+			echo "Invalid lock file found and deleted: $LOCK_FILE" >&2
+			mkdir "${LOCK_FILE}"
+			if [ $? -ne 0 ]; then
+				echo "Can't create lock after removing invalid lock." >&2
+				exit 247
+			fi
+			trap 'rm -r -f "${LOCK_FILE}"' EXIT
+			echo $$ > "$LOCK_PIDFILE"
+			if [ $? -ne 0 ]; then
+				echo "Can't create lock file after removing invalid lock file." >&2
+				exit 246
+			fi
+		fi
+	fi
+}
+
+#start script by creating new lock
+create_lock
+
+#prepare temporary working directory
+TMP_HOSTNAME_DIR="`mktemp -d /tmp/perun-send.XXXXXXXXXX`"
+if [ $? -ne 0 ]; then
+	echo "Can't create temporary dir" >&2
+	exit 255
+fi
+
+#prepare after exit removing of temporary files and directories
+trap 'rm -r -f "${LOCK_FILE}" "${TMP_HOSTNAME_DIR}"' EXIT
+
+#copy all needed files to the temporary directory
+cp $SERVICE_FILES_DIR/$SERVICE_NAME-users $TMP_HOSTNAME_DIR
+cp $SERVICE_FILES_DIR/$SERVICE_NAME-groups $TMP_HOSTNAME_DIR
+cp $SERVICE_FILES_DIR/$SERVICE_NAME-facilityId $TMP_HOSTNAME_DIR
+if [ $? -ne 0 ]; then
+	echo "Can't copy service file to temporary dir" >&2
+	exit 254
+fi
+
+#test if exists perl script to call from this one
+if [ ! -f "$EXECSCRIPT" ]; then
+	echo "Can't locate process script!" >&2
+	exit 253
+fi
+
+#call perl script with mandatory options
+$EXECSCRIPT -i $INSTANCE_NAME -p $TMP_HOSTNAME_DIR -s $SERVICE_NAME
+
+#catch return statement and process it
+ERRORCODE=$?
+if [ $ERRORCODE -ne 0 ]; then
+	echo "Process exit with error" >&2
+	exit $ERRORCODE
+fi
+
+ERR_CODE=$?
+echo "Slave script ends with return code: $ERR_CODE" >&2
+
+exit $ERR_CODE

--- a/send/o365_mu_process.pl
+++ b/send/o365_mu_process.pl
@@ -1,0 +1,426 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use threads;
+use threads::shared;
+use Thread::Queue;
+use DBI;
+use Getopt::Long qw(:config no_ignore_case);
+use File::Temp qw/ tempfile tempdir /;
+use File::Copy;
+use Data::Dumper;
+
+#predefined subs
+sub waitForThreads;
+sub startThreads;
+sub processTasks;
+sub processGroup;
+sub processUser;
+sub readDataAboutUsers;
+sub readDataAboutActiveUsers;
+sub readDataAboutGroups;
+sub readFacilityId;
+sub shellEscape($);
+
+#DEBUG = 0 means no debug, DEBUG>0 means print other messages
+my $DEBUG=0;
+
+#file locks for groups and users
+my $FILE_USERS_LOCK :shared;
+my $FILE_GROUPS_LOCK :shared;
+
+#number of worker threads
+my $THREAD_COUNT = 10;
+
+#constants for jobs 
+my $OPERATION = "operation";
+my $OPERATION_USER = "user";
+my $OPERATION_USER_CHANGED = $OPERATION_USER . "-CHANGED";
+my $OPERATION_USER_NOT_CHANGED = $OPERATION_USER . "-NOT_CHANGED";
+my $OPERATION_GROUP = "group";
+my $OPERATION_GROUP_CHANGED = $OPERATION_GROUP . "-CHANGED";
+my $OPERATION_GROUP_NOT_CHANGED = $OPERATION_GROUP . "-NOT_CHANGED";
+my $OPERATION_END = "end"; #signal end of the operation
+my $ARGUMENT = "argument";
+
+#text predefined constants to use
+my $UPN_TEXT = "upn";
+my $DELIVERED_TO_MAILBOX_AND_FORWARD_TEXT = "deliverToMailBoxAndForward";
+my $FORWARDING_SMTP_ADDRESS_TEXT = "forwardingSmtpAdress";
+my $ARCHIVE_TEXT = "archive";
+my $LANGUAGE_TEXT = "language";
+my $PLAIN_TEXT_OBJECT_TEXT = "plainTextObject";
+my $AD_GROUP_NAME_TEXT = "adGroupName";
+my $SEND_AS_TEXT = "sendAs";
+
+#needed global variables and constants for this script
+my $instanceName;
+my $pathToServiceFile;
+my $serviceName;
+my $domain = "";
+my $o365ConnectorFile = "./o365-connector.pl";
+
+#get options from input of script
+GetOptions ("instanceName|i=s" => \$instanceName, "pathToServiceFile|p=s" => \$pathToServiceFile, "serviceName|s=s" => \$serviceName);
+
+#check mandatory parameters
+#instance name is mandatory parameter
+if(!defined $instanceName) {
+	print "ERROR - Missing DBNAME to process service.\n";
+	exit 10;
+}
+
+#pathToServiceFile is mandatory parameter
+if(!defined $pathToServiceFile) {
+	print "ERROR - Missing path to file with generated data to process service.\n";
+	exit 11;
+}
+
+#name of service is mandatory parameter
+if(!defined $serviceName) {
+	print "ERROR - Missing info about service name to process service.\n";
+	exit 12;
+}
+
+#user data filename from perun need to exists (even if it is empty)
+my $usersDataFilename = "$pathToServiceFile/$serviceName-users";
+if(! -f $usersDataFilename) {
+	print "ERROR - Missing service file with data about users.\n";
+	exit 13;
+}
+
+#group data filename from perun need to exists (even if it is empty)
+my $groupsDataFilename = "$pathToServiceFile/$serviceName-groups";
+if(! -f $groupsDataFilename) {
+	print "ERROR - Missing service file with data about groups.\n";
+	exit 14;
+}
+
+#file with facility id from gen (can't be empty)
+my $facilityIdFilename = "$pathToServiceFile/$serviceName-facilityId";
+if(! -f $facilityIdFilename) {
+  print "ERORR - Missing file with facilit id.\n";
+  exit 16;
+}
+
+#read facility id from file
+my $facilityId = readFacilityId $facilityIdFilename;
+
+#prepare paths to files with cache (users and groups cache)
+my $basicCacheDir = "/var/cache/perun/services/$facilityId/$serviceName/";
+my $cacheDir = $basicCacheDir . "/" . $instanceName . "/";
+my $lastStateOfUsersFilename = $cacheDir . "o365_mu-users";
+my $lastStateOfGroupsFilename = $cacheDir . "o365_mu-groups";
+
+#file with active users need to exists
+my $pathToActiveUsersFile = $basicCacheDir . "activeO365Users";
+if(! -f $pathToActiveUsersFile) {
+	print "ERORR - Missing file with list of active o365 users.\n";
+	exit 15;
+}
+
+#read data from files and convert them to the hash structure in perl
+#read new data about users from PERUN
+my $newUsersStruc = readDataAboutUsers $usersDataFilename;
+
+#read new data about groups from PERUN
+my $newGroupsStruc = readDataAboutGroups $groupsDataFilename;
+
+#Read active users from file
+my $activeUsers = readDataAboutActiveUsers $pathToActiveUsersFile;
+
+#Read data (cache) about last state of users
+my $lastUsersStruc = {};
+if( -f $lastStateOfUsersFilename) { 
+	$lastUsersStruc = readDataAboutUsers $lastStateOfUsersFilename; 
+}
+
+#Read data (cache) about last state of groups
+my $lastGroupsStruc = {};
+if( -f $lastStateOfGroupsFilename) {
+	$lastGroupsStruc = readDataAboutGroups $lastStateOfGroupsFilename;
+}
+
+#prepare new cache files
+my $newUsersCache = new File::Temp( UNLINK => 1 );
+my $newGroupsCache = new File::Temp( UNLINK => 1 );
+open FILE_USERS_CACHE, ">$newUsersCache" or die "Could not open file with new cache of users data $newUsersCache: $!\n";
+open FILE_GROUPS_CACHE, ">$newGroupsCache" or die "Could not open file with new cache of users data $newGroupsCache: $!\n";
+
+#prepare threads for work jobs
+my $jobQueue = Thread::Queue->new();
+#start threads to do their jobs
+startThreads;
+
+#create and submit jobs for working with user's objects
+foreach my $key (keys %$newUsersStruc) {
+	my $newUser = $newUsersStruc->{$key};
+	my $oldUser = $lastUsersStruc->{$key};
+	#if user is not active in AD, skip him
+	unless($activeUsers->{$key}) { next; }
+
+	my $job;
+	unless($oldUser) {
+		#user is new, add him
+		$job = { $OPERATION => $OPERATION_USER_CHANGED, $ARGUMENT => $newUser };
+	} else {
+		if($newUser->{$PLAIN_TEXT_OBJECT_TEXT} eq $oldUser->{$PLAIN_TEXT_OBJECT_TEXT}) {
+			#user exists and he is equals, just write his data to the cache file
+			$job = { $OPERATION => $OPERATION_USER_NOT_CHANGED, $ARGUMENT => $newUser };
+		} else {
+			#user eixsts but he is different, modify him (add and modify operation is the same there)
+			$job = { $OPERATION => $OPERATION_USER_CHANGED, $ARGUMENT => $newUser };
+		}
+	}
+	#add job to the queue to process it by threads
+	$jobQueue->enqueue($job);
+}
+
+#create and submit jobs for working with group's objets
+foreach my $key (keys %$newGroupsStruc) {
+	my $newGroup = $newGroupsStruc->{$key};
+	my $oldGroup = $lastGroupsStruc->{$key};
+	
+	#remove not active users from sendAs of the new group
+	$newGroup->{$SEND_AS_TEXT} = [ grep { $activeUsers->{$_}  }  @{$newGroup->{$SEND_AS_TEXT}} ];
+	$newGroup->{$PLAIN_TEXT_OBJECT_TEXT} = $key . "\t" . join " ", @{$newGroup->{$SEND_AS_TEXT}};
+
+	my $job;
+	unless($oldGroup) {
+		#group is new, add it
+		$job = { $OPERATION => $OPERATION_GROUP_CHANGED, $ARGUMENT => $newGroup };
+	} else {
+		if($newGroup->{$PLAIN_TEXT_OBJECT_TEXT} eq $oldGroup->{$PLAIN_TEXT_OBJECT_TEXT}) {
+			#group exists and it is equals, just write it's data to the cache file
+			$job = { $OPERATION => $OPERATION_GROUP_NOT_CHANGED, $ARGUMENT => $newGroup };
+		} else {
+			#group exists but it is different, modify it (add and modify operation is the same there)
+			$job = { $OPERATION => $OPERATION_GROUP_CHANGED, $ARGUMENT => $newGroup };
+		}
+	}
+	#add job to the queue to process it by threads
+	$jobQueue->enqueue($job);
+}
+
+#wait for all threads to finish
+waitForThreads;
+
+#copy new cache files to place with old cache files
+close FILE_USERS_CACHE or die "Could not close file $newUsersCache: $!\n";
+close FILE_GROUPS_CACHE or die "Could not close file $newGroupsCache: $!\n";;
+copy( $newUsersCache, $lastStateOfUsersFilename );
+copy( $newGroupsCache, $lastStateOfGroupsFilename );
+
+exit 0;
+
+#---------------------------------SUBS------------------------------------
+
+#Sub to start all threads
+sub startThreads {
+	for(1 .. $THREAD_COUNT) {
+		threads->create(\&processTasks);
+	}
+}
+
+#Sub to process one job from queue of jobs
+sub processTasks {
+	my $running = 1;
+	while($running) {
+		my $job = $jobQueue->dequeue;
+
+		if($job->{$OPERATION} eq $OPERATION_END) {
+			$running = 0;
+		} else {
+			#do the job
+			if($job->{$OPERATION} =~ $OPERATION_GROUP) {
+				processGroup( $job->{$ARGUMENT} , $job->{$OPERATION} );
+			} elsif ($job->{$OPERATION} =~ $OPERATION_USER) {
+				processUser( $job->{$ARGUMENT} , $job->{$OPERATION} );
+			} else {
+				print "ERROR - UNKNOWN OPERATION: " . $job->{$OPERATION} . " was skipped!\n";
+			}
+		}
+	}
+}
+
+#Sub to send end operation for every running thread
+sub waitForThreads {
+	#send special job to queue to signal the thread to terminate
+	for(1 .. $THREAD_COUNT) {
+		$jobQueue->enqueue( { $OPERATION => $OPERATION_END } );
+	}
+
+	#wait for all threads to finish work
+	foreach my $thr (threads->list()) {
+		$thr->join();
+	}
+}
+
+#Sub to process group with O365 connector and if success, add him to the cache file
+sub processGroup {
+	my $groupObject = shift;
+	my $localOperation = shift;
+
+	if( $localOperation eq $OPERATION_GROUP_CHANGED ) {
+		my $command = $o365ConnectorFile . " -s " . shellEscape($serviceName)  . " -S " . shellEscape($instanceName) . " -c setMuniGroup" . " -i " . shellEscape $groupObject->{$AD_GROUP_NAME_TEXT};
+		my $sendAsMails = join " ", map { shellEscape $_ } @{$groupObject->{$SEND_AS_TEXT}} ;
+		if($sendAsMails) {
+			$command = $command . " -t " . $sendAsMails;
+		}
+
+		if($DEBUG) { print "CHANGE GROUP N-EQ: " . $groupObject->{$AD_GROUP_NAME_TEXT} . " - STARTED\n"; }
+		`$command`;
+		if($?) { 
+			print "CHANGE GROUP N-EQ: " . $groupObject->{$AD_GROUP_NAME_TEXT} . " - ERROR\n";
+			return 0; 
+		}
+		{
+			lock $FILE_GROUPS_LOCK;
+			print FILE_GROUPS_CACHE $groupObject->{$PLAIN_TEXT_OBJECT_TEXT} . "\n";
+		}
+		if($DEBUG) { print "CHANGE GROUP N-EQ: " . $groupObject->{$AD_GROUP_NAME_TEXT} . " - OK\n" };
+	} elsif( $localOperation eq $OPERATION_GROUP_NOT_CHANGED ) {
+		if($DEBUG) { print "CHANGE GROUP EQ: " . $groupObject->{$AD_GROUP_NAME_TEXT} . " - STARTED\n"; }
+		{
+			lock $FILE_GROUPS_LOCK;
+			print FILE_GROUPS_CACHE $groupObject->{$PLAIN_TEXT_OBJECT_TEXT} . "\n";
+		}
+		if($DEBUG) { print "CHANGE GROUP EQ: " . $groupObject->{$AD_GROUP_NAME_TEXT} . " - OK\n" };
+	} else {
+		print "ERROR - UNKNOWN OPERATION: " . $localOperation . " was skipped for group " . $groupObject->{$AD_GROUP_NAME_TEXT} . "\n";
+	}
+	
+	return 0;
+}
+
+#Sub to process user with O365 connector and if success, add him to the cache file
+sub processUser {
+	my $userObject = shift;
+	my $localOperation = shift;
+
+	if( $localOperation eq $OPERATION_USER_CHANGED ) {
+		my $command = $o365ConnectorFile . " -s " . shellEscape($serviceName)  . " -S " . shellEscape($instanceName) . " -c setMuniMailbox " . " -i " . shellEscape($userObject->{$UPN_TEXT}) . " -a " . shellEscape($userObject->{$ARCHIVE_TEXT}) . " -d " . shellEscape($userObject->{$DELIVERED_TO_MAILBOX_AND_FORWARD_TEXT}) . " -l " . shellEscape $userObject->{$LANGUAGE_TEXT};
+		if($userObject->{$FORWARDING_SMTP_ADDRESS_TEXT}) {
+			$command = $command . " -f " . shellEscape $userObject->{$FORWARDING_SMTP_ADDRESS_TEXT};
+		}
+
+		if($DEBUG) { print "CHANGE USER N-EQ: " . $userObject->{$UPN_TEXT} . " - STARTED\n"; }
+		`$command`;
+		if($?) {
+			print "CHANGE USER N-EQ: " . $userObject->{$UPN_TEXT} . " - ERROR\n"; 
+			return 0; 
+		}
+		{
+			lock $FILE_USERS_LOCK;
+			print FILE_USERS_CACHE $userObject->{$PLAIN_TEXT_OBJECT_TEXT} . "\n";
+		}
+		if($DEBUG) { print "CHANGE USER N-EQ: " . $userObject->{$UPN_TEXT} . " - OK\n"; }
+	} elsif( $localOperation eq $OPERATION_USER_NOT_CHANGED ) {
+		if($DEBUG) { print "CHANGE USER EQ: " . $userObject->{$UPN_TEXT} . " - STARTED\n"; }
+		{
+			lock $FILE_USERS_LOCK;
+			print FILE_USERS_CACHE $userObject->{$PLAIN_TEXT_OBJECT_TEXT} . "\n";
+		}
+		if($DEBUG) { print "CHANGE USER EQ: " . $userObject->{$UPN_TEXT} . " - OK\n"; }
+	} else {
+		print "ERROR - UNKNOWN OPERATION: " . $localOperation . " was skipped for user " . $userObject->{$UPN_TEXT} . "\n";
+	}
+
+	return 0;
+}
+
+#Sub to read data about users from file and convert it to perl hash
+sub readDataAboutUsers {
+	my $pathToFile = shift;
+
+	my $usersStruc = {};
+	open FILE, $pathToFile or die "Could not open file with users data $pathToFile: $!\n";
+	while(my $line = <FILE>) {
+		chomp( $line );
+		my @parts = split /\t/, $line;
+		my $UPN = $parts[0];
+		unless($domain) { 
+			$domain = $UPN;
+			$domain =~ s/^.*@//;
+		}
+	
+		$usersStruc->{$UPN}->{$UPN_TEXT} = $UPN;
+		$usersStruc->{$UPN}->{$FORWARDING_SMTP_ADDRESS_TEXT} = $parts[1];
+		$usersStruc->{$UPN}->{$ARCHIVE_TEXT} = $parts[2];
+		$usersStruc->{$UPN}->{$DELIVERED_TO_MAILBOX_AND_FORWARD_TEXT} = $parts[3];
+		$usersStruc->{$UPN}->{$LANGUAGE_TEXT} = $parts[4];
+		$usersStruc->{$UPN}->{$PLAIN_TEXT_OBJECT_TEXT} = $line ;
+	}
+	close FILE or die "Could not close file $pathToFile: $!\n";
+
+	return $usersStruc;
+}
+
+#Sub to read data about active users from file and convert it to perl hash
+sub readDataAboutActiveUsers {
+	my $pathToFile = shift;
+
+	my $activeUsersStruc = {};
+	open FILE, $pathToFile or die "Could not open file with active users $pathToFile: $!\n";
+	while(my $line = <FILE>) {
+		chomp( $line );
+		my $id = $line . "@" . $domain;
+		$activeUsersStruc->{$id} = 1;
+	}
+	close FILE or die "Could not close file $pathToFile: $!\n";
+
+	return $activeUsersStruc;
+}
+
+#Sub to read data about groups from file and convert it to perl hash
+sub readDataAboutGroups {
+	my $pathToFile = shift;
+
+	my $groupsStruc = {};
+	open FILE, $pathToFile or die "Could not open file with groups data from perun $pathToFile: $!\n";
+	while(my $line = <FILE>) {
+		chomp( $line );
+		my @parts = split /\t/, $line;
+		my $groupADName = $parts[0];
+		my @emails = ();
+		if($parts[1]) { @emails = split / /, $parts[1]; }
+	
+		$groupsStruc->{$groupADName}->{$AD_GROUP_NAME_TEXT} = $groupADName;
+		$groupsStruc->{$groupADName}->{$SEND_AS_TEXT} = \@emails;
+		$groupsStruc->{$groupADName}->{$PLAIN_TEXT_OBJECT_TEXT} = $line;
+	}
+	close FILE or die "Could not close file $pathToFile: $!\n";
+
+	return $groupsStruc;
+}
+
+#Sub to read data about facility id from file
+sub readFacilityId {
+	my $pathToFile = shift;
+
+	my $facId;
+	open FILE, $pathToFile or die "Could not open file with groups data from perun $pathToFile: $!\n";
+	while(my $line = <FILE>) {
+		chomp( $line );
+		unless($facId) {
+			$facId = $line;
+		} else {
+			die "There is more than one line in file with facility ids $pathToFile!\n";
+		}
+	}
+
+	unless($facId) {
+		die "Facility Id can't be obtain from file $pathToFile, it seems to be empty!\n";
+	}
+	return $facId;
+}
+
+#Escape all shell special characters from input
+sub shellEscape($) {
+	$_ = shift;
+
+	s/([-!\@\#\$\^&\*\(\)\{\}\[\]\\\/+=\.\<\>\?;:"',`\|%\s])/\\$1/g;
+
+	$_;
+}


### PR DESCRIPTION
 - new service o365_mu
 - add gen script to prepare two files with users and groups
 - add connector to o365 which is command line tool to connect o365 REST
   API and try to execute some commands there (return 0 if success, >0
   if error)
 - add bash send script for o365_mu service to check mandatory
   parameters and call o365_mu perl library
 - add perl library for o365_mu service to prepare all structures from
   perun, create diff structures using cache files and file with active
   users in o365 and then execute commands to o365 REST API ussing
   o365-connector. This library using threads for better scalability. It
   also skips records which ends in hard error from any reason.