### PR TITLE
Fixed error code comparison for determining timeout in generic_send

### DIFF
--- a/send/generic_send
+++ b/send/generic_send
@@ -139,8 +139,8 @@ fi
 ERR_CODE=$?
 
 #Error code 124 means - timeouted
-if [ $ERR_CODE -e 124 ]; then
-	echo "Communication with slave script was timeouted with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
+if [ $ERR_CODE -eq 124 ]; then
+	echo "Communication with slave script was timed out with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
 else
 	echo "Communication with slave script ends with return code: $ERR_CODE" >&2
 fi


### PR DESCRIPTION
- There was a typo in comparison command. Sending data worked, but
  it printed warning.
  Now we compare error code correctly so the state is reported back
  also correctly.