### PR TITLE
Use new group_resource attributes in voms services

### DIFF
--- a/gen/voms
+++ b/gen/voms
@@ -20,8 +20,8 @@ our $A_USER_MAIL;       *A_USER_MAIL =         \'urn:perun:user:attribute-def:de
 our $A_USER_CERT_DNS;   *A_USER_CERT_DNS =     \'urn:perun:user:attribute-def:virt:userCertDNs';
 our $A_USER_STATUS;     *A_USER_STATUS =       \'urn:perun:member:attribute-def:core:status';
 our $A_R_VOMS_ROLES;    *A_R_VOMS_ROLES =      \'urn:perun:resource:attribute-def:def:vomsRoles';
-our $A_G_VOMS_GR_NAME;  *A_G_VOMS_GR_NAME =    \'urn:perun:group:attribute-def:def:vomsGroupName';
-our $A_G_VOMS_ROLES;    *A_G_VOMS_ROLES =      \'urn:perun:group:attribute-def:def:vomsRoles';
+our $A_GR_VOMS_GR_NAME; *A_GR_VOMS_GR_NAME =   \'urn:perun:group_resource:attribute-def:def:vomsGroupName';
+our $A_GR_VOMS_ROLES;   *A_GR_VOMS_ROLES =     \'urn:perun:group_resource:attribute-def:def:vomsRoles';
 our $STATUS_VALID;      *STATUS_VALID =        \'VALID';
 
 my $struc = {};
@@ -42,9 +42,9 @@ foreach my $resourceData ($data->getChildElements) {
 	foreach my $groupData (($resourceData->getChildElements)[0]->getChildElements) {
 		my %groupAttributes = attributesToHash $groupData->getAttributes;
 		#get vomsGroupNameIfExists
-		my $vomsGroupName = $groupAttributes{$A_G_VOMS_GR_NAME};
+		my $vomsGroupName = $groupAttributes{$A_GR_VOMS_GR_NAME};
 		my @rolesInVoForGroup = ();
-		if(defined($groupAttributes{$A_G_VOMS_ROLES})) { @rolesInVoForGroup = @{$groupAttributes{$A_G_VOMS_ROLES}}; }
+		if(defined($groupAttributes{$A_GR_VOMS_ROLES})) { @rolesInVoForGroup = @{$groupAttributes{$A_GR_VOMS_ROLES}}; }
 
 		#group members one by one
 		foreach my $memberData (($groupData->getChildElements)[1]->getChildElements) {

--- a/gen/voms_dirac
+++ b/gen/voms_dirac
@@ -20,8 +20,8 @@ our $A_USER_MAIL;       *A_USER_MAIL =         \'urn:perun:user:attribute-def:de
 our $A_USER_CERT_DNS;   *A_USER_CERT_DNS =     \'urn:perun:user:attribute-def:virt:userCertDNs';
 our $A_USER_STATUS;     *A_USER_STATUS =       \'urn:perun:member:attribute-def:core:status';
 our $A_R_VOMS_ROLES;    *A_R_VOMS_ROLES =      \'urn:perun:resource:attribute-def:def:vomsRoles';
-our $A_G_VOMS_GR_NAME;  *A_G_VOMS_GR_NAME =    \'urn:perun:group:attribute-def:def:vomsGroupName';
-our $A_G_VOMS_ROLES;    *A_G_VOMS_ROLES =      \'urn:perun:group:attribute-def:def:vomsRoles';
+our $A_GR_VOMS_GR_NAME; *A_GR_VOMS_GR_NAME =   \'urn:perun:group_resource:attribute-def:def:vomsGroupName';
+our $A_GR_VOMS_ROLES;   *A_GR_VOMS_ROLES =     \'urn:perun:group_resource:attribute-def:def:vomsRoles';
 our $A_USER_NICKNAME;   *A_USER_NICKNAME =     \'urn:perun:user:attribute-def:virt:vomsDiracNickname';
 our $STATUS_VALID;      *STATUS_VALID =        \'VALID';
 
@@ -43,9 +43,9 @@ foreach my $resourceData ($data->getChildElements) {
 	foreach my $groupData (($resourceData->getChildElements)[0]->getChildElements) {
 		my %groupAttributes = attributesToHash $groupData->getAttributes;
 		#get vomsGroupNameIfExists
-		my $vomsGroupName = $groupAttributes{$A_G_VOMS_GR_NAME};
+		my $vomsGroupName = $groupAttributes{$A_GR_VOMS_GR_NAME};
 		my @rolesInVoForGroup = ();
-		if(defined($groupAttributes{$A_G_VOMS_ROLES})) { @rolesInVoForGroup = @{$groupAttributes{$A_G_VOMS_ROLES}}; }
+		if(defined($groupAttributes{$A_GR_VOMS_ROLES})) { @rolesInVoForGroup = @{$groupAttributes{$A_GR_VOMS_ROLES}}; }
 
 		#group members one by one
 		foreach my $memberData (($groupData->getChildElements)[1]->getChildElements) {


### PR DESCRIPTION
 - instead of "group" specific attributes "vomsGroupName" and
   "vomsRoles" we want to use same attribute for namespace
   "group_resource". This help to use one group for more than one
   resource with different settings.