### PR TITLE
Add missing versions of perun-base dependency for k5login and fs-home

### DIFF
--- a/slave/process-fs-home/dependencies
+++ b/slave/process-fs-home/dependencies
@@ -1,1 +1,1 @@
-perun-slave-base
+perun-slave-base (>= 3.1.9)

--- a/slave/process-fs-home/rpm.dependencies
+++ b/slave/process-fs-home/rpm.dependencies
@@ -1,1 +1,1 @@
-perun-slave-base
+perun-slave-base >= 3.1.9

--- a/slave/process-k5login/dependencies
+++ b/slave/process-k5login/dependencies
@@ -1,1 +1,1 @@
-perun-slave-base
+perun-slave-base (>= 3.1.9)

--- a/slave/process-k5login/rpm.dependencies
+++ b/slave/process-k5login/rpm.dependencies
@@ -1,1 +1,1 @@
-perun-slave-base
+perun-slave-base >= 3.1.9


### PR DESCRIPTION
 - there is a new method needed for k5login and for fs-home so
   dependency need to have set proper version