### PR TITLE
fs_scratch_local conditions modification

### DIFF
--- a/slave/process-fs-scratch-local/bin/process-fs_scratch_local.sh
+++ b/slave/process-fs-scratch-local/bin/process-fs_scratch_local.sh
@@ -30,21 +30,22 @@ function process {
 
 	# lines contains login\tUID\tGID\t...
 	while IFS=`echo -e "\t"` read LOGIN U_UID U_GID SOFT_QUOTA_DATA HARD_QUOTA_DATA SOFT_QUOTA_FILES HARD_QUOTA_FILES; do
+		SCRATCH_DIR="${SCRATCH_MOUNTPOINT}/${LOGIN}"
 
-		if [ ! -d "${SCRATCH_MOUNTPOINT}/${LOGIN}" ]; then
-			catch_error E_CANNOT_CREATE_DIR  mkdir "${SCRATCH_MOUNTPOINT}/${LOGIN}"
-
-			catch_error E_CANNOT_SET_OWNERSHIP chown "${U_UID}":"${U_GID}" "${SCRATCH_MOUNTPOINT}/${LOGIN}"
-			catch_error E_CANNOT_SET_PERMISSIONS chmod "${UMASK}" "${SCRATCH_MOUNTPOINT}/${LOGIN}"
-
-			# Set quota
-			# setquota name block-softlimit block-hardlimit inode-softlimit inode-hardlimit filesystem
-			#      if [ -x /usr/sbin/setquota ]; then
-			#        # Get $QUOTA_FS
-			#        /usr/sbin/setquota $U_UID $SOFT_QUOTA_DATA $HARD_QUOTA_DATA $SOFT_QUOTA_FILES $HARD_QUOTA_FILES $QUOTA_FS
-			#      fi
-
+		if [ ! -d "${SCRATCH_DIR}" ]; then
+			catch_error E_CANNOT_CREATE_DIR  mkdir "${SCRATCH_DIR}"
 			log_msg I_DIR_CREATED
 		fi
+
+		if [ "`stat -L -c '%u:%g' ${SCRATCH_DIR}`" != "${U_UID}:${U_GID}" ]; then
+			catch_error E_CANNOT_SET_OWNERSHIP chown ${U_UID}:${U_GID} "${SCRATCH_DIR}"
+			log_debug "Ownership of ${SCRATCH_DIR} was set to ${U_UID}:${U_GID}"
+		fi
+
+		if [ "`stat -L -c '%a' ${SCRATCH_DIR}`" != "${UMASK}" ]; then
+			catch_error E_CANNOT_SET_PERMISSIONS chmod "${UMASK}" "${SCRATCH_DIR}"
+			log_debug "Permissions on ${SCRATCH_DIR} were set to ${UMASK}"
+		fi
+
 	done < "${FROM_PERUN}"
 }

--- a/slave/process-fs-scratch-local/changelog
+++ b/slave/process-fs-scratch-local/changelog
@@ -1,3 +1,16 @@
+perun-slave-process-fs-scratch-local (3.1.5) stable; urgency=low
+
+  * Modify service behaviour to be able to recover from a failure
+    in the previous run.
+  * Change access control list on scratch directory
+    when permissions have been changed. In the previous version,
+    the access control list was set only when scratch directory was created.
+  * Change ownership of scratch directory when the owner has been changed.
+    In the previous version, the ownership was set only when scratch
+    directory was created.
+
+ -- Peter Balcirak <peter.balcirak@gmail.com>  Wed, 31 Oct 2018 08:30:00 +0100
+
 perun-slave-process-fs-scratch-local (3.1.4) stable; urgency=medium
 
   * Use colon instead of dot when performing chown


### PR DESCRIPTION
- modify behavior in fs_scratch_local service to be
  able to continue from it's own failure and also change ACLs on
  scratch directories when there are any differencies