### PR TITLE
Add 23:59:59 to the account expiration time for VŠUP services

### DIFF
--- a/gen/ad_user_vsup
+++ b/gen/ad_user_vsup
@@ -270,6 +270,9 @@ sub calculateExpiration() {
 		$result = $latest_expiration;
 	}
 
+	# Add time 23:59:59 to the date, since we want accounts to be active on the last day
+	$result = $result + 86399;
+
 	# add seconds before 1.1.1970 since Windows epoch starts at 1601-01-01T00:00:00Z
 	$result = $result + 11644473600;
 	# convert seconds to 100-nano seconds (hundreds of nano seconds)

--- a/gen/vsup_google_groups
+++ b/gen/vsup_google_groups
@@ -154,6 +154,9 @@ sub isExpired() {
 		return 0;
 	}
 
+	# Add time 23:59:59 to the date, since we want accounts to be active on the last day
+	$latest_expiration = $latest_expiration + 86399;
+
 	if ($latest_expiration > $currentDate->epoch) {
 		# not expired yet
 		return 0;

--- a/gen/vsup_zimbra
+++ b/gen/vsup_zimbra
@@ -216,6 +216,9 @@ sub getStatus() {
 		return 'active';
 	}
 
+	# Add time 23:59:59 to the date, since we want accounts to be active on the last day
+	$latest_expiration = $latest_expiration + 86399;
+
 	if ($latest_expiration > $currentDate->epoch) {
 		return 'active';
 	}


### PR DESCRIPTION
- We want accounts to be active during the last day, so we
  add 23:59:59 to the resulting expiration date, which is compared
  with current date.