### PR TITLE
Modify service o365_mu

### DIFF
--- a/gen/o365_mu
+++ b/gen/o365_mu
@@ -22,6 +22,7 @@ my $data      = perunServicesInit::getDataWithGroups;
 our $A_GR_AD_NAME;                *A_GR_AD_NAME =                \'urn:perun:group_resource:attribute-def:def:adName';
 our $A_F_DOMAIN_NAME;             *A_F_DOMAIN_NAME =             \'urn:perun:facility:attribute-def:def:o365DomainName';
 our $A_MR_O365_SEND_AS;           *A_MR_O365_SEND_AS =           \'urn:perun:member_group:attribute-def:def:o365SendAs';
+our $A_UF_DISABLE_MAIL_FORWARD;   *A_UF_DISABLE_MAIL_FORWARD =   \'urn:perun:user_facility:attribute-def:def:disableO365MailForward';
 our $A_UF_LOGIN;                  *A_UF_LOGIN =                  \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_UF_O365_MAIL_FORWARD;      *A_UF_O365_MAIL_FORWARD =      \'urn:perun:user_facility:attribute-def:def:o365MailForward';
 our $A_UF_O365_ARCHIVE;           *A_UF_O365_ARCHIVE =           \'urn:perun:user_facility:attribute-def:def:o365MailInPlaceArchive';
@@ -33,6 +34,9 @@ our $UPN_TEXT = "UPN";
 our $MAIL_FORWARD_TEXT = "mailForward";
 our $ARCHIVE_TEXT = "archive";
 our $STORE_AND_FORWARD_TEXT = "storeAndForward";
+
+#Default forwarding domain for MU
+our $DEFAULT_FORWARDING_DOMAIN = '@mo.muni.cz';
 
 #Global data structure
 our $users = {};
@@ -135,7 +139,18 @@ sub processMember {
 	my %memberAttributes = attributesToHash $memberData->getAttributes;
 
 	my $UCO = $memberAttributes{$A_UF_LOGIN};
-	my $mailForward = $memberAttributes{$A_UF_O365_MAIL_FORWARD};
+
+	my $disableForward = $memberAttributes{$A_UF_DISABLE_MAIL_FORWARD};
+	my $mailForward;
+	#If forwarding is disabled, return empty value for mail forward
+	unless($disableForward) {
+		#if mail for forwarding is not empty, use its value, in other case use default value
+		if($mailForward) {
+			$mailForward = $memberAttributes{$A_UF_O365_MAIL_FORWARD};
+		} else {
+			$mailForward = $UCO . $DEFAULT_FORWARDING_DOMAIN;
+		}
+	}
 	my $archive = $memberAttributes{$A_UF_O365_ARCHIVE};
 	my $storeAndForward = $memberAttributes{$A_UF_O365_STORE_AND_FORWARD};
 


### PR DESCRIPTION
 - change in gen script, for forwarding is now used default address
 if forwarding email is empty. If disable for forwarding is set, then
 we will use empty value for forwarding.