### PR TITLE
`process-voms`: Sort user records by CA

### DIFF
--- a/slave/process-voms/changelog
+++ b/slave/process-voms/changelog
@@ -1,3 +1,10 @@
+perun-slave-process-voms (3.1.13) stable; urgency=medium
+
+  * Sort user records by CA, so that matching DNs issued by different
+    CAs will always come in the same order, probably oldest first.
+
+ -- Zdenek Sustr <sustr4@cesnet.cz>  Thu 25 Apr 2019 16:41:28 +0200
+
 perun-slave-process-voms (3.1.12) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-voms/lib/process-voms.pl
+++ b/slave/process-voms/lib/process-voms.pl
@@ -262,7 +262,7 @@ foreach my $vo (@{$vos->{'vo'}}) { # Iterating through individual VOs in the XML
 	my @groups_toBe = ( "/$name" );	# Desired list of groups
 	my @roles_toBe = ( "VO-Admin" );# Desired list of roles, plus the default VO-Admin role
 	my @DNs_Seen;			# DNs already included
-	foreach $user (@{$vo->{'users'}->{'user'}}) {
+	foreach $user (sort { $a->{'CA'} cmp $b->{'CA'} } @{$vo->{'users'}->{'user'}}) {
 		next unless knownCA(\@cas, $user->{'CA'});
 		my %theUser= ( 'CA' => "$user->{'CA'}",'DN' => normalizeUID(normalizeEmail($user->{'DN'})), 'CN' => getCN($user->{'DN'}), 'email' => "$user->{'email'}" );
 		next unless ($checkCA || uniqueDN(\%theUser, \@DNs_Seen));


### PR DESCRIPTION
- Matching DNs issued by different CAs will always come in the same order, probably oldest first.
- This is to fix flapping registrations wherein the VOMS record for a given user is deleted and immediately recreated if `skip-CA-check` is `true` and CAs come in different order from the parsed XML.