### PR TITLE
Fix problem with creating home from skel dir

### DIFF
--- a/slave/process-fs-home/changelog
+++ b/slave/process-fs-home/changelog
@@ -1,3 +1,13 @@
+perun-slave-process-fs-home (3.1.5) stable; urgency=high
+
+  * When creating home from skeletal directory, there was a problem with wrong
+    behavior of 'cp -r' command. When temporary directory was already created,
+    it copied not only files from skel dir, but the whole skel dir to the new
+    home directory. Now it creates new directory from the skel dir if such 
+    exists and also preserve all ACLs and links there.
+
+ -- Michal Stava <stavamichal@gmail.com>  Wed, 06 Dec 2017 08:55:00 +0100
+
 perun-slave-process-fs-home (3.1.4) stable; urgency=medium
 
   * Use temporary directory to prepare new home, set correct permission and


### PR DESCRIPTION
Fix problem with creating home from skel dir
- command "cp -r" on directory copies also directory itself. If the
 destination of copying is also directory (in this case it is temp
 directory prepared for creating a new home) it copies whole target to
 the destination instead of copying only content of target to the
 destination. For this reason this behavior was changed to prevent
 this.
- added preservation of ACLs and links from the target directory.
 Command "cp -ar" instead of "cp -r". Command "chmod" is now called
 only on the target directory, not recursively.