### PR TITLE
Allowed domains processing for o365_contacts_export

### DIFF
--- a/gen/o365_contacts_export
+++ b/gen/o365_contacts_export
@@ -22,7 +22,7 @@ my $file_name = "$DIRECTORY/$::SERVICE_NAME";
 open FILE,">$file_name" or die "Cannot open $file_name: $! \n";
 
 my %facilityAttributes = attributesToHash $data->getAttributes;
-my %allowedDomains = @{$facilityAttributes{$A_FACILITY_O365_ALLOWED_DOMAINS}};
+my %allowedDomains = map { $_ => 1 } @{$facilityAttributes{$A_FACILITY_O365_ALLOWED_DOMAINS}};
 
 my $memberDataByLogin;
 my @resourcesData = $data->getChildElements;


### PR DESCRIPTION
o365_contacts_export service processed only every second domain from
allowed domains list. Now it correctly processes all domains.