### PR TITLE
fs_scratch conditions modification

### DIFF
--- a/slave/process-fs-scratch/changelog
+++ b/slave/process-fs-scratch/changelog
@@ -1,3 +1,16 @@
+perun-slave-process-fs-scratch (3.1.5) stable; urgency=low
+
+  * Modify service behaviour to be able to recover from a failure
+    in the previous run.
+  * Change access control list on scratch directory
+    when permissions have been changed. In the previous version,
+    the access control list was set only when scratch directory was created.
+  * Change ownership of scratch directory when the owner has been changed.
+    In the previous version, the ownership was set only when scratch
+    directory was created.
+
+ -- Peter Balcirak <peter.balcirak@gmail.com>  Wed, 31 Oct 2018 0:25:00 +0100
+
 perun-slave-process-fs-scratch (3.1.4) stable; urgency=medium
 
   * Use colon instead of dot when performing chown


### PR DESCRIPTION
- modify behavior in fs_scratch service to be
  able to continue from it's own failure and also change ACLs on
  scratch directories when there are any differencies