### PR TITLE
Fixed newlines in gen safeQ

### DIFF
--- a/gen/safeq
+++ b/gen/safeq
@@ -65,8 +65,8 @@ binmode FILE,":utf8";
 foreach my $id (sort keys %costcentersById) {
 	print FILE "dn: ", escapeDnValue("costcenterno=" . $id . ", ou=costcenters, o=ysoftsafeq"), "\n";
 	print FILE "objectclass: ysqcostcenter", "\n";
-	print FILE "costcenterno:", checkBase64($id), "\n";
-	print FILE "costcentername:", checkBase64($costcentersById{$id}), "\n";
+	print FILE "costcenterno:", checkBase64($id);
+	print FILE "costcentername:", checkBase64($costcentersById{$id});
 	print FILE "\n";
 }
 
@@ -95,12 +95,12 @@ foreach my $login (sort keys %$usersByLogin) {
 
 	print FILE "dn: ", escapeDnValue("username=" . $login . ", ou=users, o=ysoftsafeq"), "\n";
 	print FILE "objectclass: ysquser", "\n";
-	print FILE "username:", checkBase64($login), "\n";
-	print FILE "ldapauthdn:", checkBase64("cn=" . $login . ", ou=users, ou=mu, dc=ucn, dc=muni, dc=cz"), "\n";
-	print FILE "firstname:", checkBase64($attributes->{$A_USER_FIRST_NAME} || '(N/A)'), "\n";
-	print FILE "lastname:", checkBase64($attributes->{$A_USER_LAST_NAME} || '(N/A)'), "\n";
-	print FILE "costcenter:", checkBase64("costcenterno=" . $attributes->{$A_USER_WORKPLACE_ID} || 100 . ", ou=costcenters, o=ysoftsafeq"), "\n";
-	print FILE "email:", checkBase64($attributes->{$A_USER_MAIL}), "\n";
+	print FILE "username:", checkBase64($login);
+	print FILE "ldapauthdn:", checkBase64("cn=" . $login . ", ou=users, ou=mu, dc=ucn, dc=muni, dc=cz");
+	print FILE "firstname:", checkBase64($attributes->{$A_USER_FIRST_NAME} || '(N/A)');
+	print FILE "lastname:", checkBase64($attributes->{$A_USER_LAST_NAME} || '(N/A)');
+	print FILE "costcenter:", checkBase64("costcenterno=" . $attributes->{$A_USER_WORKPLACE_ID} || 100 . ", ou=costcenters, o=ysoftsafeq");
+	print FILE "email:", checkBase64($attributes->{$A_USER_MAIL});
 	print FILE "homedir:: ", encode_base64('\\\\ha-ntc.ics.muni.cz\\profiles\\' . $attributes->{$A_USER_LOGIN});
 
 	foreach my $chipNumber (@{$attributes->{$A_USER_CHIP_NUM}}) {
@@ -108,16 +108,16 @@ foreach my $login (sort keys %$usersByLogin) {
 			warn "Same chip number shared by more users. Logins of users: " . $login . ", " . $allChipNumbers{$chipNumber} . "\n";
 		}
 		$allChipNumbers{$chipNumber} = $login;
-		print FILE "card:", checkBase64($chipNumber), "\n";
+		print FILE "card:", checkBase64($chipNumber);
 	}
 
 	foreach my $role (keys %{$resourceAttrsByUserLogin->{$login}->{$STRUC_ROLES}}) {
-		print FILE "role:", checkBase64($role), "\n";
+		print FILE "role:", checkBase64($role);
 	}
 	print FILE "role: everyone", "\n";
 
 	foreach my $billingcode (keys %{$resourceAttrsByUserLogin->{$login}->{$STRUC_BILLINGCODES}}) {
-		print FILE "billingcode:",checkBase64("billingcode=" . $billingcode . ", ou=billingcodes, o=ysoftsafeq"), "\n";
+		print FILE "billingcode:",checkBase64("billingcode=" . $billingcode . ", ou=billingcodes, o=ysoftsafeq");
 	}
 
 	if($attributes->{$A_R_PRINT_FOR_FREE}) {
@@ -190,7 +190,7 @@ sub checkBase64 {
 	my $value = shift;
 
 	if ($value =~ /^[\x01-\x09\x0B-\x0C\x0E-\x1F\x21-\x39\x3B\x3D-\x7F][\x01-\x09\x0B-\x0C\x0E-\x7F]*$/){
-		return " ", $value;
+		return " ", $value, "\n";
 	}
 	return ": ", encode_base64(Encode::encode_utf8($value));
 }


### PR DESCRIPTION
- problem: when some value in gen safeq was encoded to Base64 it created extra line
- change: new lines are added just when value is not encoded to Base64
- result: seems to work fine,
          but Base64 function is adding new lines after every 76 characters,
          and I am not sure if it is correct.