### PR TITLE
Changes in service rt_bbmri

### DIFF
--- a/gen/rt_bbmri
+++ b/gen/rt_bbmri
@@ -1,12 +1,81 @@
 #!/usr/bin/perl
-
 use strict;
 use warnings;
+use perunServicesInit;
+use perunServicesUtils;
 use File::Basename;
-use perunDataGenerator;
+use JSON::XS;
 
-local $::SERVICE_NAME = basename($0);
-local $::PROTOCOL_VERSION = "3.0.0";
+our $SERVICE_NAME = basename($0);
+our $PROTOCOL_VERSION = "3.1.0";
+my $SCRIPT_VERSION = "3.0.0";
 
-perunDataGenerator::generateUsersDataInJSON;
+perunServicesInit::init;
+my $DIRECTORY = perunServicesInit::getDirectory;
+my $data = perunServicesInit::getHierarchicalData;
 
+#Constants
+our $A_USER_ID;                 *A_USER_ID =                   \'urn:perun:user:attribute-def:core:id';
+our $A_USER_LOGIN_BBMRI;        *A_USER_LOGIN_BBMRI =          \'urn:perun:user:attribute-def:def:login-namespace:bbmri';
+our $A_USER_PREFERRED_MAIL;     *A_USER_PREFERRED_MAIL =       \'urn:perun:user:attribute-def:def:preferredMail';
+our $A_USER_RT_PREF_MAIL;       *A_USER_RT_PREF_MAIL =         \'urn:perun:user:attribute-def:def:rtPreferredMail';
+our $A_USER_LAST_NAME;          *A_USER_LAST_NAME =            \'urn:perun:user:attribute-def:core:lastName';
+our $A_RES_NAME;                *A_RES_NAME =                  \'urn:perun:resource:attribute-def:core:name';
+our $A_RES_RT_GROUP_NAME;       *A_RES_RT_GROUP_NAME =         \'urn:perun:resource:attribute-def:def:rtGroupName';
+our $A_FAC_OUTPUT_FILE_NAME;    *A_FAC_OUTPUT_FILE_NAME =      \'urn:perun:facility:attribute-def:def:rtOutputFileName';
+
+#Headers
+our $LOGIN_HEADER = 'login';
+our $PREF_MAIL_HEADER = 'preferredMail';
+our $LAST_NAME_HEADER = 'lastName';
+our $GROUPS_IN_RT_HEADER = 'groupsInRT';
+
+my $service_file_name = "$DIRECTORY/$::SERVICE_NAME";
+my $file_with_output_file_name = "$DIRECTORY/output_file_name";
+
+my $usersStructureByUserId = {};
+
+#####################################
+
+my %facilityAttributes = attributesToHash $data->getAttributes;
+my $output_file_name = $facilityAttributes{$A_FAC_OUTPUT_FILE_NAME} || 'rt-bbmri-data';
+
+my @resourcesData = $data->getChildElements; 
+foreach my $rData (@resourcesData) {
+	my %resourceAttributes  = attributesToHash $rData->getAttributes;
+	
+	my $rtGroupName = $resourceAttributes{$A_RES_RT_GROUP_NAME} || $resourceAttributes{$A_RES_NAME} ;
+
+	my @membersData = $rData->getChildElements;
+	foreach my $memberAttributes (dataToAttributesHashes @membersData) {
+
+		my $userId = $memberAttributes->{$A_USER_ID};
+		unless(defined $usersStructureByUserId->{$userId}) {
+			my $login = $memberAttributes->{$A_USER_LOGIN_BBMRI};
+			my $userPrefMail = $memberAttributes->{$A_USER_RT_PREF_MAIL} || $memberAttributes->{$A_USER_PREFERRED_MAIL};
+			my $lastName = $memberAttributes->{$A_USER_LAST_NAME};
+
+			$usersStructureByUserId->{$userId}->{$PREF_MAIL_HEADER} = $userPrefMail;
+			$usersStructureByUserId->{$userId}->{$LAST_NAME_HEADER} = $lastName;
+			$usersStructureByUserId->{$userId}->{$LOGIN_HEADER} = $login;
+			$usersStructureByUserId->{$userId}->{$GROUPS_IN_RT_HEADER} = ();
+		}
+		
+		my @listOfRTGroups = uniqList((@{$usersStructureByUserId->{$userId}->{$GROUPS_IN_RT_HEADER}},  $rtGroupName));
+		$usersStructureByUserId->{$userId}->{$GROUPS_IN_RT_HEADER} = \@listOfRTGroups;
+	}
+}
+
+####### FILE WITH NAME OF THE OUTPUT FILE ######
+open NAME_FILE,">$file_with_output_file_name" or die "Cannot open $file_with_output_file_name: $! \n";
+binmode NAME_FILE, ":utf8";
+print NAME_FILE $output_file_name;
+close(NAME_FILE);
+
+my @users = values %$usersStructureByUserId;
+####### FILE WITH JSON DATA FOR OUTPUT FILE ######
+open SERVICE_FILE,">$service_file_name" or die "Cannot open $service_file_name: $! \n";
+print SERVICE_FILE JSON::XS->new->utf8->pretty->encode(\@users);
+close(SERVICE_FILE) or die "Cannot close $service_file_name: $! \n";
+
+perunServicesInit::finalize;

--- a/slave/process-rt-bbmri/bin/process-rt_bbmri.sh
+++ b/slave/process-rt-bbmri/bin/process-rt_bbmri.sh
@@ -1,24 +1,30 @@
 #!/bin/bash
 
-PROTOCOL_VERSION='3.0.0'
-
+PROTOCOL_VERSION='3.1.0'
 
 function process {
-	DST_FILE="/tmp/rt-bbmri-data"
+	DST_DIR="/tmp/"
 
 	### Status codes
 	I_CHANGED=(0 "${DST_FILE} updated")
 	E_NOT_CHANGE=(50 'Cannot copy file ${FROM_PERUN} to ${DST_FILE}')
+	E_FILE_NOT_EXIST=(51 'Cannot find file with destination file name in ${NAME_FILE}')
 
 	FROM_PERUN="${WORK_DIR}/rt_bbmri"
+	NAME_FILE="${WORK_DIR}/output_file_name"
+
+	if [ ! -s "$NAME_FILE" ]; then
+		log_msg E_FILE_NOT_EXIST
+	fi
+	DST_FILE=`cat $NAME_FILE`
 
 	create_lock
 
-	cp "${FROM_PERUN}" "${DST_FILE}"
+	cp "${FROM_PERUN}" "${DST_DIR}/${DST_FILE}"
 
 	if [ $? -eq 0 ]; then
 		log_msg I_CHANGED
 	else
-		log_msg I_NOT_CHANGED
+		log_msg E_NOT_CHANGED
 	fi
 }

--- a/slave/process-rt-bbmri/changelog
+++ b/slave/process-rt-bbmri/changelog
@@ -1,3 +1,16 @@
+perun-slave-process-rt-bbmri (3.1.2) stable; urgency=high
+
+  * Change of data format. It is still JSON but entities has name without the
+    base part "urn:perun..." and there can be other entities than just user or
+    user-facility
+  * new attribute in json: groupsInRT (list of all resources, where user is
+    assigned in by any of his groups)
+  * the output file name can be now changed by the facility attribute
+    "rtOutputFileName" in Perun
+  * Protocol version was increased
+
+ -- Michal Stava <stavamichal@gmail.com>  Fri, 13 Sep 2019 12:45:00 +0200
+
 perun-slave-process-rt-bbmri (3.1.1) stable; urgency=low
 
   * New package version for perun-slave-process-rt-bbmri


### PR DESCRIPTION
 - concept of generating data was changed from automatic data generator
   to manual processing. This will add way how to process other than
   user specific attributes.
 - names of attributes are no more generated by automatic so they were
 changed from original (standard urn part was removed)
 - new information about resources where use is assigned was added
 - the name of output file can be set by the facility attribute
 rtOutputFileName and it is optional
 - slave script was also changed to support new funcionality
 - protocol version was changed