### PR TITLE
Fix locking mechanism for o365_mu and tinia services

### DIFF
--- a/send/o365_mu
+++ b/send/o365_mu
@@ -58,7 +58,7 @@ function create_lock {
 		fi
 	else
 		# lock file exists, check for existence of concurrent process
-		if ps | grep "$SERVICE_NAME" | sed 's/^\([0-9]\+\).*/\1/' | grep "\(^\| \)`cat $LOCK_PIDFILE`\( \|$\)"; then
+		if ps ax | grep "$SERVICE_NAME" | sed 's/^\([0-9]\+\).*/\1/' | grep "\(^\| \)`cat $LOCK_PIDFILE`\( \|$\)"; then
 		# concurrent process is running - this skript must terminate
 			echo "Concuret process $SERVICE_NAME is running" >&2
 			exit 249

--- a/send/tinia
+++ b/send/tinia
@@ -51,7 +51,7 @@ function create_lock {
 		fi
 	else
 		# lock file exists, check for existence of concurrent process
-		if ps | grep "$SERVICE_NAME" | sed 's/^\([0-9]\+\).*/\1/' | grep "\(^\| \)`cat $LOCK_PIDFILE`\( \|$\)"; then
+		if ps ax | grep "$SERVICE_NAME" | sed 's/^\([0-9]\+\).*/\1/' | grep "\(^\| \)`cat $LOCK_PIDFILE`\( \|$\)"; then
 		# concurrent process is running - this skript must terminate
 			echo "Concuret process tinia_process is running" >&2
 			exit 249


### PR DESCRIPTION
 - both services are using similar mechanism and they are trying to find
   running process with saved pid in the lock. If they not found such
   running process, they know that lock can be removed and created
   again. In other case they will end with error
 - but we need to use "ps" with option "a" to see all running processes
   there or we can just miss the process we are looking for