### PR TITLE
Extend valid regex of destination for o365_mu service

### DIFF
--- a/send/o365_mu
+++ b/send/o365_mu
@@ -12,7 +12,7 @@ if [ -z "$DESTINATION" ]; then
 	echo "Missing Destination argument (Name of instance there)" >&2
 	exit 258
 else
-	if echo "$DESTINATION" | grep "[^A-Za-z_0-9-]"; then
+	if echo "$DESTINATION" | grep "[^.A-Za-z_0-9-]"; then
 		echo "Bad fromat of destination!" >&2
 		exit 257
 	fi


### PR DESCRIPTION
 - we want to add also character '.' to valid regular exrepssion for
   name of destination