### PR TITLE
Fix return code for o365_mu service

### DIFF
--- a/send/o365_mu
+++ b/send/o365_mu
@@ -120,10 +120,6 @@ $EXECSCRIPT -i $INSTANCE_NAME -p $TMP_HOSTNAME_DIR -s $SERVICE_NAME
 ERRORCODE=$?
 if [ $ERRORCODE -ne 0 ]; then
 	echo "Process exit with error" >&2
-	exit $ERRORCODE
 fi
 
-ERR_CODE=$?
-echo "Slave script ends with return code: $ERR_CODE" >&2
-
-exit $ERR_CODE
+exit $ERRORCODE

--- a/send/o365_mu_process.pl
+++ b/send/o365_mu_process.pl
@@ -67,7 +67,8 @@ my $pathToServiceFile;
 my $serviceName;
 my $domain = "";
 my $o365ConnectorFile = "./o365-connector.pl";
-my $returnCode=0;
+my $returnCode :shared;
+$returnCode = 0;
 
 #get options from input of script
 GetOptions ("instanceName|i=s" => \$instanceName, "pathToServiceFile|p=s" => \$pathToServiceFile, "serviceName|s=s" => \$serviceName);


### PR DESCRIPTION
 - there is variable "returnCode" which need to be delcared as shared,
   because it need to be shared between all threads to set correct
   return code
 - small change of processing return code in gen script o365_mu was
   done, it is more cosmetic change