### PR TITLE
Fix wrong usage of teesting string equality in bash

### DIFF
--- a/send/generic_send
+++ b/send/generic_send
@@ -29,7 +29,7 @@ if [ -z "$DESTINATION_TYPE" ]; then
 fi
 
 #choose transport command, only url type has different transport command at this moment
-if [ "$DESTINATION_TYPE"!="$DESTINATION_TYPE_URL" ]; then
+if [ "$DESTINATION_TYPE" != "$DESTINATION_TYPE_URL" ]; then
 	TRANSPORT_COMMAND="ssh -o StrictHostKeyChecking=no -o GSSAPIAuthentication=no -o GSSAPIKeyExchange=no -o ConnectTimeout=5  -i $KEY_PATH"
 else
 	#add certificate to the curl if cert file and key file exists and they are readable
@@ -115,7 +115,7 @@ fi
 #Add host to the transport command for all types of destination
 TRANSPORT_COMMAND="$TRANSPORT_COMMAND $HOST"
 #Add also slave command if this is not url type of destination
-if [ "$DESTINATION_TYPE"!="$DESTINATION_TYPE_URL" ]; then
+if [ "$DESTINATION_TYPE" != "$DESTINATION_TYPE_URL" ]; then
 	TRANSPORT_COMMAND="$TRANSPORT_COMMAND $SLAVE_COMMAND"
 fi
 


### PR DESCRIPTION
 - there must be an empty space before and after binary operator "!=" in
   bash, because it is just and argument of function test "["