### PR TITLE
Buildinfo files removed while processing Makefile

### DIFF
--- a/slave/Makefile
+++ b/slave/Makefile
@@ -43,11 +43,11 @@ $(processes):
 	cd $@ && debuild -us -uc
 	@echo "Cleaning after $@ building process..."
 	@rm -rf "$@/"{Makefile,debian}
-	@rm -f "$(package_prefix_name)$@_"*.{build,changes,dsc,tar.gz,tar.xz}
+	@rm -f "$(package_prefix_name)$@_"*.{build,changes,dsc,tar.gz,tar.xz,buildinfo}
 	@echo "Generate spec file for $@..."
 	@./generate_rpm.sh $@
 
 
 clean:
-	@rm -f *.{deb,build,changes,dsc,tar.gz,tar.xz,rpm,spec,tgz}
+	@rm -f *.{deb,build,changes,dsc,tar.gz,tar.xz,rpm,spec,tgz,buildinfo}
 	@rm -rf {$(subst $(space),$(comma),$(processes))}/{Makefile,debian}


### PR DESCRIPTION
- Problem: While making package, makefile was not removing buildinfo files
           so they remained in the directory. These files are useless for us.
- Change:  Removing buildinfo files was added to process and clean functions in Makefile.
           Reason to add it also to clean is that if make package fails,
           buildinfo could remained in the directory. So after calling clean,
           we are sure buildinfo files are removed.
- Result:  There are no neccessary files left after process or clean.