### PR TITLE
Changes in perun_propagate

### DIFF
--- a/other/perun-propagate/debian/changelog
+++ b/other/perun-propagate/debian/changelog
@@ -1,3 +1,15 @@
+perun-propagate (3.0.6) stable; urgency=low
+
+  * add two new options for perun_propagate script, both are optional
+  * first option is "-n" or "--notPropagate" which will skip all
+    propagations if needed for any reason
+  * second option is "-u" or "--unblockDestinations" which will unblock all
+    services for server destination
+  * options can be set by using variable OPTIONS="" in
+    /etc/default/perun_propagate file for every affected server
+
+ -- Michal Stava <stavamichal@gmail.com>  Wed, 16 Oct 2019 14:40:00 +0200
+
 perun-propagate (3.0.5) stable; urgency=low
 
   * add perun_propagate while instalation to initialization after system

--- a/other/perun-propagate/etc/perun_propagate
+++ b/other/perun-propagate/etc/perun_propagate
@@ -16,6 +16,8 @@ KEYTAB=/etc/krb5.keytab
 NAME=perun-propagate
 DESC="Perun propagation"
 PERUN_SERVER='perun.ics.muni.cz'
+#Default options for perun propagate scipt are empty, they can be set in script defaults
+OPTIONS=""
 #Timeout in seconds
 TIMEOUT=120
 LOG=/var/log/$NAME
@@ -98,7 +100,7 @@ perun_propagate_start() {
 		fi
 		TMP_ERROR=`mktemp --tmpdir=/tmp/ perun-propagate.XXXXXXXXX`
 		add_on_exit "rm -f ${TMP_ERROR}"
-		remctl "${PERUN_SERVER}" perun propagate 2>&1 | tee ${TMP_ERROR} | sed "s;^;$LINE:;" | ts >> ${LOG} &
+		remctl "${PERUN_SERVER}" perun propagate "${OPTIONS}" 2>&1 | tee ${TMP_ERROR} | sed "s;^;$LINE:;" | ts >> ${LOG} &
 		PID=$!
 		PID_ARRAY[$ITERATOR]=$PID
 		TMP_ERROR_ARRAY[$ITERATOR]=$TMP_ERROR


### PR DESCRIPTION
 - two new options for perun_propagate script were added, they are both
 optional
 - first option "-n" or "--notPropagate" will prevent propagation of all
 services, this is useful for example for testing purposes
 - second option "-u" or "--unblockDestinations" will unblock all
 services for destination of the server
 - these changes must be also supported on the server site
 - options can be set by using variable OPTIONS="" in
 /etc/default/perun_propagate file for every affected server