### PR TITLE
Use colon instead of dot for chown operation

### DIFF
--- a/slave/process-fs-home/bin/process-fs_home.sh
+++ b/slave/process-fs-home/bin/process-fs_home.sh
@@ -35,7 +35,7 @@ function process {
 			QUOTA_ENABLED=0
 		fi
 	fi
-	
+
 	if [ "${QUOTA_ENABLED}" -gt 0 ]; then
 		if [ ! -z "${SET_QUOTA_PROGRAM}" ]; then
 			if [ -x "${SET_QUOTA_PROGRAM}" ]; then
@@ -74,7 +74,7 @@ function process {
 	while IFS=`echo -e "\t"` read U_HOME_MNT_POINT U_LOGNAME U_UID U_GID SOFT_QUOTA_DATA HARD_QUOTA_DATA SOFT_QUOTA_FILES HARD_QUOTA_FILES USER_STATUS USER_GROUPS REST_OF_LINE; do
 		HOME_DIR="${U_HOME_MNT_POINT}/${U_LOGNAME}"
 		TMP_DIR=`mktemp -d --tmpdir="${U_HOME_MNT_POINT}" "tmp-perun-fs_home-${U_LOGNAME}.XXXX"`
-		if [ "$?" -ne 0 ]; then 
+		if [ "$?" -ne 0 ]; then
 			log_msg  E_CANNOT_CREATE_TEMP
 		fi
 		#set this temp directory for remove when script ends (if still exists)
@@ -91,7 +91,7 @@ function process {
 				catch_error E_CANNOT_CREATE_TMP_HOME_DIR mkdir "$TMP_HOME_DIR"
 			fi
 
-			catch_error E_CANNOT_SET_OWNERSHIP chown -R "${U_UID}"."${U_GID}" "${TMP_HOME_DIR}"
+			catch_error E_CANNOT_SET_OWNERSHIP chown -R "${U_UID}":"${U_GID}" "${TMP_HOME_DIR}"
 			catch_error E_CANNOT_SET_PERMISSIONS chmod "$UMASK" "${TMP_HOME_DIR}"
 
 			catch_error E_CANNOT_MOVE_TEMP mv "${TMP_HOME_DIR}" "${HOME_DIR}"

--- a/slave/process-fs-home/changelog
+++ b/slave/process-fs-home/changelog
@@ -1,9 +1,16 @@
+perun-slave-process-fs-home (3.1.6) stable; urgency=medium
+
+  * Use colon instead of dot when performing chown
+    as coreutils suggests.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Mon, 9 Apr 2018 10:20:00 +0100
+
 perun-slave-process-fs-home (3.1.5) stable; urgency=high
 
   * When creating home from skeletal directory, there was a problem with wrong
     behavior of 'cp -r' command. When temporary directory was already created,
     it copied not only files from skel dir, but the whole skel dir to the new
-    home directory. Now it creates new directory from the skel dir if such 
+    home directory. Now it creates new directory from the skel dir if such
     exists and also preserve all ACLs and links there.
 
  -- Michal Stava <stavamichal@gmail.com>  Wed, 06 Dec 2017 08:55:00 +0100

--- a/slave/process-fs-scratch-local/bin/process-fs_scratch_local.sh
+++ b/slave/process-fs-scratch-local/bin/process-fs_scratch_local.sh
@@ -34,7 +34,7 @@ function process {
 		if [ ! -d "${SCRATCH_MOUNTPOINT}/${LOGIN}" ]; then
 			catch_error E_CANNOT_CREATE_DIR  mkdir "${SCRATCH_MOUNTPOINT}/${LOGIN}"
 
-			catch_error E_CANNOT_SET_OWNERSHIP chown "${U_UID}"."${U_GID}" "${SCRATCH_MOUNTPOINT}/${LOGIN}"
+			catch_error E_CANNOT_SET_OWNERSHIP chown "${U_UID}":"${U_GID}" "${SCRATCH_MOUNTPOINT}/${LOGIN}"
 			catch_error E_CANNOT_SET_PERMISSIONS chmod "${UMASK}" "${SCRATCH_MOUNTPOINT}/${LOGIN}"
 
 			# Set quota

--- a/slave/process-fs-scratch-local/changelog
+++ b/slave/process-fs-scratch-local/changelog
@@ -1,3 +1,10 @@
+perun-slave-process-fs-scratch-local (3.1.4) stable; urgency=medium
+
+  * Use colon instead of dot when performing chown
+    as coreutils suggests.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Mon, 9 Apr 2018 10:20:00 +0100
+
 perun-slave-process-fs-scratch-local (3.1.3) stable; urgency=medium
 
   * Change service name in /etc/perun/{service}.d/ to match real service

--- a/slave/process-fs-scratch/bin/process-fs_scratch.sh
+++ b/slave/process-fs-scratch/bin/process-fs_scratch.sh
@@ -45,7 +45,7 @@ function process {
 		if [ ! -d "${SCRATCH_DIR}" ]; then
 
 			catch_error E_CANNOT_CREATE_DIR mkdir "${SCRATCH_DIR}"
-			catch_error E_CANNOT_SET_OWNERSHIP chown "${U_UID}"."${U_GID}" "${SCRATCH_DIR}"
+			catch_error E_CANNOT_SET_OWNERSHIP chown "${U_UID}":"${U_GID}" "${SCRATCH_DIR}"
 			catch_error E_CANNOT_SET_PERMISSIONS chmod "$UMASK" "${SCRATCH_DIR}"
 
 			log_msg I_DIR_CREATED

--- a/slave/process-fs-scratch/changelog
+++ b/slave/process-fs-scratch/changelog
@@ -1,3 +1,10 @@
+perun-slave-process-fs-scratch (3.1.4) stable; urgency=medium
+
+  * Use colon instead of dot when performing chown
+    as coreutils suggests.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Mon, 9 Apr 2018 10:20:00 +0100
+
 perun-slave-process-fs-scratch (3.1.3) stable; urgency=medium
 
   * Change service name in /etc/perun/{service}.d/ to match real service

--- a/slave/process-k5login/bin/process-k5login.sh
+++ b/slave/process-k5login/bin/process-k5login.sh
@@ -25,7 +25,7 @@ function process {
 		HOME_DIR=`echo "${line}" | awk '{ print $1 };'`
 		PRINCIPALS=`echo "${line}" | sed -e 's/^[^\t]*[\t]//'`
 		K5LOGIN="${HOME_DIR}/.k5login"
-	
+
 		#set home dir of user as current working directory
 		catch_error E_DIR_NOT_EXISTS cd "${HOME_DIR}"
 
@@ -65,7 +65,7 @@ function process {
 		# Setup ownership, the k5login temp file will have the same owner and group as user's home directory
 		F_USER=`ls -ld "${HOME_DIR}" | awk '{ print $3; }'`
 		F_GROUP=`ls -ld "${HOME_DIR}" | awk '{ print $4; }'`
-		catch_error E_CHANGE_OWNER chown ${F_USER}.${F_GROUP} "${TMP_K5LOGIN}"
+		catch_error E_CHANGE_OWNER chown ${F_USER}:${F_GROUP} "${TMP_K5LOGIN}"
 
 		F_USER_REAL=`ls -l "${TMP_K5LOGIN}" | awk '{ print $3; }'`
 		F_GROUP_REAL=`ls -l "${TMP_K5LOGIN}" | awk '{ print $4; }'`
@@ -78,7 +78,7 @@ function process {
 
 		#if something to add, create or update k5login
 		catch_error E_K5LOGIN_NOT_UPDATED diff_mv "${TMP_K5LOGIN}" "${K5LOGIN}"
-		
+
 		#log info about operation (update or create)
 		if [ ${K5LOGIN_EXISTS} == true ]; then
 			log_msg I_K5LOGIN_UPDATED

--- a/slave/process-k5login/changelog
+++ b/slave/process-k5login/changelog
@@ -1,7 +1,14 @@
+perun-slave-process-k5login (3.1.4) stable; urgency=medium
+
+  * Use colon instead of dot when performing chown
+    as coreutils suggests.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Mon, 9 Apr 2018 10:20:00 +0100
+
 perun-slave-process-k5login (3.1.3) stable; urgency=medium
 
   * Use temporary file for k5login in home of each user, add data from Perun
-    to it and then move it atomically. The reason for this change is to 
+    to it and then move it atomically. The reason for this change is to
     overcome problems on distributed filesystems.
 
  -- Michal Stava <stavamichal@gmail.com>  Wed, 15 Mar 2017 14:35:00 +0100

--- a/slave/process-sshkeys-root/bin/process-sshkeys_root.sh
+++ b/slave/process-sshkeys-root/bin/process-sshkeys_root.sh
@@ -23,7 +23,7 @@ function process {
 
 	# Destination file doesn't exist
 	if [ ! -f ${DST_FILE} ]; then
-		catch_error E_CHOWN chown root.root $FROM_PERUN
+		catch_error E_CHOWN chown root:root $FROM_PERUN
 		catch_error E_CHMOD chmod 0644 $FROM_PERUN
 	fi
 

--- a/slave/process-sshkeys-root/changelog
+++ b/slave/process-sshkeys-root/changelog
@@ -1,3 +1,10 @@
+perun-slave-process-sshkeys-root (3.1.5) stable; urgency=medium
+
+  * Use colon instead of dot when performing chown
+    as coreutils suggests.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Mon, 9 Apr 2018 10:20:00 +0100
+
 perun-slave-process-sshkeys-root (3.1.4) stable; urgency=low
 
   * Add possibility to change destination file (default is


### PR DESCRIPTION
 - Using dot prevents user/group names with dot characters.
 - We will use colon as coreutils docs suggest for chown operation.