### PR TITLE
Manage aliases and preferredFrom in Zimbra for vsup_zimbra service

### DIFF
--- a/gen/vsup_zimbra
+++ b/gen/vsup_zimbra
@@ -6,19 +6,23 @@ use perunServicesInit;
 use perunServicesUtils;
 use File::Copy;
 use Time::Piece;
+use Perun::Agent;
 
 sub getStatus;
 
 local $::SERVICE_NAME = "vsup_zimbra";
-local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+local $::PROTOCOL_VERSION = "3.1.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
 my $fileName = "$DIRECTORY/$::SERVICE_NAME".".csv";
 my $data = perunServicesInit::getHierarchicalData;
+my $agent = Perun::Agent->new();
+my $attributesAgent = $agent->getAttributesAgent;
 
 # Constants
+our $A_USER_ID; *A_USER_ID = \'urn:perun:user:attribute-def:core:id';
 our $A_LOGIN; *A_LOGIN = \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_UCO; *A_UCO = \'urn:perun:user:attribute-def:def:ucoVsup';
 our $A_FIRST_NAME;  *A_FIRST_NAME = \'urn:perun:user:attribute-def:core:firstName';
@@ -32,6 +36,9 @@ our $A_EXPIRATION_KOS;  *A_EXPIRATION_KOS = \'urn:perun:user:attribute-def:def:e
 our $A_EXPIRATION_DC2;  *A_EXPIRATION_DC2 = \'urn:perun:user:attribute-def:def:expirationDc2';
 our $A_EXPIRATION_MANUAL; *A_EXPIRATION_MANUAL = \'urn:perun:user:attribute-def:def:expirationManual';
 our $A_ZIMBRA_DISPLAY_NAME;  *A_ZIMBRA_DISPLAY_NAME = \'urn:perun:user:attribute-def:def:zimbraDisplayName';
+# following are manually retrieved
+our $A_EMAIL_VSUP_ALIAS;  *A_EMAIL_VSUP_ALIAS = \'urn:perun:user:attribute-def:def:vsupMailAlias';
+our $A_EMAIL_VSUP_ALIASES;  *A_EMAIL_VSUP_ALIASES = \'urn:perun:user:attribute-def:def:vsupMailAliases';
 
 # Read which accounts are "system wide" => IGNORED by Perun.
 open FILE, "<" . "/etc/perun/services/$::SERVICE_NAME/vsup_zimbra_ignored_accounts";
@@ -63,7 +70,7 @@ foreach my $rData ($data->getChildElements) {
 
 		my %uAttributes = attributesToHash $member->getAttributes;
 
-		# SKIP MEMBERS WHICH SUPOSSED TO BE SYSTEM WIDE ACCOUNTS => IGNORED BY PERUN
+		# SKIP MEMBERS WHICH SUPPOSED TO BE SYSTEM WIDE ACCOUNTS => IGNORED BY PERUN
 		if (exists $ignoredAccounts{$uAttributes{$A_LOGIN}}) {
 			next;
 		}
@@ -71,6 +78,8 @@ foreach my $rData ($data->getChildElements) {
 		my $uco = $uAttributes{$A_UCO};
 		$users->{$uco}->{$A_LOGIN} = $uAttributes{$A_LOGIN};
 		$users->{$uco}->{'EMAIL'} = ($uAttributes{$A_EMAIL_VSUP} || $uAttributes{$A_LOGIN} . '@vsup.cz');
+
+		$users->{$uco}->{$A_USER_ID} = $uAttributes{$A_USER_ID};
 
 		# determine user account type
 		if ($relationType eq "ZAM") {
@@ -121,6 +130,33 @@ foreach my $rData ($data->getChildElements) {
 	}
 }
 
+# manually get mail aliases
+my @uco_keys = sort keys %{$users};
+for my $uco (@uco_keys) {
+
+	my $uid = $users->{$uco}->{$A_USER_ID};
+	my @attrNames = ($A_EMAIL_VSUP_ALIAS, $A_EMAIL_VSUP_ALIASES);
+
+	my @attributes = $attributesAgent->getAttributes( user => $uid , attrNames => \@attrNames );
+	foreach (@attributes) {
+		if ($_->getName() eq $A_EMAIL_VSUP_ALIAS) {
+
+			$users->{$uco}->{$A_EMAIL_VSUP_ALIAS} = $_->getValue || '';
+
+		} elsif ($_->getName() eq $A_EMAIL_VSUP_ALIASES) {
+
+			my $aliases = $_->getValue;
+			my @aliases = ();
+			if ($aliases) {
+				@aliases = @$aliases;
+			}
+			$users->{$uco}->{$A_EMAIL_VSUP_ALIASES} = join(",",@aliases) || '';
+
+		}
+	}
+
+}
+
 #
 # PRINT user data
 #
@@ -134,7 +170,8 @@ for my $uco (@keys) {
 	# print attributes, which are never empty
 	print FILE $uco . "\t" . $users->{$uco}->{$A_LOGIN} . "\t" . $users->{$uco}->{'TYPE'} . "\t" .
 		$users->{$uco}->{'EMAIL'} . "\t" . $users->{$uco}->{"FIRST_NAME"} . "\t" . $users->{$uco}->{"LAST_NAME"} .
-		"\t" . $users->{$uco}->{"DISPLAY_NAME"} . "\t" . $users->{$uco}->{"STATUS"} . "\t" . $users->{$uco}->{"COS"} . "\n";
+		"\t" . $users->{$uco}->{"DISPLAY_NAME"} . "\t" . $users->{$uco}->{"STATUS"} . "\t" . $users->{$uco}->{"COS"} .
+		"\t" . $users->{$uco}->{$A_EMAIL_VSUP_ALIAS} . "\t" . $users->{$uco}->{$A_EMAIL_VSUP_ALIASES} . "\n";
 
 }
 

--- a/slave/process-vsup-zimbra/bin/process-vsup_zimbra.sh
+++ b/slave/process-vsup-zimbra/bin/process-vsup_zimbra.sh
@@ -2,7 +2,7 @@
 
 # Script for managing users in Zimbra mail server
 
-PROTOCOL_VERSION='3.0.0'
+PROTOCOL_VERSION='3.1.0'
 
 function process {
 

--- a/slave/process-vsup-zimbra/changelog
+++ b/slave/process-vsup-zimbra/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-vsup-zimbra (3.0.6) stable; urgency=medium
+
+  * Manage also aliases and preferredFrom in Zimbra for each account.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Tue, 09 Jan 2018 07:00:00 +0100
+
 perun-slave-process-vsup-zimbra (3.0.5) stable; urgency=medium
 
   * Fixed setting of zimbraCOSId attribute.

--- a/slave/process-vsup-zimbra/lib/process-vsup_zimbra.pl
+++ b/slave/process-vsup-zimbra/lib/process-vsup_zimbra.pl
@@ -7,11 +7,15 @@ sub createAccount;
 sub updateAccount;
 sub createAccounts;
 sub updateAccounts;
-sub compareAndUpdateAttribute;
+sub compareAndUpdateAttribute($$$);
+sub addAlias;
+sub removeAlias;
+sub setPrefFrom;
+sub resolveAliasChange;
 sub logMessage;
 
-my $perunAccounts;  # $perunAccounts->{login}->{MAILBOX|givenName|sn|displayName|zimbraAccountStatus|zimbraCOSId}=value
-my $zimbraAccounts;  # $zimbraAccounts->{login}->{MAILBOX|givenName|sn|displayName|zimbraAccountStatus|zimbraCOSId}=value
+my $perunAccounts;  # $perunAccounts->{login}->{MAILBOX|givenName|sn|displayName|zimbraAccountStatus|zimbraCOSId|zimbraPrefFromAddress|zimbraMailAlias}=value
+my $zimbraAccounts;  # $zimbraAccounts->{login}->{MAILBOX|givenName|sn|displayName|zimbraAccountStatus|zimbraCOSId|zimbraPrefFromAddress|zimbraMailAlias}=value
 
 # IF SET TO 1, no changes are actually done to Zimbra mail server
 my $dry_run = 0;
@@ -39,6 +43,23 @@ foreach my $line ( @lines ) {
 	$perunAccounts->{$parts[1]}->{'displayName'} = (($parts[6] ne '') ? $parts[6] : undef);
 	$perunAccounts->{$parts[1]}->{'zimbraAccountStatus'} = (($parts[7] ne '') ? $parts[7] : undef);
 	$perunAccounts->{$parts[1]}->{'zimbraCOSId'} = (($parts[8] ne '') ? $parts[8] : undef);
+	$perunAccounts->{$parts[1]}->{'zimbraPrefFromAddress'} = (($parts[9] ne '') ? $parts[9] : undef);
+
+	my $aliases = (($parts[10] ne '') ? $parts[10] : undef);
+	if ($aliases) {
+		my @existing_aliases = split /,/, $aliases;
+		foreach my $alias (@existing_aliases) {
+			$perunAccounts->{$parts[1]}->{'zimbraMailAlias'}->{$alias} = 1;
+		}
+	} else {
+		# no aliases -> set to empty hash ref, so we can safely "sort keys" on it later
+		$perunAccounts->{$parts[1]}->{'zimbraMailAlias'} = {};
+	}
+
+	# put preferred alias between aliases
+	if ($perunAccounts->{$parts[1]}->{'zimbraPrefFromAddress'}) {
+		$perunAccounts->{$parts[1]}->{'zimbraMailAlias'}->{$perunAccounts->{$parts[1]}->{'zimbraPrefFromAddress'}} = 1;
+	}
 
 }
 
@@ -125,6 +146,16 @@ sub getAllAccounts() {
 			$existingAccounts->{$currentLogin}->{"sn"} = $currentName;
 		}
 
+		if ($line =~ m/^zimbraMailAlias: (.*)$/) {
+			my $currentAlias = ($line =~ m/^zimbraMailAlias: (.*)$/)[0];
+			$existingAccounts->{$currentLogin}->{"zimbraMailAlias"}->{$currentAlias} = 1;
+		}
+
+		if ($line =~ m/^zimbraPrefFromAddress: (.*)$/) {
+			my $currentPrefFrom = ($line =~ m/^zimbraPrefFromAddress: (.*)$/)[0];
+			$existingAccounts->{$currentLogin}->{"zimbraPrefFromAddress"} = $currentPrefFrom;
+		}
+
 	}
 
 	return $existingAccounts;
@@ -158,8 +189,12 @@ sub createAccounts() {
 					print $perunAccounts->{$login}->{"MAILBOX"} . " would be created.\n";
 					logMessage($perunAccounts->{$login}->{"MAILBOX"} . " would be created.");
 				} else {
+					# create account
 					createAccount($perunAccounts->{$login});
 				}
+
+				# has dry-run inside
+				resolveAliasChange($perunAccounts->{$login}, undef);
 
 			} else {
 
@@ -199,6 +234,8 @@ sub updateAccounts() {
 			compareAndUpdateAttribute($perunAccounts->{$login}, $zimbraAccounts->{$login}, "displayName");
 			compareAndUpdateAttribute($perunAccounts->{$login}, $zimbraAccounts->{$login}, "zimbraAccountStatus");
 
+			resolveAliasChange($perunAccounts->{$login}, $zimbraAccounts->{$login});
+
 		} else {
 
 			# is missing from perun but present in zimbra => 'closed', in future delete !!
@@ -222,8 +259,9 @@ sub updateAccounts() {
 				logMessage($zimbraAccounts->{$login}->{"MAILBOX"}." already is closed - skipped.");
 			}
 
-		}
+			resolveAliasChange(undef, $zimbraAccounts->{$login});
 
+		}
 	}
 
 }
@@ -236,7 +274,7 @@ sub updateAccounts() {
 # 2. param: hash reference of zimbra account
 # 3. param: name of attribute
 #
-sub compareAndUpdateAttribute() {
+sub compareAndUpdateAttribute($$$) {
 
 	my $perunAccount = shift;
 	my $zimbraAccount = shift;
@@ -261,6 +299,137 @@ sub compareAndUpdateAttribute() {
 				print $perunAccount->{"MAILBOX"} . " $attrName updated '$zimbraAttr'=>'$perunAttr'.\n";
 				logMessage($perunAccount->{"MAILBOX"} . " $attrName updated '$zimbraAttr'=>'$perunAttr'.\n");
 			}
+		}
+	}
+
+}
+
+#
+# Compare Zimbra account aliases and prefFrom attributes between Zimbra and Perun version
+# and perform update if necessary
+#
+# 1. param: hash reference of perun account
+# 2. param: hash reference of zimbra account
+#
+sub resolveAliasChange() {
+
+	my $perunAccount = shift;
+	my $zimbraAccount = shift;
+
+	if (!$perunAccount && $zimbraAccount) {
+
+		# CLOSING/DELETING ZIMBRA ACCOUNT -> remove preferred from and aliases
+
+		# 1. unset preferred from address
+		my $zimbraAttr = $zimbraAccount->{'zimbraPrefFromAddress'};
+		my $zimbraAliases = ($zimbraAccount->{'zimbraMailAlias'}) ? $zimbraAccount->{'zimbraMailAlias'} : {};
+
+		if ($zimbraAttr) {
+			# only if previously preferred mail was set
+			if ($dry_run) {
+				print $zimbraAccount->{"MAILBOX"} . " 'zimbraPrefFromAddress' would be updated '$zimbraAttr'=>''.\n";
+				logMessage($zimbraAccount->{"MAILBOX"} . " 'zimbraPrefFromAddress' would be updated '$zimbraAttr'=>''.");
+			} else {
+				# set preferred from to '' (aka empty it)
+				my $ret = updateAccount($zimbraAccount->{"MAILBOX"}, 'zimbraPrefFromAddress', '');
+				if ($ret != 0) {
+					print "ERROR: " . $zimbraAccount->{"MAILBOX"} . " update of 'zimbraPrefFromAddress' failed.\n";
+					logMessage("ERROR: " . $zimbraAccount->{"MAILBOX"} . " update of 'zimbraPrefFromAddress' failed, ret.code: " . $ret);
+				} else {
+					print $zimbraAccount->{"MAILBOX"} . " 'zimbraPrefFromAddress' updated '$zimbraAttr'=>''.\n";
+					logMessage($zimbraAccount->{"MAILBOX"} . " 'zimbraPrefFromAddress' updated '$zimbraAttr'=>''.\n");
+				}
+			}
+		}
+
+		# 2. remove non-existing aliases
+		foreach my $zimbraAlias (sort keys %{$zimbraAliases}) {
+			if ($dry_run) {
+				print $zimbraAccount->{"MAILBOX"} . " alias would be removed '$zimbraAlias'.\n";
+				logMessage($zimbraAccount->{"MAILBOX"} . " alias would be removed '$zimbraAlias'.");
+			} else {
+				removeAlias($zimbraAccount->{"MAILBOX"}, $zimbraAlias);
+			}
+		}
+
+	} elsif ($perunAccount && $zimbraAccount) {
+
+		# UPDATE ZIMBRA ACCOUNT -> add and remove aliases, set preferred
+
+		my $perunAliases = $perunAccount->{"zimbraMailAlias"}; # set to empty hash ref from perun if empty, so it's safe
+		my $zimbraAliases = ($zimbraAccount->{"zimbraMailAlias"}) ? $zimbraAccount->{"zimbraMailAlias"} : {};
+
+		# 1. add missing aliases
+		my @to_be_added;
+		foreach my $perunAlias (sort keys %{$perunAliases}) {
+			unless (exists $zimbraAliases->{$perunAlias}) {
+				push (@to_be_added, $perunAlias);
+			}
+		}
+
+		foreach my $perunAlias (@to_be_added) {
+			if ($dry_run) {
+				print $perunAccount->{"MAILBOX"} . " alias would be added '$perunAlias'.\n";
+				logMessage($perunAccount->{"MAILBOX"} . " alias would be added '$perunAlias'.");
+			} else {
+				addAlias($perunAccount->{"MAILBOX"}, $perunAlias);
+			}
+		}
+
+		# 2. set preferred from address (usually one of aliases)
+		compareAndUpdateAttribute($perunAccount, $zimbraAccount, "zimbraPrefFromAddress");
+
+		# 3. remove non-existing aliases
+		my @to_be_removed;
+		foreach my $zimbraAlias (sort keys %{$zimbraAliases}) {
+			unless (exists $perunAliases->{$zimbraAlias}) {
+				push (@to_be_removed, $zimbraAlias);
+			}
+		}
+
+		foreach my $zimbraAlias (@to_be_removed) {
+			if ($dry_run) {
+				print $perunAccount->{"MAILBOX"} . " alias would be removed '$zimbraAlias'.\n";
+				logMessage($perunAccount->{"MAILBOX"} . " alias would be removed '$zimbraAlias'.");
+			} else {
+				removeAlias($perunAccount->{"MAILBOX"}, $zimbraAlias);
+			}
+		}
+
+	} elsif ($perunAccount && !$zimbraAccount) {
+
+		# CREATE/ENABLE ZIMBRA ACCOUNT
+
+		my $perunAliases = $perunAccount->{"zimbraMailAlias"};
+		my $perunAttr = $perunAccount->{'zimbraPrefFromAddress'};
+
+		# 1. add missing aliases
+		foreach my $perunAlias (sort keys %{$perunAliases}) {
+			if ($dry_run) {
+				print $perunAccount->{"MAILBOX"} . " alias would be added '$perunAlias'.\n";
+				logMessage($perunAccount->{"MAILBOX"} . " alias would be added '$perunAlias'.");
+			} else {
+				addAlias($perunAccount->{"MAILBOX"}, $perunAlias);
+			}
+		}
+
+		# 2. set preferred from address (usually one of aliases) and only if exists
+		if ($perunAttr) {
+			if ($dry_run) {
+				print $perunAccount->{"MAILBOX"} . " 'zimbraPrefFromAddress' would be updated '$perunAttr'=>''.\n";
+				logMessage($perunAccount->{"MAILBOX"} . " 'zimbraPrefFromAddress' would be updated '$perunAttr'=>''.");
+			} else {
+				# user original value in update call
+				my $ret = updateAccount($perunAccount->{"MAILBOX"}, 'zimbraPrefFromAddress', $perunAttr);
+				if ($ret != 0) {
+					print "ERROR: " . $perunAccount->{"MAILBOX"} . " update of 'zimbraPrefFromAddress' failed.\n";
+					logMessage("ERROR: " . $perunAccount->{"MAILBOX"} . " update of 'zimbraPrefFromAddress' failed, ret.code: " . $ret);
+				} else {
+					print $perunAccount->{"MAILBOX"} . " 'zimbraPrefFromAddress' updated '$perunAttr'=>''.\n";
+					logMessage($perunAccount->{"MAILBOX"} . " 'zimbraPrefFromAddress' updated '$perunAttr'=>''.\n");
+				}
+			}
+
 		}
 	}
 
@@ -311,6 +480,66 @@ sub updateAccount() {
 	# only for logging verbose output
 	if ($ret != 0) {
 		logMessage("ERROR: $account attribute $attrName not updated, ret.code: $ret, output: $output.");
+	}
+
+	return $ret;
+
+}
+
+#
+# Add alias to Zimbra account
+#
+# 1. param: name of Zimbra account to update (mail)
+# 2. param: value of alias to be added
+#
+# Return: return code of zmprov command
+#
+sub addAlias() {
+
+	my $account = shift;
+	my $alias = shift;
+
+	my $output = `sudo /opt/zimbra/bin/zmprov aaa '$account' '$alias'`;
+	my $ret = $?; # get ret.code of backticks command
+	$ret = ($ret >> 8); # shift 8 bits to get original return code
+
+	# only for logging verbose output
+	if ($ret != 0) {
+		print "ERROR: $account alias $alias not added.\n";
+		logMessage("ERROR: $account alias $alias not added, ret.code: $ret, output: $output.");
+	} else {
+		print "$account alias $alias added.\n";
+		logMessage("$account alias $alias added, ret.code: $ret, output: $output.");
+	}
+
+	return $ret;
+
+}
+
+#
+# Remove alias from Zimbra account
+#
+# 1. param: name of Zimbra account to update (mail)
+# 2. param: value of alias to be removed
+#
+# Return: return code of zmprov command
+#
+sub removeAlias() {
+
+	my $account = shift;
+	my $alias = shift;
+
+	my $output = `sudo /opt/zimbra/bin/zmprov raa '$account' '$alias'`;
+	my $ret = $?; # get ret.code of backticks command
+	$ret = ($ret >> 8); # shift 8 bits to get original return code
+
+	# only for logging verbose output
+	if ($ret != 0) {
+		print "ERROR: $account alias $alias not removed.\n";
+		logMessage("ERROR: $account alias $alias not removed, ret.code: $ret, output: $output.");
+	} else {
+		print "$account alias $alias removed.\n";
+		logMessage("$account alias $alias removed, ret.code: $ret, output: $output.");
 	}
 
 	return $ret;


### PR DESCRIPTION
- Get also aliases and preferredFrom from Perun while generating data.
  It's independent from this service (generated and checked by
  vsup_zimbra_aliases).
- Manage aliases for new and active accounts, if present,
  set preferredFrom and for closed accounts remove all aliases.