### PR TITLE
SafeQ backup file timestamp fix

### DIFF
--- a/send/safeq
+++ b/send/safeq
@@ -83,5 +83,5 @@ else
 	rm "$FINAL"
 	echo No changes
 fi
-mv "$OLD_FILE" "$DESTINATION_DIR/backup-data-from-perun/safeq-content-$TIMESTAMP.ldif"
+cp "$INFILE" "$DESTINATION_DIR/backup-data-from-perun/safeq-content-$TIMESTAMP.ldif"
 cp "$INFILE" "$OLD_FILE"


### PR DESCRIPTION
- Problem: Send script for safeQ was creating archive file from previous run with wrong timestamp.
	   File had timestamp with date when the archive file was created (date of actual run of the send script),
	   but it shuld have date when the content for that file was created.
	   (date of previous run of the send script)
- Change:  Send script changed so it is not archiving content from previous run,
	   but it is archiving content from actual run.
- Result:  Timestamp corresponds with the date when the content was created.
	   Last proccesed file will exists twice,
	   in the archive directory and in the directory for last processed file.