### PR TITLE
Fix typo in project service

### DIFF
--- a/slave/process-fs-project/bin/process-fs_project.sh
+++ b/slave/process-fs-project/bin/process-fs_project.sh
@@ -42,7 +42,7 @@ function process {
 					#If projectPaths are not same, set all not managed existing directories to nobady
 					for LINE in $EXISTING_DIRECTORIES; do
 						#Set permission to 2000 and owners to nobody:nogroup
-						setfacl --remove-all --remove-default
+						setfacl --remove-all --remove-default "$PREVIOUS_PROJECT_PATH"/"$LINE"
 						catch_error E_CANNOT_CHANGE_PERMISSIONS_TO_NOBODY chmod 2000 "$PREVIOUS_PROJECT_PATH"/"$LINE"
 						catch_error E_CANNOT_CHANGE_OWNER_TO_NOBODY chown nobody:nogroup "$PREVIOUS_PROJECT_PATH"/"$LINE"
 					done
@@ -119,7 +119,7 @@ function process {
 	#Need to do it for the last time when while ends
 	for LINE in $EXISTING_DIRECTORIES; do
 		#Set permission to 2000 and owners to nobody:nogroup
-		setfacl --remove-all --remove-default
+		setfacl --remove-all --remove-default "$PREVIOUS_PROJECT_PATH"/"$LINE"
 		catch_error E_CANNOT_CHANGE_PERMISSIONS_TO_NOBODY chmod 2000 "$PREVIOUS_PROJECT_PATH"/"$LINE"
 		catch_error E_CANNOT_CHANGE_OWNER_TO_NOBODY chown nobody:nogroup "$PREVIOUS_PROJECT_PATH"/"$LINE"
 	done

--- a/slave/process-fs-project/changelog
+++ b/slave/process-fs-project/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-fs-project (3.1.5) stable; urgency=low
+
+  * fix typo in command setfacl - it expects path to the file or directory
+
+ -- Michal Stava <Michal.Stava@cesnet.cz>  Mon, 08 Oct 2018 14:07:00 +0200
+
 perun-slave-process-fs-project (3.1.4) stable; urgency=medium
 
   * Set permissions using setfacl and set group permissions as default.


### PR DESCRIPTION
 - there was a typo in using setfacl command - it expects path to the
   file or directory