### PR TITLE
Manage also gecos and altSecurityIdentities attributes in VŠUP AD

### DIFF
--- a/gen/ad_user_vsup
+++ b/gen/ad_user_vsup
@@ -10,7 +10,7 @@ sub calculateExpiration;
 
 local $::SERVICE_NAME = "ad_user_vsup";
 local $::PROTOCOL_VERSION = "3.0.1";
-my $SCRIPT_VERSION = "3.0.4";
+my $SCRIPT_VERSION = "3.0.5";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
@@ -41,6 +41,7 @@ our $A_EXPIRATION_KOS;  *A_EXPIRATION_KOS = \'urn:perun:user:attribute-def:def:e
 our $A_EXPIRATION_DC2;  *A_EXPIRATION_DC2 = \'urn:perun:user:attribute-def:def:expirationDc2';
 our $A_EXPIRATION_MANUAL;  *A_EXPIRATION_MANUAL = \'urn:perun:user:attribute-def:def:expirationManual';
 our $A_VSUP_PREF_MAIL;  *A_VSUP_PREF_MAIL = \'urn:perun:user:attribute-def:def:vsupPreferredMail';
+our $A_VSUP_SSH_KEYS;  *A_VSUP_SSH_KEYS = \'urn:perun:user:attribute-def:def:sshPublicKey';
 
 # CHECK ON FACILITY ATTRIBUTES
 my %facilityAttributes = attributesToHash $data->getAttributes;
@@ -108,6 +109,7 @@ foreach my $user (($data->getChildElements)[1]->getChildElements) {
 		$users->{$login}->{$A_EXPIRATION_DC2} = $uAttributes{$A_EXPIRATION_DC2};
 		$users->{$login}->{$A_EXPIRATION_MANUAL} = $uAttributes{$A_EXPIRATION_MANUAL};
 		$users->{$login}->{$A_VSUP_PREF_MAIL} = $uAttributes{$A_VSUP_PREF_MAIL};
+		$users->{$login}->{$A_VSUP_SSH_KEYS} = $uAttributes{$A_VSUP_SSH_KEYS};
 
 	}
 
@@ -145,6 +147,7 @@ for my $login (@logins) {
 	my $barcodes = $users->{$login}->{$A_CARD_BARCODES};
 	my $chipNumers = $users->{$login}->{$A_CARD_CHIP_NUMBERS};
 	my $vsupPrefMail = $users->{$login}->{$A_VSUP_PREF_MAIL};
+	my $sshKeys = $users->{$login}->{$A_VSUP_SSH_KEYS};
 
 	# print display name from firstName/lastName only
 	my $printedDisplayName = undef;
@@ -157,6 +160,7 @@ for my $login (@logins) {
 	}
 	if (defined $printedDisplayName and length $printedDisplayName) {
 		print FILE "displayName: " . $printedDisplayName . "\n";
+		print FILE "gecos: " . $printedDisplayName . "\n";
 	}
 
 	if (defined $sn and length $sn) {
@@ -194,6 +198,10 @@ for my $login (@logins) {
 
 	foreach my $val (@$chipNumers) {
 		print FILE "vsupPersonIdCardChipNumber: " . $val . "\n";
+	}
+
+	foreach my $val (@$sshKeys) {
+		print FILE "altSecurityIdentities: " . $val . "\n";
 	}
 
 	# print classes

--- a/gen/ad_user_vsup_service
+++ b/gen/ad_user_vsup_service
@@ -7,7 +7,7 @@ use perunServicesUtils;
 
 local $::SERVICE_NAME = "ad_user_vsup_service";
 local $::PROTOCOL_VERSION = "3.0.1";
-my $SCRIPT_VERSION = "3.0.3";
+my $SCRIPT_VERSION = "3.0.4";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
@@ -35,6 +35,7 @@ our $A_PHONE;  *A_PHONE = \'urn:perun:user:attribute-def:def:phoneDc2';
 our $A_CARD_BARCODES;  *A_CARD_BARCODES = \'urn:perun:user:attribute-def:def:cardBarCodes';
 our $A_CARD_CHIP_NUMBERS;  *A_CARD_CHIP_NUMBERS = \'urn:perun:user:attribute-def:def:cardCodes';
 our $A_VSUP_PREF_MAIL;  *A_VSUP_PREF_MAIL = \'urn:perun:user:attribute-def:def:vsupPreferredMail';
+our $A_VSUP_SSH_KEYS;  *A_VSUP_SSH_KEYS = \'urn:perun:user:attribute-def:def:sshPublicKey';
 
 # CHECK ON FACILITY ATTRIBUTES
 my %facilityAttributes = attributesToHash $data->getAttributes;
@@ -99,6 +100,7 @@ foreach my $user (($data->getChildElements)[1]->getChildElements) {
 		$users->{$login}->{$A_CARD_BARCODES} = $uAttributes{$A_CARD_BARCODES};
 		$users->{$login}->{$A_CARD_CHIP_NUMBERS} = $uAttributes{$A_CARD_CHIP_NUMBERS};
 		$users->{$login}->{$A_VSUP_PREF_MAIL} = $uAttributes{$A_VSUP_PREF_MAIL};
+		$users->{$login}->{$A_VSUP_SSH_KEYS} = $uAttributes{$A_VSUP_SSH_KEYS};
 
 	}
 
@@ -133,6 +135,7 @@ for my $login (@logins) {
 	my $barcodes = $users->{$login}->{$A_CARD_BARCODES};
 	my $chipNumers = $users->{$login}->{$A_CARD_CHIP_NUMBERS};
 	my $vsupPrefMail = $users->{$login}->{$A_VSUP_PREF_MAIL};
+	my $sshKeys = $users->{$login}->{$A_VSUP_SSH_KEYS};
 
 	# print display name from firstName/lastName only
 	my $printedDisplayName = undef;
@@ -145,6 +148,7 @@ for my $login (@logins) {
 	}
 	if (defined $printedDisplayName and length $printedDisplayName) {
 		print FILE "displayName: " . $printedDisplayName . "\n";
+		print FILE "gecos: " . $printedDisplayName . "\n";
 	}
 
 	if (defined $sn and length $sn) {
@@ -182,6 +186,10 @@ for my $login (@logins) {
 
 	foreach my $val (@$chipNumers) {
 		print FILE "vsupPersonIdCardChipNumber: " . $val . "\n";
+	}
+
+	foreach my $val (@$sshKeys) {
+		print FILE "altSecurityIdentities: " . $val . "\n";
 	}
 
 	# print classes

--- a/send/ad_user_vsup
+++ b/send/ad_user_vsup
@@ -66,7 +66,7 @@ ldap_bind($ldap, $conf[1], $conf[2]);
 
 # load all data
 my @perun_entries = load_perun($service_files_dir . "/" . $service_name . ".ldif");
-my @ad_entries = load_ad($ldap, $base_dn, $filter, ['cn','displayName','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','userAccountControl','samAccountName','accountExpires']);
+my @ad_entries = load_ad($ldap, $base_dn, $filter, ['cn','displayName','gecos','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','altSecurityIdentities','userAccountControl','samAccountName','accountExpires']);
 
 # put it in a mep to speed processing
 my %ad_entries_map = ();
@@ -181,7 +181,7 @@ sub process_update() {
 			my $ad_entry = $ad_entries_map{$login};
 
 			# attrs without cn since it's part of DN to be updated
-			my @attrs = ('displayName','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','accountExpires');
+			my @attrs = ('displayName','gecos','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','altSecurityIdentities','accountExpires');
 
 			# stored log messages to check if entry should be updated
 			my @entry_changed = ();
@@ -281,7 +281,7 @@ sub get_entry_by_login() {
 	my $response = $ldap->search( base => $top_dn ,
 		scope => 'sub' ,
 		filter => $filter ,
-		attrs => ['cn','displayName','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','userAccountControl','samAccountName','accountExpires']
+		attrs => ['cn','displayName','gecos','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','altSecurityIdentities','userAccountControl','samAccountName','accountExpires']
 	);
 
 	unless ($response->is_error()) {

--- a/send/ad_user_vsup_service
+++ b/send/ad_user_vsup_service
@@ -66,7 +66,7 @@ ldap_bind($ldap, $conf[1], $conf[2]);
 
 # load all data
 my @perun_entries = load_perun($service_files_dir . "/" . $service_name . ".ldif");
-my @ad_entries = load_ad($ldap, $base_dn, $filter, ['cn','displayName','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','userAccountControl','samAccountName']);
+my @ad_entries = load_ad($ldap, $base_dn, $filter, ['cn','displayName','gecos','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','altSecurityIdentities','userAccountControl','samAccountName']);
 
 # put it in a mep to speed processing
 my %ad_entries_map = ();
@@ -181,7 +181,7 @@ sub process_update() {
 			my $ad_entry = $ad_entries_map{$login};
 
 			# attrs without cn since it's part of DN to be updated
-			my @attrs = ('displayName','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber');
+			my @attrs = ('displayName','gecos','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','altSecurityIdentities');
 
 			# stored log messages to check if entry should be updated
 			my @entry_changed = ();
@@ -283,7 +283,7 @@ sub get_entry_by_login() {
 	my $response = $ldap->search( base => $top_dn ,
 		scope => 'sub' ,
 		filter => $filter ,
-		attrs => ['cn','displayName','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','userAccountControl','samAccountName']
+		attrs => ['cn','displayName','gecos','sn','givenName','mail','vsupPersonPersonalId','vsupPersonTitleHead','vsupPersonTitleTail','telephoneNumber','vsupPersonIdCardBarcode','vsupPersonIdCardChipNumber','altSecurityIdentities','userAccountControl','samAccountName']
 	);
 
 	unless ($response->is_error()) {


### PR DESCRIPTION
- Manage also gecos attribute in AD. Value is same as displayName.
- Manage also altSecurityIdentities in AD, which is a list of user
  account identifiers (kerberos or cert). But since it will be used
  by FreeIPA we will fill it with public SSH keys of user.
- Updated both services for normal and service users at VŠUP.