### PR TITLE
Bug fix for processing $@ in catch_error function

### DIFF
--- a/slave/base/bin/perun
+++ b/slave/base/bin/perun
@@ -144,7 +144,7 @@ function catch_error {
 	shift
 
 	exec 3>&1
-	ERR_TXT=`$@ 2>&1 1>&3`
+	ERR_TXT=`"$@" 2>&1 1>&3`
 	ERR=$?
 	exec 3>&-
 	if [ "$ERR_TXT" ]; then echo "$ERR_TXT" >&2; fi

--- a/slave/base/changelog
+++ b/slave/base/changelog
@@ -1,3 +1,11 @@
+perun-slave-base (3.1.13) stable; urgency=high
+
+  * Bug fix for processing of $@ in catch_error function.
+  * We need to use double quotes around $@ to prevent incorrect processing of
+    arguments in $@.
+
+ -- Michal Stava <stavamichal@gmail.com>  Fri, 2 Nov 2018 11:27:00 +0100
+
 perun-slave-base (3.1.12) stable; urgency=low
 
   * Extend process of loging errors,


### PR DESCRIPTION
 - We need to use double quotes around $@ to prevent incorrect processing of
   arguments in $@.