### PR TITLE
New version of service fs_home

### DIFF
--- a/gen/fs_home
+++ b/gen/fs_home
@@ -7,8 +7,8 @@ use File::Basename;
 no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
 our $SERVICE_NAME = basename($0);
-our $PROTOCOL_VERSION = "3.6.0";
-my $SCRIPT_VERSION = "3.0.9";
+our $PROTOCOL_VERSION = "3.7.0";
+my $SCRIPT_VERSION = "3.0.10";
 
 sub mergeQuotas {
 	my ($sumQuota, $resourceQuota, $memberQuota) = @_;
@@ -44,6 +44,8 @@ my $data = perunServicesInit::getDataWithGroups;
 
 #Constants
 our $A_USER_LOGIN;                 *A_USER_LOGIN =                   \'urn:perun:user_facility:attribute-def:virt:login';
+our $A_UF_DATA_QUOTAS;             *A_UF_DATA_QUOTAS =               \'urn:perun:user_facility:attribute-def:virt:dataQuotas';
+our $A_UF_FILE_QUOTAS;             *A_UF_FILE_QUOTAS =               \'urn:perun:user_facility:attribute-def:virt:fileQuotas';
 our $A_USER_STATUS;                *A_USER_STATUS =                  \'urn:perun:member:attribute-def:core:status';
 our $A_HOME_MOUNTPOINT;            *A_HOME_MOUNTPOINT =              \'urn:perun:resource:attribute-def:def:fsHomeMountPoint';
 our $A_R_VOLUME;                   *A_R_VOLUME =                     \'urn:perun:resource:attribute-def:def:fsVolume';
@@ -62,22 +64,34 @@ our $A_F_QUOTAENABLED;             *A_F_QUOTAENABLED =               \'urn:perun
 our $A_GROUP_UNIX_GROUP_NAME;      *A_GROUP_UNIX_GROUP_NAME =        \'urn:perun:group_resource:attribute-def:virt:unixGroupName';
 our $A_GROUP_GROUP_NAME;           *A_GROUP_GROUP_NAME =             \'urn:perun:group:attribute-def:core:name';
 our $A_R_VO_NAME;                  *A_R_VO_NAME =                    \'urn:perun:resource:attribute-def:virt:voShortName';
+our $A_F_NEW_QUOTAS_READY;         *A_F_NEW_QUOTAS_READY =           \'urn:perun:facility:attribute-def:def:readyForNewQuotas';
 
 our $STRUC_GROUPS;   *STRUC_GROUPS =  \"groups";
 
+#headers
+my $DATA_QUOTA_HEADER = "dataQuota";
+my $DATA_LIMIT_HEADER = "dataLimit";                                                                                                      
+my $FILE_QUOTA_HEADER = "fileQuota";
+my $FILE_LIMIT_HEADER = "fileLimit";
+
 my $service_file_name = "$DIRECTORY/$::SERVICE_NAME";
+my $quotas_file_name = "$DIRECTORY/quotas";
 my $umask_file_name = "$DIRECTORY/umask";
 my $quota_enabled_file_name = "$DIRECTORY/quota_enabled";
 
-my $memberAttributesByLoginAndMount = {};
-
 my %facilityAttributes = attributesToHash $data->getAttributes;
-#####################################
+my @resourcesData = $data->getChildElements;
 
-####### output file ######################
+#----------------------------------------------------------
+# HOME DATA
+#----------------------------------------------------------
+
+#structured data about user's home directories
+my $dataForUserHomeByLogin = {};
+
 open SERVICE_FILE,">$service_file_name" or die "Cannot open $service_file_name: $! \n";
 
-my @resourcesData = $data->getChildElements;
+#prepare home data
 foreach my $rData (@resourcesData) {
 	my %resourceAttributes = attributesToHash $rData->getAttributes;
 
@@ -90,18 +104,14 @@ foreach my $rData (@resourcesData) {
 		my %memberAttributes = attributesToHash $mData->getAttributes;
 		my $login = $memberAttributes{$A_USER_LOGIN};
 
-		unless(defined $memberAttributesByLoginAndMount->{$login}->{$volume}) { $memberAttributesByLoginAndMount->{$login}->{$volume} = {}; }
-		my $alreadyStoredMemberAttrByMount = $memberAttributesByLoginAndMount->{$login}->{$volume};
+		unless(defined $dataForUserHomeByLogin->{$login}->{$volume}) { $dataForUserHomeByLogin->{$login}->{$volume} = {}; }
+		my $alreadyStoredMemberAttrByMount = $dataForUserHomeByLogin->{$login}->{$volume};
 
 		$alreadyStoredMemberAttrByMount->{$A_R_VOLUME} = $volume;
 		$alreadyStoredMemberAttrByMount->{$A_USER_LOGIN} = $login;
 		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_GID} = $resourceAttributes{$A_GID};
 		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_UID} = $memberAttributes{$A_UID};
 		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_USER_STATUS} = mergeStatuses $memberAttributes{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_USER_STATUS}, $memberAttributes{$A_USER_STATUS};
-		$alreadyStoredMemberAttrByMount->{$A_MR_DATAQUOTA}  = mergeQuotas $memberAttributesByLoginAndMount->{$login}->{$volume}->{$A_MR_DATAQUOTA},  quotaToKb $resourceAttributes{$A_R_SOFT_QUOTA_DATA}, (defined $memberAttributes{$A_MR_DATAQUOTA} ? quotaToKb $memberAttributes{$A_MR_DATAQUOTA} : undef);
-		$alreadyStoredMemberAttrByMount->{$A_MR_DATALIMIT}  = mergeQuotas $memberAttributesByLoginAndMount->{$login}->{$volume}->{$A_MR_DATALIMIT},  quotaToKb $resourceAttributes{$A_R_HARD_QUOTA_DATA}, (defined $memberAttributes{$A_MR_DATALIMIT} ? quotaToKb $memberAttributes{$A_MR_DATALIMIT} : undef);
-		$alreadyStoredMemberAttrByMount->{$A_MR_FILESQUOTA} = mergeQuotas $memberAttributesByLoginAndMount->{$login}->{$volume}->{$A_MR_FILESQUOTA}, $resourceAttributes{$A_R_SOFT_QUOTA_FILE}, $memberAttributes{$A_MR_FILESQUOTA};
-		$alreadyStoredMemberAttrByMount->{$A_MR_FILESLIMIT} = mergeQuotas $memberAttributesByLoginAndMount->{$login}->{$volume}->{$A_MR_FILESLIMIT}, $resourceAttributes{$A_R_HARD_QUOTA_FILE}, $memberAttributes{$A_MR_FILESLIMIT};
 	}
 
 	foreach my $groupData (($rData->getChildElements)[0]->getChildElements) {
@@ -117,25 +127,21 @@ foreach my $rData (@resourcesData) {
 		foreach my $mData ($membersElement->getChildElements) {
 			my %memberAttributes = attributesToHash $mData->getAttributes;
 			my $login = $memberAttributes{$A_USER_LOGIN};
-			$memberAttributesByLoginAndMount->{$login}->{$volume}->{$STRUC_GROUPS}->{$groupNameWithVo} = $unixGroupName;
+			$dataForUserHomeByLogin->{$login}->{$volume}->{$STRUC_GROUPS}->{$groupNameWithVo} = $unixGroupName;
 		}
 	}
 }
 
-foreach my $login (sort keys %$memberAttributesByLoginAndMount) {
-	my $userAttributesByMount = $memberAttributesByLoginAndMount->{$login};
+foreach my $login (sort keys %$dataForUserHomeByLogin) {
+	my $userAttributesByMount = $dataForUserHomeByLogin->{$login};
 	
 	for my $userAttributes (values %$userAttributesByMount) {
 		
-		for my $mountPoint (keys %{$userAttributes->{$A_HOME_MOUNTPOINT}}) {
+		for my $mountPoint (sort keys %{$userAttributes->{$A_HOME_MOUNTPOINT}}) {
 			print SERVICE_FILE $mountPoint . "\t";
 			print SERVICE_FILE $login . "\t";
 			print SERVICE_FILE $userAttributes->{$A_HOME_MOUNTPOINT}->{$mountPoint}->{$A_UID} . "\t";
 			print SERVICE_FILE $userAttributes->{$A_HOME_MOUNTPOINT}->{$mountPoint}->{$A_GID} . "\t";
-			print SERVICE_FILE $userAttributes->{$A_MR_DATAQUOTA} . "\t";
-			print SERVICE_FILE $userAttributes->{$A_MR_DATALIMIT} . "\t";
-			print SERVICE_FILE $userAttributes->{$A_MR_FILESQUOTA} . "\t";
-			print SERVICE_FILE $userAttributes->{$A_MR_FILESLIMIT} . "\t";
 			print SERVICE_FILE $userAttributes->{$A_HOME_MOUNTPOINT}->{$mountPoint}->{$A_USER_STATUS} . "\t";
 
 			print SERVICE_FILE join ',', map { $_ . ">" . ($userAttributes->{$STRUC_GROUPS}->{$_} || "") } sort keys %{$userAttributes->{$STRUC_GROUPS}};
@@ -147,16 +153,108 @@ foreach my $login (sort keys %$memberAttributesByLoginAndMount) {
 
 close(SERVICE_FILE);
 
+#----------------------------------------------------------
+# QUOTAS DATA
+#----------------------------------------------------------
+
+#structured data about quotas
+my $dataForUserQuotasByUID = {};
+
+open QUOTAS_FILE,">$quotas_file_name" or die "Cannot open $quotas_file_name: $! \n";
+
+#Temporary define if facility is ready for new quotas (dataQuotas and fileQuotas)
+my $readyForNewQuotas = $facilityAttributes{$A_F_NEW_QUOTAS_READY};
+
+#prepare quotas data
+foreach my $rData (@resourcesData) {
+	my %resourceAttributes = attributesToHash $rData->getAttributes;
+	my @membersData = ($rData->getChildElements)[1]->getChildElements;
+
+	if($readyForNewQuotas) {
+		foreach my $mData (@membersData) {
+			my %memberAttributes = attributesToHash $mData->getAttributes;
+			my $uid = $memberAttributes{$A_UID};
+
+			unless($dataForUserQuotasByUID->{$uid}) {
+				#First process data quotas
+				foreach my $volume (keys %{$memberAttributes{$A_UF_DATA_QUOTAS}}) {
+					my $dataQuota = $memberAttributes{$A_UF_DATA_QUOTAS}{$volume};
+
+					my $softDataQuota = $dataQuota;
+					$softDataQuota =~ s/:.*$//;
+					my $hardDataQuota = $dataQuota;
+					$hardDataQuota =~ s/^.*://;
+					$dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_QUOTA_HEADER} = quotaToKb $softDataQuota;
+					$dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_LIMIT_HEADER} = quotaToKb $hardDataQuota;
+					$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_QUOTA_HEADER} = 0;
+					$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_LIMIT_HEADER} = 0;
+				}
+
+				#Then process file quotas
+				foreach my $volume (keys %{$memberAttributes{$A_UF_FILE_QUOTAS}}) {
+					my $fileQuota = $memberAttributes{$A_UF_FILE_QUOTAS}{$volume};
+					
+					my $softFileQuota = $fileQuota;
+					$softFileQuota =~ s/:.*$//;
+					my $hardFileQuota = $fileQuota;
+					$hardFileQuota =~ s/^.*://;
+					$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_QUOTA_HEADER} = $softFileQuota;
+					$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_LIMIT_HEADER} = $hardFileQuota;
+					unless ($dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_QUOTA_HEADER}) {
+						$dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_QUOTA_HEADER} = 0;
+					}
+					unless ($dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_LIMIT_HEADER}) {
+						$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_LIMIT_HEADER} = 0;
+					}
+				}
+			}
+		}		
+	} else {
+		my $volume = $resourceAttributes{$A_R_VOLUME} || $resourceAttributes{$A_HOME_MOUNTPOINT};
+
+		foreach my $mData (@membersData) {
+			my %memberAttributes = attributesToHash $mData->getAttributes;
+			my $uid = $memberAttributes{$A_UID};
+
+			$dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_QUOTA_HEADER} = mergeQuotas $dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_QUOTA_HEADER}, quotaToKb $resourceAttributes{$A_R_SOFT_QUOTA_DATA}, (defined $memberAttributes{$A_MR_DATAQUOTA} ? quotaToKb $memberAttributes{$A_MR_DATAQUOTA} : undef);
+			$dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_LIMIT_HEADER} = mergeQuotas $dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_LIMIT_HEADER}, quotaToKb $resourceAttributes{$A_R_HARD_QUOTA_DATA}, (defined $memberAttributes{$A_MR_DATALIMIT} ? quotaToKb $memberAttributes{$A_MR_DATALIMIT} : undef);
+			$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_QUOTA_HEADER} = mergeQuotas $dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_QUOTA_HEADER}, $resourceAttributes{$A_R_SOFT_QUOTA_FILE}, $memberAttributes{$A_MR_FILESQUOTA};
+			$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_LIMIT_HEADER} = mergeQuotas $dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_LIMIT_HEADER}, $resourceAttributes{$A_R_HARD_QUOTA_FILE}, $memberAttributes{$A_MR_FILESLIMIT};
+		}		
+	}
+}
+
+foreach my $uid (sort keys %$dataForUserQuotasByUID) {
+	foreach my $volume (sort keys %{$dataForUserQuotasByUID->{$uid}}) {
+		print QUOTAS_FILE $uid . "\t";
+		print QUOTAS_FILE $volume . "\t";
+		print QUOTAS_FILE $dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_QUOTA_HEADER} . "\t";
+		print QUOTAS_FILE $dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_LIMIT_HEADER} . "\t";
+		print QUOTAS_FILE $dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_QUOTA_HEADER} . "\t";
+		print QUOTAS_FILE $dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_LIMIT_HEADER} . "\n";
+	}
+}
+
+close(QUOTAS_FILE);
+#----------------------------------------------------------
+# UMASK DATA
+#----------------------------------------------------------
+
 if(defined $facilityAttributes{$A_F_UMASK}) {
 	open UMASK_FH, ">$umask_file_name" or die "Cannot open $umask_file_name: $!\n";
 	print UMASK_FH $facilityAttributes{$A_F_UMASK}, "\n";
 	close UMASK_FH;
 }
 
+#----------------------------------------------------------
+# QUOTA ENABLED DATA
+#----------------------------------------------------------
+
 if(defined $facilityAttributes{$A_F_QUOTAENABLED}) {
 	open QUOTA_FH, ">$quota_enabled_file_name" or die "Cannot open $quota_enabled_file_name: $!\n";
 	print QUOTA_FH $facilityAttributes{$A_F_QUOTAENABLED}, "\n";
 	close QUOTA_FH;
 }
+
 #####################################################
 perunServicesInit::finalize;

--- a/gen/fs_home_mu
+++ b/gen/fs_home_mu
@@ -7,8 +7,8 @@ use File::Basename;
 no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
 our $SERVICE_NAME = basename($0);
-our $PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+our $PROTOCOL_VERSION = "3.1.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 sub mergeQuotas {
 	my ($sumQuota, $resourceQuota, $memberQuota) = @_;
@@ -43,7 +43,10 @@ my $DIRECTORY = perunServicesInit::getDirectory;
 my $data = perunServicesInit::getDataWithGroups;
 
 #Constants
+our $A_USER_OPTIONAL_LOGIN;        *A_USER_OPTIONAL_LOGIN =          \'urn:perun:user:attribute-def:virt:optionalLogin-namespace:mu';
 our $A_USER_LOGIN;                 *A_USER_LOGIN =                   \'urn:perun:user_facility:attribute-def:virt:login';
+our $A_UF_DATA_QUOTAS;             *A_UF_DATA_QUOTAS =               \'urn:perun:user_facility:attribute-def:virt:dataQuotas';
+our $A_UF_FILE_QUOTAS;             *A_UF_FILE_QUOTAS =               \'urn:perun:user_facility:attribute-def:virt:fileQuotas';
 our $A_USER_STATUS;                *A_USER_STATUS =                  \'urn:perun:member:attribute-def:core:status';
 our $A_HOME_MOUNTPOINT;            *A_HOME_MOUNTPOINT =              \'urn:perun:resource:attribute-def:def:fsHomeMountPoint';
 our $A_R_VOLUME;                   *A_R_VOLUME =                     \'urn:perun:resource:attribute-def:def:fsVolume';
@@ -59,30 +62,37 @@ our $A_MR_DATAQUOTA;               *A_MR_DATAQUOTA =                 \'urn:perun
 our $A_MR_FILESLIMIT;              *A_MR_FILESLIMIT =                \'urn:perun:member_resource:attribute-def:def:filesLimit';
 our $A_MR_FILESQUOTA;              *A_MR_FILESQUOTA =                \'urn:perun:member_resource:attribute-def:def:filesQuota';
 our $A_F_QUOTAENABLED;             *A_F_QUOTAENABLED =               \'urn:perun:facility:attribute-def:def:quotaEnabled';
-our $A_USER_OPTIONAL_LOGIN;        *A_USER_OPTIONAL_LOGIN =          \'urn:perun:user:attribute-def:virt:optionalLogin-namespace:mu';
-
-#our $A_RESOURCE_UNIX_GROUP_NAME;  *A_RESOURCE_UNIX_GROUP_NAME =     \'urn:perun:resource:attribute-def:virt:unixGroupName';
-#our $A_RESOURCE_UNIX_GID;         *A_RESOURCE_UNIX_GID =            \'urn:perun:resource:attribute-def:virt:unixGID';
 our $A_GROUP_UNIX_GROUP_NAME;      *A_GROUP_UNIX_GROUP_NAME =        \'urn:perun:group_resource:attribute-def:virt:unixGroupName';
 our $A_GROUP_GROUP_NAME;           *A_GROUP_GROUP_NAME =             \'urn:perun:group:attribute-def:core:name';
-#our $A_GROUP_UNIX_GID;            *A_GROUP_UNIX_GID =               \'urn:perun:group_resource:attribute-def:virt:unixGID';
 our $A_R_VO_NAME;                  *A_R_VO_NAME =                    \'urn:perun:resource:attribute-def:virt:voShortName';
+our $A_F_NEW_QUOTAS_READY;         *A_F_NEW_QUOTAS_READY =           \'urn:perun:facility:attribute-def:def:readyForNewQuotas';
 
 our $STRUC_GROUPS;   *STRUC_GROUPS =  \"groups";
 
+#headers
+my $DATA_QUOTA_HEADER = "dataQuota";
+my $DATA_LIMIT_HEADER = "dataLimit";                                                                                                      
+my $FILE_QUOTA_HEADER = "fileQuota";
+my $FILE_LIMIT_HEADER = "fileLimit";
+
 my $service_file_name = "$DIRECTORY/$::SERVICE_NAME";
+my $quotas_file_name = "$DIRECTORY/quotas";
 my $umask_file_name = "$DIRECTORY/umask";
 my $quota_enabled_file_name = "$DIRECTORY/quota_enabled";
 
-my $memberAttributesByLoginAndMount = {};
-
 my %facilityAttributes = attributesToHash $data->getAttributes;
-#####################################
+my @resourcesData = $data->getChildElements;
 
-####### output file ######################
+#----------------------------------------------------------
+# HOME DATA
+#----------------------------------------------------------
+
+#structured data about user's home directories
+my $dataForUserHomeByLogin = {};
+
 open SERVICE_FILE,">$service_file_name" or die "Cannot open $service_file_name: $! \n";
 
-my @resourcesData = $data->getChildElements;
+#prepare home data
 foreach my $rData (@resourcesData) {
 	my %resourceAttributes = attributesToHash $rData->getAttributes;
 
@@ -93,23 +103,17 @@ foreach my $rData (@resourcesData) {
 
 	foreach my $mData (@membersData) {
 		my %memberAttributes = attributesToHash $mData->getAttributes;
+		my $login = $memberAttributes{$A_USER_LOGIN};
 
-		unless(defined $memberAttributesByLoginAndMount->{$memberAttributes{$A_USER_LOGIN}}->{$volume}) { $memberAttributesByLoginAndMount->{$memberAttributes{$A_USER_LOGIN}}->{$volume} = {}; }
-		my $alreadyStoredMemberAttrByMount = $memberAttributesByLoginAndMount->{$memberAttributes{$A_USER_LOGIN}}->{$volume};
+		unless(defined $dataForUserHomeByLogin->{$login}->{$volume}) { $dataForUserHomeByLogin->{$login}->{$volume} = {}; }
+		my $alreadyStoredMemberAttrByMount = $dataForUserHomeByLogin->{$login}->{$volume};
 
 		$alreadyStoredMemberAttrByMount->{$A_R_VOLUME} = $volume;
-		$alreadyStoredMemberAttrByMount->{$A_USER_LOGIN} = $memberAttributes{$A_USER_LOGIN};
+		$alreadyStoredMemberAttrByMount->{$A_USER_LOGIN} = $login;
 		$alreadyStoredMemberAttrByMount->{$A_USER_OPTIONAL_LOGIN} = $memberAttributes{$A_USER_OPTIONAL_LOGIN};
 		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_GID} = $resourceAttributes{$A_GID};
 		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_UID} = $memberAttributes{$A_UID};
 		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_USER_STATUS} = mergeStatuses $memberAttributes{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_USER_STATUS}, $memberAttributes{$A_USER_STATUS};
-		$alreadyStoredMemberAttrByMount->{$A_MR_DATAQUOTA}  = mergeQuotas $memberAttributesByLoginAndMount->{$memberAttributes{$A_USER_LOGIN}}->{$volume}->{$A_MR_DATAQUOTA},  quotaToKb $resourceAttributes{$A_R_SOFT_QUOTA_DATA}, (defined $memberAttributes{$A_MR_DATAQUOTA} ? quotaToKb $memberAttributes{$A_MR_DATAQUOTA} : undef);
-		$alreadyStoredMemberAttrByMount->{$A_MR_DATALIMIT}  = mergeQuotas $memberAttributesByLoginAndMount->{$memberAttributes{$A_USER_LOGIN}}->{$volume}->{$A_MR_DATALIMIT},  quotaToKb $resourceAttributes{$A_R_HARD_QUOTA_DATA}, (defined $memberAttributes{$A_MR_DATALIMIT} ? quotaToKb $memberAttributes{$A_MR_DATALIMIT} : undef);
-		$alreadyStoredMemberAttrByMount->{$A_MR_FILESQUOTA} = mergeQuotas $memberAttributesByLoginAndMount->{$memberAttributes{$A_USER_LOGIN}}->{$volume}->{$A_MR_FILESQUOTA}, $resourceAttributes{$A_R_SOFT_QUOTA_FILE}, $memberAttributes{$A_MR_FILESQUOTA};
-		$alreadyStoredMemberAttrByMount->{$A_MR_FILESLIMIT} = mergeQuotas $memberAttributesByLoginAndMount->{$memberAttributes{$A_USER_LOGIN}}->{$volume}->{$A_MR_FILESLIMIT}, $resourceAttributes{$A_R_HARD_QUOTA_FILE}, $memberAttributes{$A_MR_FILESLIMIT};
-
-		#store to global structure
-		#$memberAttributesByLoginAndMount->{$memberAttributes{$A_USER_LOGIN}}->{$volume} = \%memberAttributes;
 	}
 
 	foreach my $groupData (($rData->getChildElements)[0]->getChildElements) {
@@ -124,27 +128,28 @@ foreach my $rData (@resourcesData) {
 
 		foreach my $mData ($membersElement->getChildElements) {
 			my %memberAttributes = attributesToHash $mData->getAttributes;
-			$memberAttributesByLoginAndMount->{$memberAttributes{$A_USER_LOGIN}}->{$volume}->{$STRUC_GROUPS}->{$groupNameWithVo} = $unixGroupName;
+			my $login = $memberAttributes{$A_USER_LOGIN};
+			$dataForUserHomeByLogin->{$login}->{$volume}->{$STRUC_GROUPS}->{$groupNameWithVo} = $unixGroupName;
 		}
 	}
 }
 
-foreach my $sortedKey (sort keys %$memberAttributesByLoginAndMount) {
-    my $userAttributesByMount = $memberAttributesByLoginAndMount->{$sortedKey};
+foreach my $login (sort keys %$dataForUserHomeByLogin) {
+	my $userAttributesByMount = $dataForUserHomeByLogin->{$login};
+	
 	for my $userAttributes (values %$userAttributesByMount) {
-		for my $mountPoint (keys %{$userAttributes->{$A_HOME_MOUNTPOINT}}) {
+		
+		for my $mountPoint (sort keys %{$userAttributes->{$A_HOME_MOUNTPOINT}}) {
 			print SERVICE_FILE $mountPoint . "\t";
-			print SERVICE_FILE $userAttributes->{$A_USER_LOGIN} . "\t";
+			print SERVICE_FILE $login . "\t";
 			print SERVICE_FILE $userAttributes->{$A_HOME_MOUNTPOINT}->{$mountPoint}->{$A_UID} . "\t";
 			print SERVICE_FILE $userAttributes->{$A_HOME_MOUNTPOINT}->{$mountPoint}->{$A_GID} . "\t";
-			print SERVICE_FILE $userAttributes->{$A_MR_DATAQUOTA} . "\t";
-			print SERVICE_FILE $userAttributes->{$A_MR_DATALIMIT} . "\t";
-			print SERVICE_FILE $userAttributes->{$A_MR_FILESQUOTA} . "\t";
-			print SERVICE_FILE $userAttributes->{$A_MR_FILESLIMIT} . "\t";
 			print SERVICE_FILE $userAttributes->{$A_HOME_MOUNTPOINT}->{$mountPoint}->{$A_USER_STATUS} . "\t";
 
 			print SERVICE_FILE join ',', map { $_ . ">" . ($userAttributes->{$STRUC_GROUPS}->{$_} || "") } sort keys %{$userAttributes->{$STRUC_GROUPS}};
-			if(defined($userAttributes->{$A_USER_OPTIONAL_LOGIN})) { print SERVICE_FILE "\t" . $userAttributes->{$A_USER_OPTIONAL_LOGIN}; }
+			if(defined($userAttributes->{$A_USER_OPTIONAL_LOGIN})) {
+				print SERVICE_FILE "\t" . $userAttributes->{$A_USER_OPTIONAL_LOGIN};
+			}
 			print SERVICE_FILE "\n";
 
 		}
@@ -153,16 +158,108 @@ foreach my $sortedKey (sort keys %$memberAttributesByLoginAndMount) {
 
 close(SERVICE_FILE);
 
+#----------------------------------------------------------
+# QUOTAS DATA
+#----------------------------------------------------------
+
+#structured data about quotas
+my $dataForUserQuotasByUID = {};
+
+open QUOTAS_FILE,">$quotas_file_name" or die "Cannot open $quotas_file_name: $! \n";
+
+#Temporary define if facility is ready for new quotas (dataQuotas and fileQuotas)
+my $readyForNewQuotas = $facilityAttributes{$A_F_NEW_QUOTAS_READY};
+
+#prepare quotas data
+foreach my $rData (@resourcesData) {
+	my %resourceAttributes = attributesToHash $rData->getAttributes;
+	my @membersData = ($rData->getChildElements)[1]->getChildElements;
+
+	if($readyForNewQuotas) {
+		foreach my $mData (@membersData) {
+			my %memberAttributes = attributesToHash $mData->getAttributes;
+			my $uid = $memberAttributes{$A_UID};
+
+			unless($dataForUserQuotasByUID->{$uid}) {
+				#First process data quotas
+				foreach my $volume (keys %{$memberAttributes{$A_UF_DATA_QUOTAS}}) {
+					my $dataQuota = $memberAttributes{$A_UF_DATA_QUOTAS}{$volume};
+
+					my $softDataQuota = $dataQuota;
+					$softDataQuota =~ s/:.*$//;
+					my $hardDataQuota = $dataQuota;
+					$hardDataQuota =~ s/^.*://;
+					$dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_QUOTA_HEADER} = quotaToKb $softDataQuota;
+					$dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_LIMIT_HEADER} = quotaToKb $hardDataQuota;
+					$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_QUOTA_HEADER} = 0;
+					$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_LIMIT_HEADER} = 0;
+				}
+
+				#Then process file quotas
+				foreach my $volume (keys %{$memberAttributes{$A_UF_FILE_QUOTAS}}) {
+					my $fileQuota = $memberAttributes{$A_UF_FILE_QUOTAS}{$volume};
+					
+					my $softFileQuota = $fileQuota;
+					$softFileQuota =~ s/:.*$//;
+					my $hardFileQuota = $fileQuota;
+					$hardFileQuota =~ s/^.*://;
+					$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_QUOTA_HEADER} = $softFileQuota;
+					$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_LIMIT_HEADER} = $hardFileQuota;
+					unless ($dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_QUOTA_HEADER}) {
+						$dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_QUOTA_HEADER} = 0;
+					}
+					unless ($dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_LIMIT_HEADER}) {
+						$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_LIMIT_HEADER} = 0;
+					}
+				}
+			}
+		}		
+	} else {
+		my $volume = $resourceAttributes{$A_R_VOLUME} || $resourceAttributes{$A_HOME_MOUNTPOINT};
+
+		foreach my $mData (@membersData) {
+			my %memberAttributes = attributesToHash $mData->getAttributes;
+			my $uid = $memberAttributes{$A_UID};
+
+			$dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_QUOTA_HEADER} = mergeQuotas $dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_QUOTA_HEADER}, quotaToKb $resourceAttributes{$A_R_SOFT_QUOTA_DATA}, (defined $memberAttributes{$A_MR_DATAQUOTA} ? quotaToKb $memberAttributes{$A_MR_DATAQUOTA} : undef);
+			$dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_LIMIT_HEADER} = mergeQuotas $dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_LIMIT_HEADER}, quotaToKb $resourceAttributes{$A_R_HARD_QUOTA_DATA}, (defined $memberAttributes{$A_MR_DATALIMIT} ? quotaToKb $memberAttributes{$A_MR_DATALIMIT} : undef);
+			$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_QUOTA_HEADER} = mergeQuotas $dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_QUOTA_HEADER}, $resourceAttributes{$A_R_SOFT_QUOTA_FILE}, $memberAttributes{$A_MR_FILESQUOTA};
+			$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_LIMIT_HEADER} = mergeQuotas $dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_LIMIT_HEADER}, $resourceAttributes{$A_R_HARD_QUOTA_FILE}, $memberAttributes{$A_MR_FILESLIMIT};
+		}		
+	}
+}
+
+foreach my $uid (sort keys %$dataForUserQuotasByUID) {
+	foreach my $volume (sort keys %{$dataForUserQuotasByUID->{$uid}}) {
+		print QUOTAS_FILE $uid . "\t";
+		print QUOTAS_FILE $volume . "\t";
+		print QUOTAS_FILE $dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_QUOTA_HEADER} . "\t";
+		print QUOTAS_FILE $dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_LIMIT_HEADER} . "\t";
+		print QUOTAS_FILE $dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_QUOTA_HEADER} . "\t";
+		print QUOTAS_FILE $dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_LIMIT_HEADER} . "\n";
+	}
+}
+
+close(QUOTAS_FILE);
+#----------------------------------------------------------
+# UMASK DATA
+#----------------------------------------------------------
+
 if(defined $facilityAttributes{$A_F_UMASK}) {
 	open UMASK_FH, ">$umask_file_name" or die "Cannot open $umask_file_name: $!\n";
 	print UMASK_FH $facilityAttributes{$A_F_UMASK}, "\n";
 	close UMASK_FH;
 }
 
+#----------------------------------------------------------
+# QUOTA ENABLED DATA
+#----------------------------------------------------------
+
 if(defined $facilityAttributes{$A_F_QUOTAENABLED}) {
 	open QUOTA_FH, ">$quota_enabled_file_name" or die "Cannot open $quota_enabled_file_name: $!\n";
 	print QUOTA_FH $facilityAttributes{$A_F_QUOTAENABLED}, "\n";
 	close QUOTA_FH;
 }
+
 #####################################################
 perunServicesInit::finalize;

--- a/slave/process-fs-home/bin/process-fs_home.sh
+++ b/slave/process-fs-home/bin/process-fs_home.sh
@@ -58,6 +58,14 @@ function process {
 		fi
 	fi
 
+	# set quotas
+	while IFS=`echo -e "\t"` read U_UID QUOTA_FS SOFT_QUOTA_DATA HARD_QUOTA_DATA SOFT_QUOTA_FILES HARD_QUOTA_FILES REST_OF_LINE; do
+		if [ "$QUOTA_ENABLED" -gt 0 ]; then
+			SET_QUOTA_PARAMS=`eval echo $SET_QUOTA_TEMPLATE`
+			catch_error E_CANNOT_SET_QUOTA $SET_QUOTA $SET_QUOTA_PARAMS
+		fi
+	done < "${QUOTAS_FILE}"
+
 	SKEL_DIR=
 	#find first path from $PERUN_SKEL_PATH which exists and is a directory
 	if [ -n "$PERUN_SKEL_PATH" ]; then
@@ -105,11 +113,4 @@ function process {
 		fi
 	done < "${FROM_PERUN}"
 
-	# set quotas
-	while IFS=`echo -e "\t"` read U_UID QUOTA_FS SOFT_QUOTA_DATA HARD_QUOTA_DATA SOFT_QUOTA_FILES HARD_QUOTA_FILES REST_OF_LINE; do
-		if [ "$QUOTA_ENABLED" -gt 0 ]; then
-			SET_QUOTA_PARAMS=`eval echo $SET_QUOTA_TEMPLATE`
-			catch_error E_CANNOT_SET_QUOTA $SET_QUOTA $SET_QUOTA_PARAMS
-		fi
-	done < "${QUOTAS_FILE}"
 }

--- a/slave/process-fs-home/changelog
+++ b/slave/process-fs-home/changelog
@@ -1,3 +1,24 @@
+perun-slave-process-fs-home (3.1.9) stable; urgency=high
+
+  * main file with data was divided into two files - first with data to create
+    home directories for users, second with data to set quotas for all defined
+    volumes
+  * both files are now processed separately so first are created homes for all
+    users and then quotas are set for defined volumes. Mid hooks are processed
+    only for the first part of creating homes.
+  * some arguments as user login, home mount point, gid etc. were removed from
+    quotas template in script and also in pre script
+  * this version of service fs_home supports new quotas attributes in Perun,
+    although format of data in the file is the same. To active it administrator 
+    has to set attribute readyForNewQuotas on Facility to 'true'
+  * Protocol version was increased, new format is not supported with older
+    versions of protocol communication
+  * IMPORTANT: pre|post scripts and mid hooks can be also affected by these 
+    changes and administrator should check and modify their behavior before 
+    updating to this version
+
+ -- Michal Stava <stavamichal@gmail.com>  Tue, 02 Apr 2019 13:25:00 +0200
+
 perun-slave-process-fs-home (3.1.8) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-fs-home/conf/example-pre_01_set_quota
+++ b/slave/process-fs-home/conf/example-pre_01_set_quota
@@ -6,7 +6,7 @@
 #SET_QUOTA_PROGRAM="/usr/lpp/mmfs/bin/mmsetquota"
 
 # Parameters template for custom set quota program
-# Available variables: $U_HOME_MNT_POINT $U_LOGNAME $U_UID $SOFT_QUOTA_DATA $HARD_QUOTA_DATA $SOFT_QUOTA_FILES $HARD_QUOTA_FILES $QUOTA_FS
+# Available variables: $U_UID $SOFT_QUOTA_DATA $HARD_QUOTA_DATA $SOFT_QUOTA_FILES $HARD_QUOTA_FILES $QUOTA_FS
 # *_DATA are in kB
 # NOTE: value must be in single quotes
-#SET_QUOTA_TEMPLATE='--user ${U_UID} --disk_softquota ${SOFT_QUOTA_DATA}k --disk_hardquota ${HARD_QUOTA_DATA}k ${U_HOME_MNT_POINT}'
+#SET_QUOTA_TEMPLATE='--user ${U_UID} --disk_softquota ${SOFT_QUOTA_DATA}k --disk_hardquota ${HARD_QUOTA_DATA}k ${QUOTA_FS}'


### PR DESCRIPTION
 - there is major change in the processing data and also in the protocol
 version
 - processing data is now divided into two separate files, first one
 with data needed for creating home directories for users, second one
 with data to set quotas on all defined volumes
 - administrator of the facility can now choose which attributes for
 quotas will be used by setting attribute 'readyForNewQuotas' to 'true'
 if new attributes should be used or to 'false' if old attributes should
 be used. Format of output data file is the same for both logic
 - slave script was modified to respect these changes so first all home
 directories are created and then all quotas are changed
 - IMPORTANT: because the protocol version has been changed, new package
 with service fs_home need to be updated. Also pre|post scripts and mid
 hooks should be check if they still work with new modifications in the
 slave script.