### PR TITLE
Use more gid ranges instead of one defined by min and max gid

### DIFF
--- a/gen/group
+++ b/gen/group
@@ -17,7 +17,7 @@ sub processMembersData;
 sub processResourceData;
 
 our $SERVICE_NAME = "group";
-our $PROTOCOL_VERSION = "3.1.0";
+our $PROTOCOL_VERSION = "3.2.0";
 my $SCRIPT_VERSION = "3.1.2";
 
 perunServicesInit::init;
@@ -34,8 +34,7 @@ our $A_USER_STATUS;                      *A_USER_STATUS =                      \
 our $A_GROUP_IS_SYSTEM_UNIX_GROUP;       *A_GROUP_IS_SYSTEM_UNIX_GROUP =       \'urn:perun:group_resource:attribute-def:def:isSystemUnixGroup';
 our $A_GROUP_SYSTEM_UNIX_GID_SYSTEM;     *A_GROUP_SYSTEM_UNIX_GID_SYSTEM =     \'urn:perun:group_resource:attribute-def:def:systemUnixGID';
 our $A_GROUP_SYSTEM_UNIX_GROUP_NAME;     *A_GROUP_SYSTEM_UNIX_GROUP_NAME =     \'urn:perun:group_resource:attribute-def:def:systemUnixGroupName';
-our $A_FACILITY_MIN_GID;                 *A_FACILITY_MIN_GID =                 \'urn:perun:facility:attribute-def:virt:minGID';
-our $A_FACILITY_MAX_GID;                 *A_FACILITY_MAX_GID =                 \'urn:perun:facility:attribute-def:virt:maxGID';
+our $A_FACILITY_GID_RANGES;              *A_FACILITY_GID_RANGES =              \'urn:perun:facility:attribute-def:virt:GIDRanges';
 our $A_FACILITY_EXCLUDE_NON_VALID_USERS; *A_FACILITY_EXCLUDE_NON_VALID_USERS = \'urn:perun:facility:attribute-def:def:excludeNonValidUsersFromUnixGroups';
 
 our $STATUS_VALID;											*STATUS_VALID =												\'VALID';
@@ -60,17 +59,17 @@ foreach my $resourceData ($data->getChildElements) {
 }
 
 my $group_file_name = "$DIRECTORY/$::SERVICE_NAME";
-my $min_gid_file_name = "$DIRECTORY/min_gid";
-my $max_gid_file_name = "$DIRECTORY/max_gid";
+my $gid_ranges_file_name = "$DIRECTORY/gid_ranges";
 
 open FILE,">$group_file_name" or die "Cannot open $group_file_name: $! \n";
-open MIN_GID,">$min_gid_file_name" or die "Cannot open $min_gid_file_name: $! \n";
-open MAX_GID,">$max_gid_file_name" or die "Cannot open $max_gid_file_name: $! \n";
+open GID_RANGES,">$gid_ranges_file_name" or die "Cannot open $gid_ranges_file_name\n";
 
-print MIN_GID $facilityAttributes{$A_FACILITY_MIN_GID}, "\n";
-print MAX_GID $facilityAttributes{$A_FACILITY_MAX_GID}, "\n";
-close MIN_GID;
-close MAX_GID;
+my %gidRanges = %{$facilityAttributes{$A_FACILITY_GID_RANGES}};
+foreach my $minimum (sort { $a <=> $b } keys  %gidRanges) {
+	my $maximum = $gidRanges{$minimum};
+	print GID_RANGES $minimum . "-" . $maximum . "\n";
+}
+close(GID_RANGES) or die "Cannot close $gid_ranges_file_name: $! \n";
 
 local $" = ',';
 foreach my $groupName (sort keys %$groupStruc) {

--- a/gen/group_mu
+++ b/gen/group_mu
@@ -17,7 +17,7 @@ sub processMembersData;
 sub processResourceData;
 
 our $SERVICE_NAME = "group_mu";
-our $PROTOCOL_VERSION = "3.0.0";
+our $PROTOCOL_VERSION = "3.1.0";
 my $SCRIPT_VERSION = "3.0.0";
 
 perunServicesInit::init;
@@ -35,8 +35,7 @@ our $A_USER_OPTIONAL_LOGIN;              *A_USER_OPTIONAL_LOGIN =              \
 our $A_GROUP_IS_SYSTEM_UNIX_GROUP;       *A_GROUP_IS_SYSTEM_UNIX_GROUP =       \'urn:perun:group_resource:attribute-def:def:isSystemUnixGroup';
 our $A_GROUP_SYSTEM_UNIX_GID_SYSTEM;     *A_GROUP_SYSTEM_UNIX_GID_SYSTEM =     \'urn:perun:group_resource:attribute-def:def:systemUnixGID';
 our $A_GROUP_SYSTEM_UNIX_GROUP_NAME;     *A_GROUP_SYSTEM_UNIX_GROUP_NAME =     \'urn:perun:group_resource:attribute-def:def:systemUnixGroupName';
-our $A_FACILITY_MIN_GID;                 *A_FACILITY_MIN_GID =                 \'urn:perun:facility:attribute-def:virt:minGID';
-our $A_FACILITY_MAX_GID;                 *A_FACILITY_MAX_GID =                 \'urn:perun:facility:attribute-def:virt:maxGID';
+our $A_FACILITY_GID_RANGES;              *A_FACILITY_GID_RANGES =              \'urn:perun:facility:attribute-def:virt:GIDRanges';
 our $A_FACILITY_EXCLUDE_NON_VALID_USERS; *A_FACILITY_EXCLUDE_NON_VALID_USERS = \'urn:perun:facility:attribute-def:def:excludeNonValidUsersFromUnixGroups';
 
 our $STATUS_VALID;											*STATUS_VALID =												\'VALID';
@@ -61,17 +60,17 @@ foreach my $resourceData ($data->getChildElements) {
 }
 
 my $group_file_name = "$DIRECTORY/group";
-my $min_gid_file_name = "$DIRECTORY/min_gid";
-my $max_gid_file_name = "$DIRECTORY/max_gid";
+my $gid_ranges_file_name = "$DIRECTORY/gid_ranges";
 
 open FILE,">$group_file_name" or die "Cannot open $group_file_name: $! \n";
-open MIN_GID,">$min_gid_file_name" or die "Cannot open $min_gid_file_name: $! \n";
-open MAX_GID,">$max_gid_file_name" or die "Cannot open $max_gid_file_name: $! \n";
+open GID_RANGES,">$gid_ranges_file_name" or die "Cannot open $gid_ranges_file_name\n";
 
-print MIN_GID $facilityAttributes{$A_FACILITY_MIN_GID}, "\n";
-print MAX_GID $facilityAttributes{$A_FACILITY_MAX_GID}, "\n";
-close MIN_GID;
-close MAX_GID;
+my %gidRanges = %{$facilityAttributes{$A_FACILITY_GID_RANGES}};
+foreach my $minimum (sort { $a <=> $b } keys  %gidRanges) {
+	my $maximum = $gidRanges{$minimum};
+	print GID_RANGES $minimum . "-" . $maximum . "\n";
+}
+close(GID_RANGES) or die "Cannot close $gid_ranges_file_name: $! \n";
 
 local $" = ',';
 foreach my $groupName (sort keys %$groupStruc) {

--- a/gen/group_nfs4
+++ b/gen/group_nfs4
@@ -11,7 +11,7 @@ sub processMembersData;
 sub processResourceData;
 
 our $SERVICE_NAME = "group_nfs4";
-our $PROTOCOL_VERSION = "3.0.0";
+our $PROTOCOL_VERSION = "3.1.0";
 my $SCRIPT_VERSION = "3.0.4";
 
 perunServicesInit::init;
@@ -25,8 +25,7 @@ our $A_GROUP_UNIX_GROUP_NAME;        *A_GROUP_UNIX_GROUP_NAME =        \'urn:per
 our $A_GROUP_UNIX_GID;               *A_GROUP_UNIX_GID =               \'urn:perun:group_resource:attribute-def:virt:unixGID';
 our $A_MEMBER_KERBEROS_LOGINS;       *A_MEMBER_KERBEROS_LOGINS =       \'urn:perun:user:attribute-def:def:kerberosLogins';
 our $A_MEMBER_STATUS;                *A_MEMBER_STATUS =                \'urn:perun:member:attribute-def:core:status';
-our $A_FACILITY_MIN_GID;             *A_FACILITY_MIN_GID =             \'urn:perun:facility:attribute-def:virt:minGID';
-our $A_FACILITY_MAX_GID;             *A_FACILITY_MAX_GID =             \'urn:perun:facility:attribute-def:virt:maxGID';
+our $A_FACILITY_GID_RANGES;          *A_FACILITY_GID_RANGES =          \'urn:perun:facility:attribute-def:virt:GIDRanges';
 our $A_GROUP_IS_SYSTEM_UNIX_GROUP;   *A_GROUP_IS_SYSTEM_UNIX_GROUP =   \'urn:perun:group_resource:attribute-def:def:isSystemUnixGroup';
 our $A_GROUP_SYSTEM_UNIX_GID_SYSTEM; *A_GROUP_SYSTEM_UNIX_GID_SYSTEM = \'urn:perun:group_resource:attribute-def:def:systemUnixGID';
 our $A_GROUP_SYSTEM_UNIX_GROUP_NAME; *A_GROUP_SYSTEM_UNIX_GROUP_NAME = \'urn:perun:group_resource:attribute-def:def:systemUnixGroupName';
@@ -51,18 +50,19 @@ foreach my $resourceData ($data->getChildElements) {
 }
 
 my $group_file_name = "$DIRECTORY/$::SERVICE_NAME";
-my $min_gid_file_name = "$DIRECTORY/min_gid";
-my $max_gid_file_name = "$DIRECTORY/max_gid";
+my $gid_ranges_file_name = "$DIRECTORY/gid_ranges";
 
 open FILE,">$group_file_name" or die "Cannot open $group_file_name: $! \n";
-open MIN_GID,">$min_gid_file_name" or die "Cannot open $min_gid_file_name: $! \n";
-open MAX_GID,">$max_gid_file_name" or die "Cannot open $max_gid_file_name: $! \n";
+open GID_RANGES,">$gid_ranges_file_name" or die "Cannot open $gid_ranges_file_name\n";
 
 my %facilityAttributes = attributesToHash $data->getAttributes;
-print MIN_GID $facilityAttributes{$A_FACILITY_MIN_GID}, "\n";
-print MAX_GID $facilityAttributes{$A_FACILITY_MAX_GID}, "\n";
-close MIN_GID;
-close MAX_GID;
+
+my %gidRanges = %{$facilityAttributes{$A_FACILITY_GID_RANGES}};
+foreach my $minimum (sort { $a <=> $b } keys  %gidRanges) {
+	my $maximum = $gidRanges{$minimum};
+	print GID_RANGES $minimum . "-" . $maximum . "\n";
+}
+close(GID_RANGES) or die "Cannot close $gid_ranges_file_name: $! \n";
 
 local $" = ',';
 foreach my $groupName (sort keys %$groupStruc) {

--- a/slave/process-group-nfs4/changelog
+++ b/slave/process-group-nfs4/changelog
@@ -1,3 +1,11 @@
+perun-slave-process-group-nfs4 (3.1.4) stable; urgency=high
+
+  * Use more gidRanges instead of one limited by min and max gid.
+  * Major protocol version was increased (this change will not work with 
+   older protocol versions)
+
+ -- Michal Stava <stavamichal@gmail.com>  Wed, 17 Jan 2018 15:31:00 +0100
+
 perun-slave-process-group-nfs4 (3.1.3) stable; urgency=medium
 
   * Generate configuration directory /etc/perun/{service}.d automatically even

--- a/slave/process-group/bin/process-group.sh
+++ b/slave/process-group/bin/process-group.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PROTOCOL_VERSION='3.1.0'
+PROTOCOL_VERSION='3.2.0'
 
 function process {
 	DST_FILE="/etc/group"
@@ -12,8 +12,7 @@ function process {
 	I_NOT_UPDATED=(0 '${OLD_GROUP} has not changed')
 
 	E_GROUP_FILTER=(50 'Error in /etc/group filter')
-	E_GROUP_WRONG_MIN_GID=(51 'Invalid min_gid parameter')
-	E_GROUP_WRONG_MAX_GID=(52 'Invalid max_gid parameter')
+	E_GROUP_WRONG_GID_RANGES=(51 'Cannot read from the gid ranges file: ${GID_RANGES_FILE}')
 	E_GROUP_MERGE=(53 'Error during group file merge')
 	E_GROUP_DUPLICATES=(54 'Group names in group file are not uniq: ${DUPLICATE_GROUP_NAMES}')
 	E_GID_DUPLICATES=(55 'Group GIDs in group file are not uniq: ${DUPLICATE_GROUP_GIDS}')
@@ -26,10 +25,11 @@ function process {
 	PREVIOUSLY_ADDED_USERS='/etc/group.perun-added-system-users'
 	NOW_ADDED_USERS="${WORK_DIR}/group.perun-added-system-users"
 	NEW_GROUP="${WORK_DIR}/group.new" # file must be on same mountpoint for atomic switch
-	MIN_PERUN_GID=`head -n 1 "${WORK_DIR}/min_gid"`
-	MAX_PERUN_GID=`head -n 1 "${WORK_DIR}/max_gid"`
-	[ "${MIN_PERUN_GID}" -gt 0 ] || log_msg E_GROUP_WRONG_MIN_GID
-	[ "${MAX_PERUN_GID}" -gt 0 ] || log_msg E_GROUP_WRONG_MAX_GID
+
+	GID_RANGES_FILE="${WORK_DIR}/gid_ranges"
+	if [ ! -r "${GID_RANGES_FILE}" ]; then
+		log_msg E_GROUP_WRONG_GID_RANGES
+	fi
 
 	create_lock
 
@@ -54,6 +54,29 @@ function process {
 	local $, = ":";
 	local $\ = "\n";
 
+	sub isGIDInAllowedRanges {
+		my $ranges = shift;
+		my $gid = shift;
+		foreach my $minimum (sort { $a <=> $b } keys %$ranges) {
+			my $maximum = $ranges->{$minimum};
+			if($gid >= $minimum && $gid <= $maximum) {
+				return 1;
+			}
+		}
+		return 0;
+	}
+
+	#Export valid gids from file to hash
+	my %validGids;
+	open FILE, "'$GID_RANGES_FILE'" or die "Cannot open '$GID_RANGES_FILE': $! \n";
+	while (my $row = <FILE>) {
+		chomp $row;
+		my @parts = split "-", $row;
+		my $minimum =  $parts[0];
+		my $maximum =  $parts[1];
+		$validGids{$minimum} = $maximum;
+	}
+	close(FILE) or die "Cannot close '$GID_RANGES_FILE': $! \n";
 
 	my %groups;
 	my %gids;
@@ -62,7 +85,7 @@ function process {
 		chomp;
 		next unless $_; #skip empty lines
 		my ($group, $password, $gid, $users) = split ":";
-		next unless ($gid < '$MIN_PERUN_GID' || $gid > '$MAX_PERUN_GID');
+		next if isGIDInAllowedRanges(\%validGids, $gid);
 		my %users = map {$_ => 1 }  split ",", $users;
 		if(defined $groups{$group}) { die "Duplicate group name: $group\n"; }
 		if(defined $gids{$gid}) { die "Duplicate group GID: $gid\n"; }
@@ -107,7 +130,8 @@ function process {
 			                   users => \%users
 			                  };
 			$gids{$gid} = 1;
-			if ($gid < '$MIN_PERUN_GID' || $gid > '$MAX_PERUN_GID') {
+
+			unless ( isGIDInAllowedRanges(\%validGids, $gid) ) {
 				my @addUsers = keys %users;
 				print NOW_ADDED $group, $password, $gid, "@addUsers";
 			}

--- a/slave/process-group/changelog
+++ b/slave/process-group/changelog
@@ -1,3 +1,11 @@
+perun-slave-process-group (3.1.4) stable; urgency=high
+
+  * Use more gidRanges instead of one limited by min and max gid.
+  * Major protocol version was increased (this change will not work with 
+    older protocol versions)
+
+ -- Michal Stava <stavamichal@gmail.com>  Wed, 17 Jan 2018 15:31:00 +0100
+
 perun-slave-process-group (3.1.3) stable; urgency=medium
 
   * Generate configuration directory /etc/perun/{service}.d automatically even


### PR DESCRIPTION
 - new attribute for list of gid ranges used in all group* services
 - change behavior in gen scripts (preparing of file with ranges) and
   also in slave scripts (processing new files)