### PR TITLE
Changes in service 'rt'

### DIFF
--- a/gen/rt
+++ b/gen/rt
@@ -9,7 +9,7 @@ use utf8;
 binmode STDOUT, ":utf8";
 
 our $SERVICE_NAME = basename($0);
-our $PROTOCOL_VERSION = "3.0.0";
+our $PROTOCOL_VERSION = "3.1.0";
 my $SCRIPT_VERSION = "3.0.0";
 
 perunServicesInit::init;
@@ -27,6 +27,7 @@ our $A_USER_ORGANIZATION;       *A_USER_ORGANIZATION =         \'urn:perun:user:
 our $A_MEMBER_STATUS;           *A_MEMBER_STATUS =             \'urn:perun:member:attribute-def:core:status';
 our $A_RES_NAME;                *A_RES_NAME =                  \'urn:perun:resource:attribute-def:core:name';
 our $A_RES_RT_GROUP_NAME;       *A_RES_RT_GROUP_NAME =         \'urn:perun:resource:attribute-def:def:rtGroupName';
+our $A_FAC_OUTPUT_FILE_NAME;    *A_FAC_OUTPUT_FILE_NAME =      \'urn:perun:facility:attribute-def:def:rtOutputFileName';
 
 our $STATUS_VALID;              *STATUS_VALID =                \'VALID';
 
@@ -42,10 +43,14 @@ our $EINFRA_DOMAIN = '@einfra.cesnet.cz';
 our $META_DOMAIN   = '@meta.cesnet.cz';
 
 my $service_file_name = "$DIRECTORY/$::SERVICE_NAME";
+my $file_with_output_file_name = "$DIRECTORY/output_file_name";
 
 my $usersStructureByUserId = {};
 
 #####################################
+
+my %facilityAttributes = attributesToHash $data->getAttributes;
+my $output_file_name = $facilityAttributes{$A_FAC_OUTPUT_FILE_NAME} || 'rt-data';
 
 my @resourcesData = $data->getChildElements; 
 foreach my $rData (@resourcesData) {
@@ -97,7 +102,13 @@ foreach my $rData (@resourcesData) {
 	}
 }
 
-####### output file ######################
+####### FILE WITH NAME OF THE OUTPUT FILE ######
+open NAME_FILE,">$file_with_output_file_name" or die "Cannot open $file_with_output_file_name: $! \n";
+binmode NAME_FILE, ":utf8";
+print NAME_FILE $output_file_name;
+close(NAME_FILE);
+
+####### FILE WITH DATA FOR OUTPUT FILE ######
 open SERVICE_FILE,">$service_file_name" or die "Cannot open $service_file_name: $! \n";
 binmode SERVICE_FILE, ":utf8";
 

--- a/slave/process-rt/bin/process-rt.sh
+++ b/slave/process-rt/bin/process-rt.sh
@@ -1,24 +1,30 @@
 #!/bin/bash
 
-PROTOCOL_VERSION='3.0.0'
-
+PROTOCOL_VERSION='3.1.0'
 
 function process {
-	DST_FILE="/tmp/rt-data"
+	DST_DIR="/tmp/"
 
 	### Status codes
 	I_CHANGED=(0 "${DST_FILE} updated")
 	E_NOT_CHANGE=(50 'Cannot copy file ${FROM_PERUN} to ${DST_FILE}')
+	E_FILE_NOT_EXIST=(51 'Cannot find file with destination file name in ${NAME_FILE}')
 
 	FROM_PERUN="${WORK_DIR}/rt"
+	NAME_FILE="${WORK_DIR}/output_file_name"
+
+	if [ ! -s "$NAME_FILE" ]; then
+		log_msg E_FILE_NOT_EXIST
+	fi
+	DST_FILE=`cat $NAME_FILE`
 
 	create_lock
 
-	cp "${FROM_PERUN}" "${DST_FILE}"
+	cp "${FROM_PERUN}" "${DST_DIR}/${DST_FILE}"
 
 	if [ $? -eq 0 ]; then
 		log_msg I_CHANGED
 	else
-		log_msg I_NOT_CHANGED
+		log_msg E_NOT_CHANGED
 	fi
 }

--- a/slave/process-rt/changelog
+++ b/slave/process-rt/changelog
@@ -1,5 +1,14 @@
+perun-slave-process-rt (3.1.2) stable; urgency=low
+
+  * Support changing of the output-file name. We are still using the same
+    directory '/tmp/' but the name of the file can be now changed by facility
+    attribute in Perun.
+  * protocol version was increased
+
+ -- Michal Stava <stavamichal@gmail.com>  Fri, 09 Aug 2019 08:49:00 +0200
+
 perun-slave-process-rt (3.1.1) stable; urgency=low
 
   * New package version for perun-slave-process-rt
 
- -- Michal Stava <stavamichal@gmail.com>  Wed, 31 Jul 2019 14:22:00 +0100
+ -- Michal Stava <stavamichal@gmail.com>  Wed, 31 Jul 2019 14:22:00 +0200


### PR DESCRIPTION
 - new funcionality for changing name of output file was added
 - the name of output file is now part of the service set to the
 specific file 'output_file_name', then read from this file and used for
 saving file with data to '/tmp/{fileName}' location. Default is still
 '/tmp/rt-data' if the facility attribute with file name is empty.
 - protocol version was increased
 - timestamp in changelog was fixed