### PR TITLE
Updated vsup_vema service

### DIFF
--- a/send/vsup_vema
+++ b/send/vsup_vema
@@ -82,8 +82,8 @@ foreach my $osbId (sort keys %$dataByOsbId) {
 
 	# NEVER-EVER DELETE, JUST INSERT
 
-	my $personExists = $dbh->prepare(qq{select 1 from $tableName_ID where OSCIS=?});
-	$personExists->execute($osbId);
+	my $personExists = $dbh->prepare(qq{select 1 from $tableName_ID where OSCIS=? and TYPPROP=?});
+	$personExists->execute($osbId, 'vmauth');
 
 	if($personExists->fetch) {
 		if($DEBUG == 1) { print "FIND: $osbId\n"; }


### PR DESCRIPTION
- Make sure we check person entry presence with proper TYPPROP column
  value ('vmauth'), since other entries might be already present.