### PR TITLE
New slave script for service o365_contacts_export

### DIFF
--- a/slave/process-o365-contacts-export/bin/process-o365_contacts_export.sh
+++ b/slave/process-o365-contacts-export/bin/process-o365_contacts_export.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+PROTOCOL_VERSION='3.0.0'
+
+function process {
+	FROM_PERUN="${WORK_DIR}/o365_contacts_export"
+	
+	#Target export file can be changed in pre-script
+	if [ ! "${TARGET_EXPORT}" ]; then
+		TARGET_EXPORT="~/data/o365_emails.mu"
+	fi
+
+	#Target script which can managed export file from perun can be changed in pre-script
+	if [ ! "${TARGET_SCRIPT}" ]; then
+		TARGET_SCRIPT="~/send_to_inet.sh"
+	fi
+
+	if [ ! "${TARGET_SCRIPT_OPTIONS}" ]; then
+		TARGET_SCRIPT_OPTIONS="o365_emails.mu"
+	fi
+
+	TARGET_COMMAND="${TARGET_SCRIPT} ${TARGET_SCRIPT_OPTIONS} ${TARGET_EXPORT}"
+
+	### Status codes
+	I_EXPORT_PROCESSED=(0 "Export file ${FROM_PERUN} was processed correctly!")
+	E_CANNOT_COPY_EXPORT_FILE=(50 "Cannot copy file from perun ${FROM_PERUN} to target location ${TARGET_EXPORT}!")
+	E_TARGET_SCRIPTS_ERROR=(51 "Target script ${TARGET_SCRIPT} ended with error for command: '${TARGET_COMMAND}'!")
+
+	create_lock
+	
+	catch_error E_CANNOT_COPY_EXPORT_FILE cp ${FROM_PERUN} ${TARGET_EXPORT}
+
+	catch_error E_TARGET_SCRIPTS_ERROR ${TARGET_COMMAND}
+
+	log_msg I_EXPORT_PROCESSED
+}

--- a/slave/process-o365-contacts-export/changelog
+++ b/slave/process-o365-contacts-export/changelog
@@ -1,0 +1,5 @@
+perun-slave-process-o365-contacts-export (3.0.0) stable; urgency=low
+
+  * Package for exporting Perun managed o365 emails
+
+ -- Michal Stava <stavamichal@gmail.com>  Tue, 27 Feb 2018 10:07:00 +0100

--- a/slave/process-o365-contacts-export/dependencies
+++ b/slave/process-o365-contacts-export/dependencies
@@ -1,0 +1,1 @@
+perun-slave-base

--- a/slave/process-o365-contacts-export/rpm.dependencies
+++ b/slave/process-o365-contacts-export/rpm.dependencies
@@ -1,0 +1,1 @@
+perun-slave-base

--- a/slave/process-o365-contacts-export/short_desc
+++ b/slave/process-o365-contacts-export/short_desc
@@ -1,0 +1,1 @@
+Package for exporting Perun managed o365 emails


### PR DESCRIPTION
 - this new service process file with exported emails, copies it to
   the expected destination (can be changed by pre-scripts) and then
   executes expected command (also can be changed by pre-scripts) for
   this new file. If command fails, this slave script also fails but
   with it's own error code (does not preserve error code from the target
   script).