### PR TITLE
Process timeout in scripts

### DIFF
--- a/send/bbmri_collections
+++ b/send/bbmri_collections
@@ -31,12 +31,22 @@ GROUP_TRANSPORT_COMMAND="$TRANSPORT_COMMAND -d @$GROUP_FILE -u `echo $DESTINATIO
 timeout -k $TIMEOUT_KILL $TIMEOUT $USER_TRANSPORT_COMMAND
 # Catch errors
 ERR_CODE=$?
-echo "Communcation with the peer ends with return code: $ERR_CODE" >&2
+#Error code 124 means - timeouted
+if [ $ERR_CODE -e 124 ]; then
+	echo "Communication with the peer was timeouted with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
+else
+	echo "Communcation with the peer ends with return code: $ERR_CODE" >&2
+fi
 
 # HTTP Request with timeout for GROUPS
 timeout -k $TIMEOUT_KILL $TIMEOUT $GROUP_TRANSPORT_COMMAND
 # Catch errors
 ERR_CODE=$?
-echo "Communcation with the peer ends with return code: $ERR_CODE" >&2
+#Error code 124 means - timeouted
+if [ $ERR_CODE -e 124 ]; then
+  echo "Communication with the peer was timeouted with return code: $ERR_CODE" >&2
+else
+	echo "Communcation with the peer ends with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
+fi
 
 exit $ERR_CODE

--- a/send/generic_send
+++ b/send/generic_send
@@ -138,6 +138,11 @@ fi
 
 ERR_CODE=$?
 
-echo "Communication with slave script ends with return code: $ERR_CODE" >&2
+#Error code 124 means - timeouted
+if [ $ERR_CODE -e 124 ]; then
+	echo "Communication with slave script was timeouted with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
+else
+	echo "Communication with slave script ends with return code: $ERR_CODE" >&2
+fi
 
 exit $ERR_CODE

--- a/send/topdesk
+++ b/send/topdesk
@@ -28,6 +28,11 @@ timeout -k $TIMEOUT_KILL $TIMEOUT $TRANSPORT_COMMAND
 
 ERR_CODE=$?
 
-echo "Communication with slave script ends with return code: $ERR_CODE" >&2
+#Error code 124 means - timeouted
+if [ $ERR_CODE -e 124 ]; then
+	echo "Communication with slave script was timeouted with return code: $ERR_CODE (Warning: this error can mask original error 124 from slave script!)" >&2
+else
+	echo "Communication with slave script ends with return code: $ERR_CODE" >&2
+fi
 
 exit $ERR_CODE


### PR DESCRIPTION
 - return code 124 means that limited time has run out and script was
   killed by the command "timeout"
 - in the situations when time has run out, we want to know it on the error
   output