### PR TITLE
Fixed k5login_root behaviour without data

### DIFF
--- a/gen/k5login_root
+++ b/gen/k5login_root
@@ -20,7 +20,7 @@ our $A_USER_STATUS;          *A_USER_STATUS =         \'urn:perun:member:attribu
 our $A_GROUP_DESTINATIONS;   *A_GROUP_DESTINATIONS =  \'urn:perun:group:attribute-def:def:listOfDestinations';
 
 my $sortingFunction = getAttributeSorting($A_PRINCIPAL, 1);
-my %outputByDestination = ();
+my %outputByDestination = ('all' => undef);
 
 my @resourcesData = $data->getChildElements;
 foreach my $resourceData (@resourcesData) {


### PR DESCRIPTION
- Problem: When there were no groups assigned on resource
           or assigned groups had no valid members, gen script didnt't generate any file.
           Slave script couldn't proccess that.
- Change:  Gen script edited, so it's generating empty files in these situations
- Result:  Slave script is able to proccess empty files so it works without errors.