### PR TITLE
Replace SUSPENDED state for new suspension logic for member

### DIFF
--- a/gen/bbmri_collections
+++ b/gen/bbmri_collections
@@ -28,6 +28,7 @@ sub processMemberships;
 #Constants
 our $A_USER_ID;                   *A_USER_ID =               \'urn:perun:user:attribute-def:core:id';
 our $A_USER_STATUS;               *A_USER_STATUS =           \'urn:perun:member:attribute-def:core:status';
+our $A_MEMBER_IS_SUSPENDED;       *A_MEMBER_IS_SUSPENDED =   \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_USER_EMAIL;                *A_USER_EMAIL =            \'urn:perun:user:attribute-def:def:preferredMail';
 our $A_USER_EPPNS;                *A_USER_EPPNS =            \'urn:perun:user:attribute-def:virt:eduPersonPrincipalNames';
 our $A_USER_D_NAME;               *A_USER_D_NAME =           \'urn:perun:user:attribute-def:core:displayName';
@@ -126,6 +127,7 @@ sub processUsers {
 	my %memberAttributes = attributesToHash $memberData->getAttributes;
 	my $uid = $memberAttributes{$A_USER_ID};
 	my $status = $memberAttributes{$A_USER_STATUS};
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
 	my $email = $memberAttributes{$A_USER_EMAIL};
 	my $d_name = $memberAttributes{$A_USER_D_NAME};
 	my $organization = $memberAttributes{$A_USER_ORGANIZATION};

--- a/gen/bbmri_networks
+++ b/gen/bbmri_networks
@@ -34,6 +34,7 @@ our $A_USER_D_NAME;               *A_USER_D_NAME =           \'urn:perun:user:at
 our $A_GROUP_ID;                  *A_GROUP_ID =              \'urn:perun:group:attribute-def:core:id';
 our $A_GROUP_NAME;                *A_GROUP_NAME =            \'urn:perun:group:attribute-def:core:name';
 our $A_NETWORK_ID;                *A_NETWORK_ID =            \'urn:perun:group:attribute-def:def:networkID';
+our $A_MEMBER_IS_SUSPENDED;       *A_MEMBER_IS_SUSPENDED =   \'urn:perun:member:attribute-def:virt:isSuspended';
 
 our $STATUS_VALID;                *STATUS_VALID =            \'VALID';
 our $STATUS_EXPIRED;              *STATUS_EXPIRED =          \'EXPIRED';
@@ -119,6 +120,7 @@ sub processUsers {
 	my %memberAttributes = attributesToHash $memberData->getAttributes;
 	my $uid = $memberAttributes{$A_USER_ID};
 	my $status = $memberAttributes{$A_USER_STATUS};
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
 	my $email = $memberAttributes{$A_USER_EMAIL};
 	my $d_name = $memberAttributes{$A_USER_D_NAME};
 

--- a/gen/coffeeroom
+++ b/gen/coffeeroom
@@ -24,6 +24,7 @@ sub processMemberships;
 #Constants
 our $A_USER_ID;                   *A_USER_ID =               \'urn:perun:user:attribute-def:core:id';
 our $A_USER_STATUS;               *A_USER_STATUS =           \'urn:perun:member:attribute-def:core:status';
+our $A_MEMBER_IS_SUSPENDED;       *A_MEMBER_IS_SUSPENDED =   \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_USER_EMAIL;                *A_USER_EMAIL =            \'urn:perun:user:attribute-def:def:preferredMail';
 our $A_USER_LOGIN;                *A_USER_LOGIN =            \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_USER_D_NAME;               *A_USER_D_NAME =           \'urn:perun:user:attribute-def:core:displayName';
@@ -109,6 +110,7 @@ sub processUsers {
         my %memberAttributes = attributesToHash $memberData->getAttributes;
         my $uid = $memberAttributes{$A_USER_ID};
         my $status = $memberAttributes{$A_USER_STATUS};
+        if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
         my $email = $memberAttributes{$A_USER_EMAIL};
         my $d_name = $memberAttributes{$A_USER_D_NAME};
         my $login = $memberAttributes{$A_USER_LOGIN};

--- a/gen/drupal_elixir
+++ b/gen/drupal_elixir
@@ -25,6 +25,7 @@ sub processMemberships;
 our $A_USER_ID;                   *A_USER_ID =               \'urn:perun:user:attribute-def:core:id';
 our $A_USER_LOGIN;                *A_USER_LOGIN =            \'urn:perun:user:attribute-def:def:login-namespace:elixir';
 our $A_USER_STATUS;               *A_USER_STATUS =           \'urn:perun:member:attribute-def:core:status';
+our $A_MEMBER_IS_SUSPENDED;       *A_MEMBER_IS_SUSPENDED =   \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_USER_EMAIL;                *A_USER_EMAIL =            \'urn:perun:user:attribute-def:def:preferredMail';
 our $A_USER_EPPNS;                *A_USER_EPPNS =            \'urn:perun:user:attribute-def:virt:eduPersonPrincipalNames';
 our $A_USER_D_NAME;               *A_USER_D_NAME =           \'urn:perun:user:attribute-def:core:displayName';
@@ -131,6 +132,7 @@ sub processUsers {
 	my $uid = $memberAttributes{$A_USER_ID};
 	my $login = $memberAttributes{$A_USER_LOGIN};
 	my $status = $memberAttributes{$A_USER_STATUS};
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
 	my $email = $memberAttributes{$A_USER_EMAIL};
 	my $d_name = $memberAttributes{$A_USER_D_NAME};
 

--- a/gen/fs_home
+++ b/gen/fs_home
@@ -47,6 +47,7 @@ our $A_USER_LOGIN;                 *A_USER_LOGIN =                   \'urn:perun
 our $A_UF_DATA_QUOTAS;             *A_UF_DATA_QUOTAS =               \'urn:perun:user_facility:attribute-def:virt:dataQuotas';
 our $A_UF_FILE_QUOTAS;             *A_UF_FILE_QUOTAS =               \'urn:perun:user_facility:attribute-def:virt:fileQuotas';
 our $A_USER_STATUS;                *A_USER_STATUS =                  \'urn:perun:member:attribute-def:core:status';
+our $A_MEMBER_IS_SUSPENDED;        *A_MEMBER_IS_SUSPENDED =          \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_HOME_MOUNTPOINT;            *A_HOME_MOUNTPOINT =              \'urn:perun:resource:attribute-def:def:fsHomeMountPoint';
 our $A_R_VOLUME;                   *A_R_VOLUME =                     \'urn:perun:resource:attribute-def:def:fsVolume';
 our $A_GID;                        *A_GID =                          \'urn:perun:resource:attribute-def:virt:unixGID';
@@ -93,6 +94,8 @@ foreach my $rData (@resourcesData) {
 	foreach my $mData (@membersData) {
 		my %memberAttributes = attributesToHash $mData->getAttributes;
 		my $login = $memberAttributes{$A_USER_LOGIN};
+		my $status = $memberAttributes{$A_USER_STATUS};
+		if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = "SUSPENDED"; }
 
 		unless(defined $dataForUserHomeByLogin->{$login}->{$volume}) { $dataForUserHomeByLogin->{$login}->{$volume} = {}; }
 		my $alreadyStoredMemberAttrByMount = $dataForUserHomeByLogin->{$login}->{$volume};
@@ -101,7 +104,7 @@ foreach my $rData (@resourcesData) {
 		$alreadyStoredMemberAttrByMount->{$A_USER_LOGIN} = $login;
 		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_GID} = $resourceAttributes{$A_GID};
 		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_UID} = $memberAttributes{$A_UID};
-		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_USER_STATUS} = mergeStatuses $memberAttributes{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_USER_STATUS}, $memberAttributes{$A_USER_STATUS};
+		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_USER_STATUS} = mergeStatuses $memberAttributes{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_USER_STATUS}, $status;
 	}
 
 	foreach my $groupData (($rData->getChildElements)[0]->getChildElements) {

--- a/gen/fs_home_mu
+++ b/gen/fs_home_mu
@@ -48,6 +48,7 @@ our $A_USER_LOGIN;                 *A_USER_LOGIN =                   \'urn:perun
 our $A_UF_DATA_QUOTAS;             *A_UF_DATA_QUOTAS =               \'urn:perun:user_facility:attribute-def:virt:dataQuotas';
 our $A_UF_FILE_QUOTAS;             *A_UF_FILE_QUOTAS =               \'urn:perun:user_facility:attribute-def:virt:fileQuotas';
 our $A_USER_STATUS;                *A_USER_STATUS =                  \'urn:perun:member:attribute-def:core:status';
+our $A_MEMBER_IS_SUSPENDED;        *A_MEMBER_IS_SUSPENDED =          \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_HOME_MOUNTPOINT;            *A_HOME_MOUNTPOINT =              \'urn:perun:resource:attribute-def:def:fsHomeMountPoint';
 our $A_R_VOLUME;                   *A_R_VOLUME =                     \'urn:perun:resource:attribute-def:def:fsVolume';
 our $A_GID;                        *A_GID =                          \'urn:perun:resource:attribute-def:virt:unixGID';
@@ -94,6 +95,8 @@ foreach my $rData (@resourcesData) {
 	foreach my $mData (@membersData) {
 		my %memberAttributes = attributesToHash $mData->getAttributes;
 		my $login = $memberAttributes{$A_USER_LOGIN};
+		my $status = $memberAttributes{$A_USER_STATUS};
+		if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = "SUSPENDED"; }
 
 		unless(defined $dataForUserHomeByLogin->{$login}->{$volume}) { $dataForUserHomeByLogin->{$login}->{$volume} = {}; }
 		my $alreadyStoredMemberAttrByMount = $dataForUserHomeByLogin->{$login}->{$volume};
@@ -103,7 +106,7 @@ foreach my $rData (@resourcesData) {
 		$alreadyStoredMemberAttrByMount->{$A_USER_OPTIONAL_LOGIN} = $memberAttributes{$A_USER_OPTIONAL_LOGIN};
 		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_GID} = $resourceAttributes{$A_GID};
 		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_UID} = $memberAttributes{$A_UID};
-		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_USER_STATUS} = mergeStatuses $memberAttributes{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_USER_STATUS}, $memberAttributes{$A_USER_STATUS};
+		$alreadyStoredMemberAttrByMount->{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_USER_STATUS} = mergeStatuses $memberAttributes{$A_HOME_MOUNTPOINT}->{$resourceAttributes{$A_HOME_MOUNTPOINT}}->{$A_USER_STATUS}, $status;
 	}
 
 	foreach my $groupData (($rData->getChildElements)[0]->getChildElements) {

--- a/gen/fs_scratch
+++ b/gen/fs_scratch
@@ -37,6 +37,7 @@ our $A_SCRATCH_MOUNTPOINT;        *A_SCRATCH_MOUNTPOINT =        \'urn:perun:fac
 our $A_GID;                       *A_GID =                       \'urn:perun:user_facility:attribute-def:virt:defaultUnixGID';
 our $A_UID;                       *A_UID =                       \'urn:perun:user_facility:attribute-def:virt:UID';
 our $A_USER_STATUS;               *A_USER_STATUS =               \'urn:perun:member:attribute-def:core:status';
+our $A_MEMBER_IS_SUSPENDED;       *A_MEMBER_IS_SUSPENDED =       \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_F_SCRATCH_DIR_PERMISSIONS; *A_F_SCRATCH_DIR_PERMISSIONS = \'urn:perun:facility:attribute-def:def:scratchDirPermissions';
 
 my $memberAttributesByLogin= {};
@@ -54,9 +55,11 @@ foreach my $rData (@resourcesData) {
 	my @membersData = $rData->getChildElements;
 	foreach my $mData (@membersData) {
 		my %memberAttributes = attributesToHash $mData->getAttributes;
+		my $status = $memberAttributes{$A_USER_STATUS};
+		if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = "SUSPENDED"; }
 				
 		$memberAttributes{$A_SCRATCH_MOUNTPOINT} = $facilityAttributes{$A_SCRATCH_MOUNTPOINT};
-		$memberAttributes{$A_USER_STATUS} = mergeStatuses $memberAttributesByLogin->{$memberAttributes{$A_USER_LOGIN}}->{$A_USER_STATUS}, $memberAttributes{$A_USER_STATUS};
+		$memberAttributes{$A_USER_STATUS} = mergeStatuses $memberAttributesByLogin->{$memberAttributes{$A_USER_LOGIN}}->{$A_USER_STATUS}, $status;
 
 		#store to global structure
 		$memberAttributesByLogin->{$memberAttributes{$A_USER_LOGIN}} = \%memberAttributes;

--- a/gen/kypo_portal
+++ b/gen/kypo_portal
@@ -26,6 +26,7 @@ sub processMemberships;
 #Constants
 our $A_USER_ID;                   *A_USER_ID =               \'urn:perun:user:attribute-def:core:id';
 our $A_USER_STATUS;               *A_USER_STATUS =           \'urn:perun:member:attribute-def:core:status';
+our $A_MEMBER_IS_SUSPENDED;       *A_MEMBER_IS_SUSPENDED =   \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_USER_EMAIL;                *A_USER_EMAIL =            \'urn:perun:user:attribute-def:def:preferredMail';
 our $A_USER_D_NAME;               *A_USER_D_NAME =           \'urn:perun:user:attribute-def:core:displayName';
 our $A_USER_LF_NAME;              *A_USER_LF_NAME =          \'urn:perun:user:attribute-def:def:login-namespace:mu';
@@ -113,6 +114,7 @@ sub processUsers {
 	my %memberAttributes = attributesToHash $memberData->getAttributes;
 	my $uid = $memberAttributes{$A_USER_ID};
 	my $status = $memberAttributes{$A_USER_STATUS};
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
 	my $email = $memberAttributes{$A_USER_EMAIL};
 	my $d_name = $memberAttributes{$A_USER_D_NAME};
 	my $lf_name = $memberAttributes{$A_USER_LF_NAME};

--- a/gen/opennebula_egi
+++ b/gen/opennebula_egi
@@ -25,6 +25,7 @@ our $A_USER_ON_SSH_KEYS;           *A_USER_ON_SSH_KEYS =          \'urn:perun:us
 our $A_U_CERT_DNS;                 *A_U_CERT_DNS  =               \'urn:perun:user:attribute-def:virt:userCertDNs';
 our $A_U_KERBEROS_LOGINS;          *A_U_KERBEROS_LOGINS =         \'urn:perun:user:attribute-def:virt:kerberosLogins';
 our $A_M_STATUS;                   *A_M_STATUS =                  \'urn:perun:member:attribute-def:core:status';
+our $A_MEMBER_IS_SUSPENDED;        *A_MEMBER_IS_SUSPENDED =   \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_USER_LOGIN;                 *A_USER_LOGIN =                \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_U_F_BLACKLISTED;            *A_U_F_BLACKLISTED =           \'urn:perun:user_facility:attribute-def:virt:blacklisted';
 our $A_USER_FACILITY_UID;          *A_USER_FACILITY_UID =         \'urn:perun:user_facility:attribute-def:virt:UID';
@@ -101,6 +102,7 @@ sub processMemberData {
 	#set group specific settings (combination of roles on resource and roles on group)
 	#set validity in group (combination of specific statuses
 	my $newStatus = $memberAttributes{$A_M_STATUS};
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $newStatus = "SUSPENDED"; }
 	if(!defined ($dataByUser->{$login}->{"groups"}->{$groupName})) {
 		#it does not exists, create it and add everything new
 		$dataByUser->{$login}->{"groups"}->{$groupName}->{"name"} = $groupName;

--- a/gen/opennebula_meta
+++ b/gen/opennebula_meta
@@ -25,6 +25,7 @@ our $A_USER_ON_SSH_KEYS;           *A_USER_ON_SSH_KEYS =          \'urn:perun:us
 our $A_U_CERT_DNS;                 *A_U_CERT_DNS  =               \'urn:perun:user:attribute-def:virt:userCertDNs';
 our $A_U_KERBEROS_LOGINS;          *A_U_KERBEROS_LOGINS =         \'urn:perun:user:attribute-def:virt:kerberosLogins';
 our $A_M_STATUS;                   *A_M_STATUS =                  \'urn:perun:member:attribute-def:core:status';
+our $A_MEMBER_IS_SUSPENDED;        *A_MEMBER_IS_SUSPENDED =       \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_USER_LOGIN;                 *A_USER_LOGIN =                \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_U_F_BLACKLISTED;            *A_U_F_BLACKLISTED =           \'urn:perun:user_facility:attribute-def:virt:blacklisted';
 our $A_RESOURCE_ON_GROUP_NAME;     *A_RESOURCE_ON_GROUP_NAME =    \'urn:perun:resource:attribute-def:def:openNebulaGroupName';
@@ -94,6 +95,7 @@ sub processMemberData {
 	#set group specific settings (combination of roles on resource and roles on group)
 	#set validity in group (combination of specific statuses
 	my $newStatus = $memberAttributes{$A_M_STATUS};
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $newStatus = 'SUSPENDED'; }
 	if(!defined ($dataByUser->{$login}->{"groups"}->{$groupName})) {
 		#it does not exists, create it and add everything new
 		$dataByUser->{$login}->{"groups"}->{$groupName}->{"name"} = $groupName;

--- a/gen/operations_portal_egi
+++ b/gen/operations_portal_egi
@@ -20,7 +20,6 @@ our $A_USER_MAIL;                       *A_USER_MAIL =                    \'urn:
 our $A_R_VO_SHORT_NAME;                 *A_R_VO_SHORT_NAME =              \'urn:perun:resource:attribute-def:virt:voShortName';
 our $A_USER_STATUS;                     *A_USER_STATUS =                  \'urn:perun:member:attribute-def:core:status';
 
-our $STATUS_SUSPENDED;                  *STATUS_SUSPENDED =                 \'SUSPENDED';
 our $STATUS_VALID;                      *STATUS_VALID =                     \'VALID';
 
 my $service_file_name = "$DIRECTORY/$::SERVICE_NAME";
@@ -50,7 +49,7 @@ for my $rData (@resourcesData) {
 }
 
 foreach my $memberAttributes (sort $sortingFunction @membersAttributes) {
-	if ($memberAttributes->{$A_USER_STATUS} eq $STATUS_VALID || $memberAttributes->{$A_USER_STATUS} eq $STATUS_SUSPENDED) {
+	if ($memberAttributes->{$A_USER_STATUS} eq $STATUS_VALID) {
 		# Print attributes
 		if (defined $memberAttributes->{$A_USER_FIRST_NAME}) { print SERVICE_FILE $memberAttributes->{$A_USER_FIRST_NAME} . ','; }
 		else { print SERVICE_FILE ','; };

--- a/gen/pakiti
+++ b/gen/pakiti
@@ -29,6 +29,7 @@ our $A_USER_EMAIL;                *A_USER_EMAIL =               \'urn:perun:user
 our $A_USER_NAME;                 *A_USER_NAME =                \'urn:perun:user:attribute-def:core:displayName';
 our $A_USER_EPPNS;                *A_USER_EPPNS =               \'urn:perun:user:attribute-def:virt:eduPersonPrincipalNames';
 our $A_USER_STATUS;               *A_USER_STATUS =              \'urn:perun:member:attribute-def:core:status';
+our $A_MEMBER_IS_SUSPENDED;       *A_MEMBER_IS_SUSPENDED =      \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_RESOURCE_NAME;             *A_RESOURCE_NAME =            \'urn:perun:resource:attribute-def:core:name';
 our $A_RESOURCE_PAKITI_ADM;       *A_RESOURCE_PAKITI_ADM =      \'urn:perun:resource:attribute-def:def:isPakitiAdministrator';
 our $A_RESOURCE_PAKITI_INSTANCE;  *A_RESOURCE_PAKITI_INSTANCE = \'urn:perun:resource:attribute-def:def:pakitiInstance';
@@ -109,6 +110,7 @@ sub processUser {
 	my $displayName = $memberAttributes{$A_USER_NAME};
 	my $eppns = $memberAttributes{$A_USER_EPPNS};
 	my $status = $memberAttributes{$A_USER_STATUS};
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
 
 	if(!$userStruc->{$pakitiInstance}->{$uid}) {
 		$userStruc->{$pakitiInstance}->{$uid}->{$HEADER_EMAIL} = $email;

--- a/gen/passwd
+++ b/gen/passwd
@@ -26,6 +26,7 @@ our $A_USER_FACILITY_SHELL;                    *A_USER_FACILITY_SHELL =         
 our $A_USER_FIRST_NAME;                        *A_USER_FIRST_NAME =                       \'urn:perun:user:attribute-def:core:firstName';
 our $A_USER_LAST_NAME;                         *A_USER_LAST_NAME =                        \'urn:perun:user:attribute-def:core:lastName';
 our $A_USER_STATUS;                            *A_USER_STATUS =                           \'urn:perun:member:attribute-def:core:status';
+our $A_MEMBER_IS_SUSPENDED;                    *A_MEMBER_IS_SUSPENDED =                   \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_USER_EXPIRATION;                        *A_USER_EXPIRATION =                       \'urn:perun:member:attribute-def:def:membershipExpiration';
 our $A_R_VO_SHORT_NAME;                        *A_R_VO_SHORT_NAME =                       \'urn:perun:resource:attribute-def:virt:voShortName';
 
@@ -68,10 +69,12 @@ foreach my $rData (@resourcesData) {
 my %memberAttributesByLogin = ();
 foreach my $memberAttributes (@membersAttributes) {
 	my $login = $memberAttributes->{$A_USER_LOGIN};
+	my $status = $memberAttributes{$A_USER_STATUS};
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
 
 	#set $memberAttributes->{$A_USER_EXPIRATION} to number of days since epoch
 	#if member is not valid set expiration to 1
-	if($memberAttributes->{$A_USER_STATUS} eq $STATUS_VALID) {
+	if($status eq $STATUS_VALID) {
 		if(! $memberAttributes->{$A_USER_EXPIRATION}) {
 			$memberAttributes->{$A_USER_EXPIRATION} = "";
 		} else {
@@ -89,10 +92,10 @@ foreach my $memberAttributes (@membersAttributes) {
 
 		if($m->{$A_USER_STATUS} eq $STATUS_SUSPENDED) { next; } #member is suspended - no change allowed
 
-		if($memberAttributes->{$A_USER_STATUS} eq $STATUS_SUSPENDED) {
+		if($status eq $STATUS_SUSPENDED) {
 			$m->{$A_USER_STATUS} = $STATUS_SUSPENDED;
 			$m->{$A_USER_EXPIRATION} = 1;
-		} elsif($memberAttributes->{$A_USER_STATUS} eq $STATUS_VALID) {
+		} elsif($status eq $STATUS_VALID) {
 			$m->{$A_USER_STATUS} = $STATUS_VALID;
 			if($m->{$A_USER_EXPIRATION} eq "" || $memberAttributes->{$A_USER_EXPIRATION} eq "") {
 				$m->{$A_USER_EXPIRATION} = "";

--- a/gen/passwd_mu
+++ b/gen/passwd_mu
@@ -26,6 +26,7 @@ our $A_USER_FACILITY_SHELL;                    *A_USER_FACILITY_SHELL =         
 our $A_USER_FIRST_NAME;                        *A_USER_FIRST_NAME =                       \'urn:perun:user:attribute-def:core:firstName';
 our $A_USER_LAST_NAME;                         *A_USER_LAST_NAME =                        \'urn:perun:user:attribute-def:core:lastName';
 our $A_USER_STATUS;                            *A_USER_STATUS =                           \'urn:perun:member:attribute-def:core:status';
+our $A_MEMBER_IS_SUSPENDED;                    *A_MEMBER_IS_SUSPENDED =                   \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_USER_EXPIRATION;                        *A_USER_EXPIRATION =                       \'urn:perun:member:attribute-def:def:membershipExpiration';
 our $A_USER_OPTIONAL_LOGIN;                    *A_USER_OPTIONAL_LOGIN =                   \'urn:perun:user:attribute-def:virt:optionalLogin-namespace:mu';
 
@@ -71,10 +72,12 @@ foreach my $rData (@resourcesData) {
 my %memberAttributesByLogin = ();
 foreach my $memberAttributes (@membersAttributes) {
 	my $login = $memberAttributes->{$A_USER_LOGIN};
+	my $status = $memberAttributes{$A_USER_STATUS};
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
 
 	#set $memberAttributes->{$A_USER_EXPIRATION} to number of days since epoch
 	#if member is not valid set expiration to 1
-	if($memberAttributes->{$A_USER_STATUS} eq $STATUS_VALID) {
+	if($status eq $STATUS_VALID) {
 		if(! $memberAttributes->{$A_USER_EXPIRATION}) {
 			$memberAttributes->{$A_USER_EXPIRATION} = "";
 		} else {
@@ -92,10 +95,10 @@ foreach my $memberAttributes (@membersAttributes) {
 
 		if($m->{$A_USER_STATUS} eq $STATUS_SUSPENDED) { next; } #member is suspended - no change allowed
 
-		if($memberAttributes->{$A_USER_STATUS} eq $STATUS_SUSPENDED) {
+		if($status eq $STATUS_SUSPENDED) {
 			$m->{$A_USER_STATUS} = $STATUS_SUSPENDED;
 			$m->{$A_USER_EXPIRATION} = 1;
-		} elsif($memberAttributes->{$A_USER_STATUS} eq $STATUS_VALID) {
+		} elsif($status eq $STATUS_VALID) {
 			$m->{$A_USER_STATUS} = $STATUS_VALID;
 			if($m->{$A_USER_EXPIRATION} eq "" || $memberAttributes->{$A_USER_EXPIRATION} eq "") {
 				$m->{$A_USER_EXPIRATION} = "";

--- a/gen/scim
+++ b/gen/scim
@@ -26,6 +26,7 @@ sub processMemberships;
 #Constants
 our $A_USER_ID;                   *A_USER_ID =               \'urn:perun:user:attribute-def:core:id';
 our $A_USER_STATUS;               *A_USER_STATUS =           \'urn:perun:member:attribute-def:core:status';
+our $A_MEMBER_IS_SUSPENDED;       *A_MEMBER_IS_SUSPENDED =   \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_USER_EMAIL;                *A_USER_EMAIL =            \'urn:perun:user:attribute-def:def:preferredMail';
 our $A_USER_LOGIN;                *A_USER_LOGIN =            \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_USER_D_NAME;               *A_USER_D_NAME =           \'urn:perun:user:attribute-def:core:displayName';
@@ -116,6 +117,7 @@ sub processUsers {
         my %memberAttributes = attributesToHash $memberData->getAttributes;
         my $uid = $memberAttributes{$A_USER_ID};
         my $status = $memberAttributes{$A_USER_STATUS};
+        if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
         my $email = $memberAttributes{$A_USER_EMAIL};
         my $d_name = $memberAttributes{$A_USER_D_NAME};
         my $login = $memberAttributes{$A_USER_LOGIN};

--- a/gen/users_export
+++ b/gen/users_export
@@ -20,7 +20,6 @@ our $A_USER_ORG;                        *A_USER_ORG =                       \'ur
 our $A_USER_STATUS;                     *A_USER_STATUS =                    \'urn:perun:member:attribute-def:core:status';
 our $A_R_VO_SHORT_NAME;                 *A_R_VO_SHORT_NAME =                \'urn:perun:resource:attribute-def:virt:voShortName';
 
-our $STATUS_SUSPENDED;                  *STATUS_SUSPENDED =                 \'SUSPENDED';
 our $STATUS_VALID;                      *STATUS_VALID =                     \'VALID';
 
 my $service_file_name = "$DIRECTORY/$::SERVICE_NAME";
@@ -50,7 +49,7 @@ for my $rData (@resourcesData) {
 }
 
 foreach my $memberAttributes (sort $sortingFunction @membersAttributes) {
-	if ($memberAttributes->{$A_USER_STATUS} eq $STATUS_VALID || $memberAttributes->{$A_USER_STATUS} eq $STATUS_SUSPENDED) {
+	if ($memberAttributes->{$A_USER_STATUS} eq $STATUS_VALID) {
 		# Print attributes
 		print SERVICE_FILE $memberAttributes->{$A_R_VO_SHORT_NAME} . ',';
 		print SERVICE_FILE $memberAttributes->{$A_USER_LOGIN} . ',';


### PR DESCRIPTION
     - when member is VALID + newly suspended = SUSPENDED
     - when member is EXPIRED + newly suspended = SUSPENDED
     - replace where needed
     - remove where not needed any more
    
    DEPLOYMENT:
     - virtual attribute need to be added to every affected service manualy
     for every instance where services exists
