### PR TITLE
Service ad_mu - fix emptying of a group

### DIFF
--- a/send/ad_mu
+++ b/send/ad_mu
@@ -762,7 +762,7 @@ sub process_groups() {
 					'extensionAttribute1' => 'FALSE'
 				);
 
-				my $response = $ldap->update($ad_entry);
+				my $response = $ad_entry->update($ldap);
 				unless ($response->is_error()) {
 					ldap_log($service_name, "Group emptied: ".$ad_entry->dn());
 					$counter_group_remove++;


### PR DESCRIPTION
There were switch parameters in LDAP update call, which leads to
following error:
"Can't locate object method "update" via package "Net::LDAPS" at ./ad_mu
line 765."

This part of code was used only to empty groups that are no longer
managed by Perun.