### PR TITLE
fix curl transport command

### DIFF
--- a/send/generic_send
+++ b/send/generic_send
@@ -36,7 +36,7 @@ else
 	if [ -r "${PERUN_CERT}" -a -r "${PERUN_KEY}" ]; then
 		PERUN_CERT_SETTING="--cert ${PERUN_CERT} --key ${PERUN_KEY}"
 	fi
-	TRANSPORT_COMMAND="curl ${PERUN_CERT_SETTING} -i -H Content-Type:application/x-tar -f --upload-file - "
+	TRANSPORT_COMMAND="curl ${PERUN_CERT_SETTING} -i -H Content-Type:application/x-tar -f -X PUT --data-binary @- "
 fi
 
 #overriding of existing variables as TRANSPORT_COMMAND etc.


### PR DESCRIPTION
Currently the  content-length field is missing in the request header. To fix this we have to use an other parameter set for the curl PUT request. 
The difference between '--file-upload -' and '-X PUT --data-binary @-' is that first argument set  streams directly to the request without buffering.  Therefore the content-length  header field is left out in the  request . The later one buffers the input.