### PR TITLE
Safeq - fixed LDIF generation

### DIFF
--- a/gen/safeq
+++ b/gen/safeq
@@ -63,10 +63,10 @@ binmode FILE,":utf8";
 ## costcenterno: 1000001
 ## costcentername: Human Resources
 foreach my $id (sort keys %costcentersById) {
-	print FILE "dn: ", escapeDnValue("costcenterno=" . $id . ", ou=costcenters, o=ysoftsafeq"), "\n";
+	print FILE "dn: ", "costcenterno=" . escapeDnValue($id) . ", ou=costcenters, o=ysoftsafeq", "\n";
 	print FILE "objectclass: ysqcostcenter", "\n";
-	print FILE "costcenterno:", checkBase64($id);
-	print FILE "costcentername:", checkBase64($costcentersById{$id});
+	print FILE "costcenterno:", checkBase64($id), "\n";
+	print FILE "costcentername:", checkBase64($costcentersById{$id}), "\n";
 	print FILE "\n";
 }
 
@@ -93,14 +93,14 @@ my %allChipNumbers;  #used for consistency check - each chip number should belon
 foreach my $login (sort keys %$usersByLogin) {
 	my $attributes = $usersByLogin->{$login};
 
-	print FILE "dn: ", escapeDnValue("username=" . $login . ", ou=users, o=ysoftsafeq"), "\n";
+	print FILE "dn: ", "username=" . escapeDnValue($login) . ", ou=users, o=ysoftsafeq", "\n";
 	print FILE "objectclass: ysquser", "\n";
-	print FILE "username:", checkBase64($login);
-	print FILE "ldapauthdn:", checkBase64("cn=" . $login . ", ou=users, ou=mu, dc=ucn, dc=muni, dc=cz");
-	print FILE "firstname:", checkBase64($attributes->{$A_USER_FIRST_NAME} || '(N/A)');
-	print FILE "lastname:", checkBase64($attributes->{$A_USER_LAST_NAME} || '(N/A)');
-	print FILE "costcenter:", checkBase64("costcenterno=" . ($attributes->{$A_USER_WORKPLACE_ID} || 100) . ", ou=costcenters, o=ysoftsafeq");
-	print FILE "email:", checkBase64($attributes->{$A_USER_MAIL});
+	print FILE "username:", checkBase64($login), "\n";
+	print FILE "ldapauthdn:", checkBase64("cn=" . $login . ", ou=users, ou=mu, dc=ucn, dc=muni, dc=cz"), "\n";
+	print FILE "firstname:", checkBase64($attributes->{$A_USER_FIRST_NAME} || '(N/A)'), "\n";
+	print FILE "lastname:", checkBase64($attributes->{$A_USER_LAST_NAME} || '(N/A)'), "\n";
+	print FILE "costcenter:", checkBase64("costcenterno=" . ($attributes->{$A_USER_WORKPLACE_ID} || 100) . ", ou=costcenters, o=ysoftsafeq"), "\n";
+	print FILE "email:", checkBase64($attributes->{$A_USER_MAIL}), "\n";
 	print FILE "homedir:: ", encode_base64('\\\\ha-ntc.ics.muni.cz\\profiles\\' . $attributes->{$A_USER_LOGIN});
 
 	foreach my $chipNumber (@{$attributes->{$A_USER_CHIP_NUM}}) {
@@ -108,16 +108,16 @@ foreach my $login (sort keys %$usersByLogin) {
 			warn "Same chip number shared by more users. Logins of users: " . $login . ", " . $allChipNumbers{$chipNumber} . "\n";
 		}
 		$allChipNumbers{$chipNumber} = $login;
-		print FILE "card:", checkBase64($chipNumber);
+		print FILE "card:", checkBase64($chipNumber), "\n";
 	}
 
 	foreach my $role (keys %{$resourceAttrsByUserLogin->{$login}->{$STRUC_ROLES}}) {
-		print FILE "role:", checkBase64($role);
+		print FILE "role:", checkBase64($role), "\n";
 	}
 	print FILE "role: everyone", "\n";
 
 	foreach my $billingcode (keys %{$resourceAttrsByUserLogin->{$login}->{$STRUC_BILLINGCODES}}) {
-		print FILE "billingcode:",checkBase64("billingcode=" . $billingcode . ", ou=billingcodes, o=ysoftsafeq");
+		print FILE "billingcode:",checkBase64("billingcode=" . $billingcode . ", ou=billingcodes, o=ysoftsafeq"), "\n";
 	}
 
 	if($attributes->{$A_R_PRINT_FOR_FREE}) {
@@ -190,8 +190,8 @@ sub checkBase64 {
 	my $value = shift;
 
 	if ($value =~ /^[\x01-\x09\x0B-\x0C\x0E-\x1F\x21-\x39\x3B\x3D-\x7F][\x01-\x09\x0B-\x0C\x0E-\x7F]*$/){
-		return " ", $value, "\n";
+		return " ", $value;
 	}
-	return ": ", encode_base64(Encode::encode_utf8($value));
+	return ": ", encode_base64(Encode::encode_utf8($value), '');
 }
 


### PR DESCRIPTION
- We must escape specific chars in DN only if they are not part
  of DN structure (like comma).
- Put back newline after print of possible base64 value. We now instruct
  encoding function to don't wrap value by newlines after each 76 chars,
  since script ldifdiff.pl doesn't understand multi-line values.