### PR TITLE
Sort users EPPNs in crm_ceitec service

### DIFF
--- a/gen/crm_ceitec
+++ b/gen/crm_ceitec
@@ -88,7 +88,7 @@ for my $login (@logins) {
 		$str =~ s/\p{NonspacingMark}//g;
 
 		if (defined $eppns) {
-			foreach my $val (@$eppns) {
+			foreach my $val (sort @$eppns) {
 				if (("Masarykova univerzita" eq $o) && ($val =~ /\@muni.cz$/)) {
 					print FILE "$val";
 					last;
@@ -99,7 +99,7 @@ for my $login (@logins) {
 				}
 			}
 			my $eppn_string = "";
-			foreach my $eppn_val (@$eppns) {
+			foreach my $eppn_val (sort @$eppns) {
 				# construct eppn string
 				$eppn_string = $eppn_string . $eppn_val . ",";
 			}


### PR DESCRIPTION
- Order of items in a list of virtual user attribute
  "eduPersonPrincipalNames" is not fixed and depends on DB engine.
  We must sort EPPNs in generated file (just like group names
  already were sorted), since sending script compares each line
  alphabetically to seek changes and updates whole entry.