### PR TITLE
Added vsup_zimbra_aliases service

### DIFF
--- a/gen/vsup_zimbra_aliases
+++ b/gen/vsup_zimbra_aliases
@@ -1,0 +1,101 @@
+#!/usr/bin/perl
+use feature "switch";
+use strict;
+use warnings;
+use perunServicesInit;
+use perunServicesUtils;
+use File::Copy;
+
+local $::SERVICE_NAME = "vsup_zimbra_aliases";
+local $::PROTOCOL_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.0";
+
+perunServicesInit::init;
+my $DIRECTORY = perunServicesInit::getDirectory;
+my $fileName = "$DIRECTORY/$::SERVICE_NAME".".csv";
+my $data = perunServicesInit::getHierarchicalData;
+
+# Constants
+our $A_LOGIN; *A_LOGIN = \'urn:perun:user_facility:attribute-def:virt:login';
+our $A_UCO; *A_UCO = \'urn:perun:user:attribute-def:def:ucoVsup';
+our $A_EMAIL_VSUP;  *A_EMAIL_VSUP = \'urn:perun:user:attribute-def:def:vsupMail';
+our $A_EMAIL_VSUP_ALIAS;  *A_EMAIL_VSUP_ALIAS = \'urn:perun:user:attribute-def:def:vsupMailAlias';
+our $A_EMAIL_VSUP_ALIASES;  *A_EMAIL_VSUP_ALIASES = \'urn:perun:user:attribute-def:def:vsupMailAliases';
+our $A_R_RELATION_TYPE; *A_R_RELATION_TYPE = \'urn:perun:resource:attribute-def:def:relationType';
+our $A_BLACKLISTED;  *A_BLACKLISTED = \'urn:perun:user_facility:attribute-def:virt:blacklisted';
+
+# Read which accounts are "system wide" => IGNORED by Perun.
+open FILE, "<" . "/etc/perun/services/vsup_zimbra/vsup_zimbra_ignored_accounts";
+my @ignoredAccountsList = <FILE>;
+close FILE;
+chomp(@ignoredAccountsList);
+my %ignoredAccounts = map { $_ => 1 } @ignoredAccountsList;
+
+# GATHER USERS
+my $users;  # $users->{$uco}->{ATTR} = $attrValue;
+
+#
+# AGGREGATE DATA
+#
+# FOR EACH USER
+foreach my $rData ($data->getChildElements) {
+
+	my %resourceAttributes = attributesToHash $rData->getAttributes;
+	my $relationType = $resourceAttributes{$A_R_RELATION_TYPE};
+
+	# Users from Resource must be in a relation
+	unless ($relationType) {
+		next;
+	}
+
+	my @membersData = $rData->getChildElements;
+
+	foreach my $member (@membersData) {
+
+		my %uAttributes = attributesToHash $member->getAttributes;
+
+		# SKIP MEMBERS WHICH SUPOSSED TO BE SYSTEM WIDE ACCOUNTS => IGNORED BY PERUN
+		if (exists $ignoredAccounts{$uAttributes{$A_LOGIN}}) {
+			next;
+		}
+
+		if (defined $uAttributes{$A_BLACKLISTED} and ($uAttributes{$A_BLACKLISTED} == 1)) {
+			# skip blacklisted users !
+			next;
+		}
+
+		my $uco = $uAttributes{$A_UCO};
+		$users->{$uco}->{$A_LOGIN} = $uAttributes{$A_LOGIN};
+		$users->{$uco}->{'TYPE'} = $uAttributes{$A_R_RELATION_TYPE};
+		$users->{$uco}->{'EMAIL'} = ($uAttributes{$A_EMAIL_VSUP} || $uAttributes{$A_LOGIN} . '@vsup.cz');
+		$users->{$uco}->{'EMAIL_ALIAS'} = $uAttributes{$A_EMAIL_VSUP_ALIAS};
+		my @aliases = $uAttributes{$A_EMAIL_VSUP_ALIASES};
+		$users->{$uco}->{'EMAIL_ALIASES'} = join(",",@aliases) || '';
+
+	}
+}
+
+#
+# PRINT user data
+#
+open FILE,">$fileName" or die "Cannot open $fileName: $! \n";
+binmode FILE, ":utf8";
+
+# print personal info
+my @keys = sort keys %{$users};
+for my $uco (@keys) {
+
+	# print attributes, which are never empty
+	print FILE $uco . "\t" . $users->{$uco}->{$A_LOGIN} . "\t" . $users->{$uco}->{'TYPE'} . "\t" .
+		$users->{$uco}->{'EMAIL'} . "\t" . $users->{$uco}->{"EMAIL_ALIAS"} . "\t" . $users->{$uco}->{"EMAIL_ALIASES"} . "\n";
+
+}
+
+close(FILE);
+
+#
+# Copy ignored accounts
+#
+copy("/etc/perun/services/vsup_zimbra/vsup_zimbra_ignored_accounts", "$DIRECTORY/vsup_zimbra_ignored_accounts") or die "Couldn't copy file of ignored Zimbra accounts.";
+
+perunServicesInit::finalize;

--- a/gen/vsup_zimbra_aliases
+++ b/gen/vsup_zimbra_aliases
@@ -66,10 +66,14 @@ foreach my $rData ($data->getChildElements) {
 
 		my $uco = $uAttributes{$A_UCO};
 		$users->{$uco}->{$A_LOGIN} = $uAttributes{$A_LOGIN};
-		$users->{$uco}->{'TYPE'} = $uAttributes{$A_R_RELATION_TYPE};
+		$users->{$uco}->{'TYPE'} = $relationType;
 		$users->{$uco}->{'EMAIL'} = ($uAttributes{$A_EMAIL_VSUP} || $uAttributes{$A_LOGIN} . '@vsup.cz');
 		$users->{$uco}->{'EMAIL_ALIAS'} = $uAttributes{$A_EMAIL_VSUP_ALIAS};
-		my @aliases = $uAttributes{$A_EMAIL_VSUP_ALIASES};
+		my $aliases = $uAttributes{$A_EMAIL_VSUP_ALIASES};
+		my @aliases = ();
+		if ($aliases) {
+			@aliases = @$aliases;
+		}
 		$users->{$uco}->{'EMAIL_ALIASES'} = join(",",@aliases) || '';
 
 	}

--- a/send/vsup_zimbra_aliases
+++ b/send/vsup_zimbra_aliases
@@ -1,0 +1,4 @@
+#!/bin/bash
+SERVICE_NAME="vsup_zimbra_aliases"
+
+. generic_send

--- a/slave/process-vsup-zimbra-aliases/bin/process-vsup_zimbra_aliases.sh
+++ b/slave/process-vsup-zimbra-aliases/bin/process-vsup_zimbra_aliases.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Script for managing mail aliases in Zimbra mail server
+
+PROTOCOL_VERSION='3.0.0'
+
+function process {
+
+	EXECSCRIPT="${LIB_DIR}/${SERVICE}/process-vsup_zimbra_aliases.pl"
+
+	create_lock
+
+	FROM_PERUN="${WORK_DIR}/vsup_zimbra_aliases.csv"
+	IGNORED="${WORK_DIR}/vsup_zimbra_ignored_accounts"
+
+	# support czech chars in Zimbra values, since Zimbra has and perun exports the "C"
+	export LANG=cs_CZ.UTF-8
+
+	perl $EXECSCRIPT $FROM_PERUN $IGNORED
+
+	exit $?
+}

--- a/slave/process-vsup-zimbra-aliases/changelog
+++ b/slave/process-vsup-zimbra-aliases/changelog
@@ -1,0 +1,5 @@
+perun-slave-process-vsup-zimbra-aliases (3.0.0) stable; urgency=low
+
+  * Package for managing aliases in Zimbra from Perun.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Wed, 11 Oct 2017 07:00:00 +0200

--- a/slave/process-vsup-zimbra-aliases/dependencies
+++ b/slave/process-vsup-zimbra-aliases/dependencies
@@ -1,0 +1,1 @@
+perun-slave-base

--- a/slave/process-vsup-zimbra-aliases/lib/process-vsup_zimbra_aliases.pl
+++ b/slave/process-vsup-zimbra-aliases/lib/process-vsup_zimbra_aliases.pl
@@ -245,8 +245,8 @@ sub updateAliases() {
 			foreach my $zimbraAlias (@to_be_removed) {
 
 				if ($dry_run) {
-					print $perunAccounts->{$login}->{"MAILBOX"} . " alias would be added '$zimbraAlias'.\n";
-					logMessage($perunAccounts->{$login}->{"MAILBOX"} . " alias would be added '$zimbraAlias'.");
+					print $perunAccounts->{$login}->{"MAILBOX"} . " alias would be removed '$zimbraAlias'.\n";
+					logMessage($perunAccounts->{$login}->{"MAILBOX"} . " alias would be removed '$zimbraAlias'.");
 				} else {
 					removeAlias($perunAccounts->{$login}->{"MAILBOX"}, $zimbraAlias);
 				}
@@ -260,9 +260,10 @@ sub updateAliases() {
 }
 
 #
-# Create single account in Zimbra and print/log the output
+# Set one of aliases as PreferredFromAddress attribute in Zimbra
 #
-# 1. param: hash reference of account to be created
+# 1. param: mailbox name
+# 2. param: preferredFrom address
 #
 sub setPrefFrom() {
 

--- a/slave/process-vsup-zimbra-aliases/lib/process-vsup_zimbra_aliases.pl
+++ b/slave/process-vsup-zimbra-aliases/lib/process-vsup_zimbra_aliases.pl
@@ -36,7 +36,7 @@ foreach my $line ( @lines ) {
 	$perunAccounts->{$parts[1]}->{'zimbraPrefFromAddress'} = (($parts[4] ne '') ? $parts[4] : undef);
 
 	my $aliases = (($parts[5] ne '') ? $parts[5] : undef);
-	unless ($aliases) {
+	if ($aliases) {
 		my @existing_aliases = split /,/, $aliases;
 		foreach my $alias (@existing_aliases) {
 			$perunAccounts->{$parts[1]}->{'zimbraMailAlias'}->{$alias} = 1;
@@ -196,7 +196,7 @@ sub updateAliases() {
 			# check and update existing
 
 			my $perunPrefFromAddress = $perunAccounts->{$login}->{"zimbraPrefFromAddress"};
-			my $zimbraPrefFromAddress = $zimbraAccounts->{$login}->{"zimbraPrefFromAddress"};
+			my $zimbraPrefFromAddress = $zimbraAccounts->{$login}->{"zimbraPrefFromAddress"} || '';
 
 			unless ($perunPrefFromAddress eq $zimbraPrefFromAddress) {
 

--- a/slave/process-vsup-zimbra-aliases/lib/process-vsup_zimbra_aliases.pl
+++ b/slave/process-vsup-zimbra-aliases/lib/process-vsup_zimbra_aliases.pl
@@ -1,0 +1,356 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+sub getAllAccounts;
+sub updateAliases;
+sub addAlias;
+sub removeAlias;
+sub setPrefFrom;
+sub logMessage;
+
+my $perunAccounts;  # $perunAccounts->{login}->{MAILBOX|zimbraPrefFromAddress|zimbraMailAlias}=value|value|{alias1 = 1, alias2 = 1}
+my $zimbraAccounts;  # $zimbraAccounts->{login}->{MAILBOX|zimbraPrefFromAddress|zimbraMailAlias}=value|value|{alias1 = 1, alias2 = 1}
+
+# IF SET TO 1, no changes are actually done to Zimbra mail server
+my $dry_run = 0;
+
+# read input files path
+my $accountsFilePath = shift;
+my $ignoredFilePath = shift;
+
+#
+# Read accounts sent from Perun
+#
+open FILE, "<" . $accountsFilePath;
+my @lines = <FILE>;
+close FILE;
+
+foreach my $line ( @lines ) {
+
+	my @parts = split /\t/, $line;
+	chomp(@parts);
+
+	$perunAccounts->{$parts[1]}->{'TYPE'} = $parts[2];   # original relation to prevent creation of wrong "active".
+	$perunAccounts->{$parts[1]}->{'MAILBOX'} = $parts[3];
+	$perunAccounts->{$parts[1]}->{'zimbraPrefFromAddress'} = (($parts[4] ne '') ? $parts[4] : undef);
+
+	my $aliases = (($parts[5] ne '') ? $parts[5] : undef);
+	unless ($aliases) {
+		my @existing_aliases = split /,/, $aliases;
+		foreach my $alias (@existing_aliases) {
+			$perunAccounts->{$parts[1]}->{'zimbraMailAlias'}->{$alias} = 1;
+		}
+	}
+
+	# put prefered alias between aliases
+	if ($perunAccounts->{$parts[1]}->{'zimbraPrefFromAddress'}) {
+		$perunAccounts->{$parts[1]}->{'zimbraMailAlias'}->{$perunAccounts->{$parts[1]}->{'zimbraPrefFromAddress'}} = 1;
+	} else {
+		# prefered from is set to mailbox name - in such case is NOT alias
+		$perunAccounts->{$parts[1]}->{'zimbraPrefFromAddress'} = $parts[3];
+	}
+
+}
+
+#
+# Read which accounts are supposed to be IGNORED by Perun
+#
+open FILE, "<" . $ignoredFilePath;
+my @ignoredAccountsList = <FILE>;
+close FILE;
+chomp(@ignoredAccountsList);
+my %ignoredAccounts = map { $_ => 1 } @ignoredAccountsList;
+
+#
+# Read existing accounts from Zimbra
+#
+$zimbraAccounts = getAllAccounts();
+
+updateAliases();
+
+exit 0;
+
+#####################
+#
+# HELPING METHODS
+#
+#####################
+
+#
+# Read all accounts from Zimbra mail server
+# Exit script with ret.code = 1 if contacting Zimbra fails.
+#
+sub getAllAccounts() {
+
+	my $existingAccounts; # $existingAccounts->{login}->{MAILBOX|ALIAS|ALIASES}=value
+	my $currentLogin;     # current step in output parsing
+
+	# read versbose output of all accounts in zimbra
+	my @output = `sudo /opt/zimbra/bin/zmprov -l gaa -v vsup.cz`;
+	my $ret = $?; # get ret.code of backticks command
+	$ret = ($ret >> 8); # shift 8 bits to get original return code
+
+	if ($ret != 0) {
+		print "Unable to read all accounts from Zimbra, err.code: $ret, output: @output";
+		logMessage("Unable to read all accounts from Zimbra, err.code: $ret, output: @output");
+		exit 1;
+	}
+
+	chomp(@output);
+
+	foreach my $line (@output) {
+
+		if ($line =~ m/^# name (.*\@vsup.cz)(.*)$/) {
+			$currentLogin = ($line =~ m/^# name (.*)\@vsup.cz(.*)$/)[0];
+			my $currentMailbox = ($line =~ m/^# name (.*\@vsup.cz)(.*)$/)[0];
+			$existingAccounts->{$currentLogin}->{"MAILBOX"} = $currentMailbox;
+		}
+
+		if ($line =~ m/^zimbraMailAlias: (.*)$/) {
+			my $currentAlias = ($line =~ m/^zimbraMailAlias: (.*)$/)[0];
+			$existingAccounts->{$currentLogin}->{"zimbraMailAlias"}->{$currentAlias} = 1;
+		}
+
+		if ($line =~ m/^zimbraPrefFromAddress: (.*)$/) {
+			my $currentPrefFrom = ($line =~ m/^zimbraPrefFromAddress: (.*)$/)[0];
+			$existingAccounts->{$currentLogin}->{"zimbraPrefFromAddress"} = $currentPrefFrom;
+		}
+
+	}
+
+	return $existingAccounts;
+
+}
+
+#
+# Iterate through Zimbra and Perun accounts and update changed aliases and preferred from addresses
+#
+# Only accounts pushed from Perun are modified !!
+#
+sub updateAliases() {
+
+	# 1. ADD all new aliases
+	foreach my $login (sort keys %$perunAccounts) {
+
+		# skip ignored
+		if (exists $ignoredAccounts{$login}) {
+			print $perunAccounts->{$login}->{"MAILBOX"} . " ignored.\n";
+			logMessage("WARN: " . $zimbraAccounts->{$login}->{"MAILBOX"} . " not updated. Belongs to ignored.");
+			next;
+		}
+
+		# skip not yet existing
+		unless (exists $zimbraAccounts->{$login}) {
+			print $perunAccounts->{$login}->{"MAILBOX"} . " ignored - not yet created in Zimbra.\n";
+			logMessage("WARN: " . $zimbraAccounts->{$login}->{"MAILBOX"} . " not updated. Not yet created in Zimbra.");
+			next;
+
+		} else {
+
+			# check and update existing
+			my $perunAliases = $perunAccounts->{$login}->{"zimbraMailAlias"};
+			my $zimbraAliases = $zimbraAccounts->{$login}->{"zimbraMailAlias"};
+			my @to_be_added;
+			foreach my $perunAlias (sort keys %{$perunAliases}) {
+				unless (exists $zimbraAliases->{$perunAlias}) {
+					push (@to_be_added, $perunAlias);
+				}
+			}
+
+			foreach my $perunAlias (@to_be_added) {
+
+				if ($dry_run) {
+					print $perunAccounts->{$login}->{"MAILBOX"} . " alias would be added '$perunAlias'.\n";
+					logMessage($perunAccounts->{$login}->{"MAILBOX"} . " alias would be added '$perunAlias'.");
+				} else {
+					addAlias($perunAccounts->{$login}->{"MAILBOX"}, $perunAlias);
+				}
+
+			}
+
+		}
+
+	}
+
+	# 2. Set all pref addresses
+
+	foreach my $login (sort keys %$perunAccounts) {
+
+		# skip ignored
+		if (exists $ignoredAccounts{$login}) {
+			print $perunAccounts->{$login}->{"MAILBOX"} . " ignored.\n";
+			logMessage("WARN: " . $zimbraAccounts->{$login}->{"MAILBOX"} . " not updated. Belongs to ignored.");
+			next;
+		}
+
+		# skip not yet existing
+		unless (exists $zimbraAccounts->{$login}) {
+
+			print $perunAccounts->{$login}->{"MAILBOX"} . " ignored - not yet created in Zimbra.\n";
+			logMessage("WARN: " . $zimbraAccounts->{$login}->{"MAILBOX"} . " not updated. Not yet created in Zimbra.");
+			next;
+
+		} else {
+
+			# check and update existing
+
+			my $perunPrefFromAddress = $perunAccounts->{$login}->{"zimbraPrefFromAddress"};
+			my $zimbraPrefFromAddress = $zimbraAccounts->{$login}->{"zimbraPrefFromAddress"};
+
+			unless ($perunPrefFromAddress eq $zimbraPrefFromAddress) {
+
+				if ($dry_run) {
+					print $perunAccounts->{$login}->{"MAILBOX"} . " zimbraPrefFromAddress would be updated '$perunPrefFromAddress'.\n";
+					logMessage($perunAccounts->{$login}->{"MAILBOX"} . " zimbraPrefFromAddress would be updated '$perunPrefFromAddress'.");
+				} else {
+					setPrefFrom($perunAccounts->{$login}->{"MAILBOX"}, $perunPrefFromAddress);
+				}
+
+			}
+
+		}
+
+	}
+
+	# 3. Remove all deleted aliases
+
+	foreach my $login (sort keys %$perunAccounts) {
+
+		# skip ignored
+		if (exists $ignoredAccounts{$login}) {
+			print $perunAccounts->{$login}->{"MAILBOX"} . " ignored.\n";
+			logMessage("WARN: " . $zimbraAccounts->{$login}->{"MAILBOX"} . " not updated. Belongs to ignored.");
+			next;
+		}
+
+		# skip not yet existing
+		unless (exists $zimbraAccounts->{$login}) {
+			print $perunAccounts->{$login}->{"MAILBOX"} . " ignored - not yet created in Zimbra.\n";
+			logMessage("WARN: " . $zimbraAccounts->{$login}->{"MAILBOX"} . " not updated. Not yet created in Zimbra.");
+			next;
+
+		} else {
+
+			# check and update existing
+			my $perunAliases = $perunAccounts->{$login}->{"zimbraMailAlias"};
+			my $zimbraAliases = $zimbraAccounts->{$login}->{"zimbraMailAlias"};
+			my @to_be_removed;
+			foreach my $zimbraAlias (sort keys %{$zimbraAliases}) {
+				unless (exists $perunAliases->{$zimbraAlias}) {
+					push (@to_be_removed, $zimbraAlias);
+				}
+			}
+
+			foreach my $zimbraAlias (@to_be_removed) {
+
+				if ($dry_run) {
+					print $perunAccounts->{$login}->{"MAILBOX"} . " alias would be added '$zimbraAlias'.\n";
+					logMessage($perunAccounts->{$login}->{"MAILBOX"} . " alias would be added '$zimbraAlias'.");
+				} else {
+					removeAlias($perunAccounts->{$login}->{"MAILBOX"}, $zimbraAlias);
+				}
+
+			}
+
+		}
+
+	}
+
+}
+
+#
+# Create single account in Zimbra and print/log the output
+#
+# 1. param: hash reference of account to be created
+#
+sub setPrefFrom() {
+
+	my $account = shift;
+	my $value = shift;
+
+	my $output = `sudo /opt/zimbra/bin/zmprov ma '$account' zimbraPrefFromAddress '$value'`;
+	my $ret = $?; # get ret.code of backticks command
+	$ret = ($ret >> 8); # shift 8 bits to get original return code
+
+	if ($ret != 0) {
+		print "ERROR: $account preferred from address not set, ret.code: $ret, output: $output.\n";
+		logMessage("ERROR: $account preferred from address not set, ret.code: $ret, output: $output.\n");
+	} else {
+		print "$account set preferred from address $value.\n";
+		logMessage("$account set preferred from address $value, ret.code: $ret, output: $output.");
+	}
+
+}
+
+#
+# Add alias to Zimbra account
+#
+# 1. param: name of Zimbra account to update (mail)
+# 2. param: value of alias to be added
+#
+# Return: return code of zmprov command
+#
+sub addAlias() {
+
+	my $account = shift;
+	my $alias = shift;
+
+	my $output = `sudo /opt/zimbra/bin/zmprov aaa '$account' '$alias'`;
+	my $ret = $?; # get ret.code of backticks command
+	$ret = ($ret >> 8); # shift 8 bits to get original return code
+
+	# only for logging verbose output
+	if ($ret != 0) {
+		print "ERROR: $account alias $alias not added.\n";
+		logMessage("ERROR: $account alias $alias not added, ret.code: $ret, output: $output.");
+	} else {
+		print "$account alias $alias added.\n";
+		logMessage("$account alias $alias added, ret.code: $ret, output: $output.");
+	}
+
+	return $ret;
+
+}
+
+#
+# Remove alias from Zimbra account
+#
+# 1. param: name of Zimbra account to update (mail)
+# 2. param: value of alias to be removed
+#
+# Return: return code of zmprov command
+#
+sub removeAlias() {
+
+	my $account = shift;
+	my $alias = shift;
+
+	my $output = `sudo /opt/zimbra/bin/zmprov raa '$account' '$alias'`;
+	my $ret = $?; # get ret.code of backticks command
+	$ret = ($ret >> 8); # shift 8 bits to get original return code
+
+	# only for logging verbose output
+	if ($ret != 0) {
+		print "ERROR: $account alias $alias not removed.\n";
+		logMessage("ERROR: $account alias $alias not removed, ret.code: $ret, output: $output.");
+	} else {
+		print "$account alias $alias removed.\n";
+		logMessage("$account alias $alias removed, ret.code: $ret, output: $output.");
+	}
+
+	return $ret;
+
+}
+
+#
+# Log message to local file /home/perun/vsup_zimbra_aliases.log
+#
+# 1. param Message to log
+#
+sub logMessage() {
+	my $message = shift;
+	open(LOGFILE, ">>/home/perun/vsup_zimbra_aliases.log");
+	print LOGFILE (localtime(time) . ": " . $message . "\n");
+	close(LOGFILE);
+}

--- a/slave/process-vsup-zimbra-aliases/rpm.dependencies
+++ b/slave/process-vsup-zimbra-aliases/rpm.dependencies
@@ -1,0 +1,1 @@
+perun-slave-base

--- a/slave/process-vsup-zimbra-aliases/short_desc
+++ b/slave/process-vsup-zimbra-aliases/short_desc
@@ -1,0 +1,1 @@
+Package for perun service - Manages mail aliases in Zimbra mail server at VŠUP


### PR DESCRIPTION
- Untested version and initial implementation.
- Perun adds and removes account aliases and set preferred from
  address. Only users pushed from Perun are managed now, so
  aliases are kept, if user is removed from all associated groups.