### PR TITLE
Fix protocol version and exec script name for voms service

### DIFF
--- a/slave/process-voms-dirac/changelog
+++ b/slave/process-voms-dirac/changelog
@@ -3,7 +3,7 @@ perun-slave-process-voms-dirac (1.0.4) stable; urgency=high
   * fix of typo in the name of process-voms slave script file, because of this
     typo slave of voms_dirac service did not work and always ended with error
 
- -- Michal Stava <stavamichal@gmail.com>  Tue, 30 Jan 2017 16:16:00 +0100
+ -- Michal Stava <stavamichal@gmail.com>  Tue, 30 Jan 2018 16:16:00 +0100
 
 perun-slave-process-voms-dirac (1.0.3) stable; urgency=low
 

--- a/slave/process-voms/bin/process-voms.sh
+++ b/slave/process-voms/bin/process-voms.sh
@@ -2,11 +2,11 @@
 
 # Script for managing user membership in VOs
 
-PROTOCOL_VERSION='3.1.0'
+PROTOCOL_VERSION='3.1.1'
 
 function process {
 
-	EXECSCRIPT="${LIB_DIR}/${SERVICE}/process-voms.pl"
+	EXECSCRIPT="${LIB_DIR}/voms/process-voms.pl"
 
 	create_lock
 

--- a/slave/process-voms/changelog
+++ b/slave/process-voms/changelog
@@ -1,3 +1,14 @@
+perun-slave-process-voms (3.1.10) stable; urgency=high
+
+  * change path for exec script to be manually set on "voms", because the value
+    in the variable $SERVICE can be set to different value if "voms_dirac"
+    service has been called and executing script then can't be found.
+  * set correct protocol version (was forgotten to increase it) in voms slave 
+    script to 3.1.1. This is just a minor difference in protocol version is 
+    it has no impact on script behavior. 
+
+ -- Michal Stava <stavamichal@gmail.com>  Tue, 30 Jan 2018 17:12:00 +0100
+
 perun-slave-process-voms (3.1.9) stable; urgency=low
 
   * service process-voms now can work with attributes in LDAP same as


### PR DESCRIPTION
- protocol version should be same for voms and voms_dirac now (was forgotten to increase it)
- exec script for voms need to be set manually, because voms_dirac use variable $SERVICE with value "voms_dirac" instead of "voms"