### PR TITLE
Fixed parsing of input file in afs service

### DIFF
--- a/slave/process-afs/bin/process-afs.sh
+++ b/slave/process-afs/bin/process-afs.sh
@@ -12,20 +12,20 @@ function process {
 
 	VOLUMES_TO_RELEASE="" # release at the end of the script.  SYNTAX: volume:cell\nvol2:cel2\n
 
-        TABCHAR=`echo -ne '\t'`
+	TABCHAR=`echo -ne '\t'`
 
-        while read -r LINE; do
+	while read -r LINE; do
 		[[ "$LINE" =~ (.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*) ]] || { echo "Bad input line" >&2; ERROR=1; continue;}
-		AFS_SERVER="${BASH_REMATCH[1]}" 
-		AFS_CELL="${BASH_REMATCH[2]}" 
-		AFS_PARTITION="${BASH_REMATCH[3]}" 
-		AFS_DEFAULT_USERS_REALM="${BASH_REMATCH[4]}" 
-		AFS_USERS_MOUNT_POINT="${BASH_REMATCH[5]}" 
-		AFS_USERS_VOLUME="${BASH_REMATCH[6]}" 
-		AFS_VOLUME="${BASH_REMATCH[7]}" 
-		USER_LOGIN="${BASH_REMATCH[8]}" 
-		USER_QUOTA="${BASH_REMATCH[9]}" 
-		TARGET_AFS_CELL="${BASH_REMATCH[10]}" 
+		AFS_SERVER="${BASH_REMATCH[1]}"
+		AFS_CELL="${BASH_REMATCH[2]}"
+		AFS_PARTITION="${BASH_REMATCH[3]}"
+		AFS_DEFAULT_USERS_REALM="${BASH_REMATCH[4]}"
+		AFS_USERS_MOUNT_POINT="${BASH_REMATCH[5]}"
+		AFS_USERS_VOLUME="${BASH_REMATCH[6]}"
+		AFS_VOLUME="${BASH_REMATCH[7]}"
+		USER_LOGIN="${BASH_REMATCH[8]}"
+		USER_QUOTA="${BASH_REMATCH[9]}"
+		TARGET_AFS_CELL="${BASH_REMATCH[10]}"
 
 		#pts listentries -users -cell "$AFS_CELL" | grep -q -F "$USER_LOGIN@$AFS_DEFAULT_USERS_REALM"
 		OUT=`pts examine -nameorid "$USER_LOGIN@$AFS_DEFAULT_USERS_REALM" -cell "$AFS_CELL" 2>&1 >/dev/null`

--- a/slave/process-afs/bin/process-afs.sh
+++ b/slave/process-afs/bin/process-afs.sh
@@ -12,7 +12,20 @@ function process {
 
 	VOLUMES_TO_RELEASE="" # release at the end of the script.  SYNTAX: volume:cell\nvol2:cel2\n
 
-	while IFS=`echo -e "\t"` read AFS_SERVER AFS_CELL AFS_PARTITION AFS_DEFAULT_USERS_REALM AFS_USERS_MOUNT_POINT AFS_USERS_VOLUME AFS_VOLUME USER_LOGIN USER_QUOTA TARGET_AFS_CELL; do
+        TABCHAR=`echo -ne '\t'`
+
+        while read -r LINE; do
+		[[ "$LINE" =~ (.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*)$TABCHAR(.*) ]] || { echo "Bad input line" >&2; ERROR=1; continue;}
+		AFS_SERVER="${BASH_REMATCH[1]}" 
+		AFS_CELL="${BASH_REMATCH[2]}" 
+		AFS_PARTITION="${BASH_REMATCH[3]}" 
+		AFS_DEFAULT_USERS_REALM="${BASH_REMATCH[4]}" 
+		AFS_USERS_MOUNT_POINT="${BASH_REMATCH[5]}" 
+		AFS_USERS_VOLUME="${BASH_REMATCH[6]}" 
+		AFS_VOLUME="${BASH_REMATCH[7]}" 
+		USER_LOGIN="${BASH_REMATCH[8]}" 
+		USER_QUOTA="${BASH_REMATCH[9]}" 
+		TARGET_AFS_CELL="${BASH_REMATCH[10]}" 
 
 		#pts listentries -users -cell "$AFS_CELL" | grep -q -F "$USER_LOGIN@$AFS_DEFAULT_USERS_REALM"
 		OUT=`pts examine -nameorid "$USER_LOGIN@$AFS_DEFAULT_USERS_REALM" -cell "$AFS_CELL" 2>&1 >/dev/null`

--- a/slave/process-afs/changelog
+++ b/slave/process-afs/changelog
@@ -1,3 +1,12 @@
+perun-slave-process-afs (3.1.6) stable; urgency=medium
+
+  * Fixed parsing of input file. Since some params can have empty
+    value (empty string) we must explicitly match line separated
+    by the tab char. Otherwise two consequent tab chars are
+    considered as a single one for IFS.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 25 Oct 2018 13:25:00 +0100
+
 perun-slave-process-afs (3.1.5) stable; urgency=low
 
   * Fixed quotation in a test of $TARGET_AFS_CELL variable.


### PR DESCRIPTION
- We must explicitly match the line with values separated by the tab char, since
  two consequent tab chars are considered as one for IFS. This can happen, if
  one of the values (columns) is empty (empty string) which is allowed state.