### PR TITLE
Fix ACL set for owner on directory

### DIFF
--- a/slave/process-fs-project/bin/process-fs_project.sh
+++ b/slave/process-fs-project/bin/process-fs_project.sh
@@ -64,7 +64,7 @@ function process {
 			U_PERMISSION=`echo $PERMISSIONS | sed -e 's/^\(.\)\(.\)\(.\)$/\1/'`
 			G_PERMISSION=`echo $PERMISSIONS | sed -e 's/^\(.\)\(.\)\(.\)$/\2/'`
 			O_PERMISSION=`echo $PERMISSIONS | sed -e 's/^\(.\)\(.\)\(.\)$/\3/'`
-			setfacl --remove-all --remove-default --modify u:$OWNER:$U_PERMISSION,d:g:$GID:$G_PERMISSION,g:$GID:$G_PERMISSION,d:g::$G_PERMISSION,g::$G_PERMISSION,o:$O_PERMISSION "$PROJECT_PATH"/"$PROJECT_NAME"
+			setfacl --remove-all --remove-default --modify u::$U_PERMISSION,u:$OWNER:$U_PERMISSION,d:g:$GID:$G_PERMISSION,g:$GID:$G_PERMISSION,d:g::$G_PERMISSION,g::$G_PERMISSION,o:$O_PERMISSION "$PROJECT_PATH"/"$PROJECT_NAME"
 			chmod g+s "$PROJECT_PATH"/"$PROJECT_NAME"
 			catch_error E_CANNOT_CHANGE_OWNER chown "$OWNER":"$UNIX_GROUP_NAME" "$PROJECT_PATH"/"$PROJECT_NAME"
 

--- a/slave/process-fs-project/changelog
+++ b/slave/process-fs-project/changelog
@@ -1,3 +1,10 @@
+perun-slave-process-fs-project (3.1.6) stable; urgency=high
+
+  * setfacl need to set also permissions for owner itself, not just user. 
+    This will prevent situation where owner can't access own directory.
+
+ -- Michal Stava <Michal.Stava@cesnet.cz>  Tue, 09 Oct 2018 14:10:00 +0200
+
 perun-slave-process-fs-project (3.1.5) stable; urgency=low
 
   * fix typo in command setfacl - it expects path to the file or directory


### PR DESCRIPTION
 - setfacl need to set also permissions for owner itself, not just user.
   This will prevent situation where owner can't access own directory.