### PR TITLE
Support Czech chars in vsup_zimbra values

### DIFF
--- a/slave/process-vsup-zimbra/bin/process-vsup_zimbra.sh
+++ b/slave/process-vsup-zimbra/bin/process-vsup_zimbra.sh
@@ -13,6 +13,9 @@ function process {
 	FROM_PERUN="${WORK_DIR}/vsup_zimbra.csv"
 	IGNORED="${WORK_DIR}/vsup_zimbra_ignored_accounts"
 
+	# support czech chars in Zimbra values, since Zimbra has and perun exports the "C"
+	export LANG=cs_CZ.UTF-8
+
 	perl $EXECSCRIPT $FROM_PERUN $IGNORED
 
 	exit $?

--- a/slave/process-vsup-zimbra/changelog
+++ b/slave/process-vsup-zimbra/changelog
@@ -1,3 +1,11 @@
+perun-slave-process-vsup-zimbra (3.0.4) stable; urgency=medium
+
+  * Export LANG=cs_CZ.UTF-8 to support Czech chars.
+    By default Zimbra has "C" and same value
+    is exported by Perun, so we must override it locally.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Mon, 09 Oct 2017 13:58:00 +0100
+
 perun-slave-process-vsup-zimbra (3.0.3) stable; urgency=medium
 
   * Fixed account attributes update in Zimbra.


### PR DESCRIPTION
- Export LANG=cs_CZ.UTF-8 in a slave script, since Zimbra by
  default has "C" and same value is exported by Perun and it
  breaks Czech diacritics.