### PR TITLE
Convert undef input to empty string in vsup_zimbra

### DIFF
--- a/slave/process-vsup-zimbra/changelog
+++ b/slave/process-vsup-zimbra/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-vsup-zimbra (3.0.7) stable; urgency=low
+
+  * Sanitize value input for manageAccount() function.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 11 Jan 2018 13:00:00 +0100
+
 perun-slave-process-vsup-zimbra (3.0.6) stable; urgency=medium
 
   * Manage also aliases and preferredFrom in Zimbra for each account.

--- a/slave/process-vsup-zimbra/lib/process-vsup_zimbra.pl
+++ b/slave/process-vsup-zimbra/lib/process-vsup_zimbra.pl
@@ -471,7 +471,7 @@ sub updateAccount() {
 
 	my $account = shift;
 	my $attrName = shift;
-	my $value = shift;
+	my $value = shift || '';
 
 	my $output = `sudo /opt/zimbra/bin/zmprov ma '$account' $attrName '$value'`;
 	my $ret = $?; # get ret.code of backticks command


### PR DESCRIPTION
- When calling manage account function, convert undef $value
  to empty string to prevent warnings.