### PR TITLE
Detect duplicities in drupal elixir service

### DIFF
--- a/gen/drupal_elixir
+++ b/gen/drupal_elixir
@@ -52,6 +52,8 @@ our $g_type = {};
 our $g_parent_id = {};
 
 our $membershipStruc = {};
+our $usedEmailsStruc = {};
+our $errorInDuplicity;
 
 my $fileUsers = $DIRECTORY . "users.csv";
 my $fileGroups = $DIRECTORY . "groups.csv";
@@ -66,6 +68,9 @@ foreach my $resourceData ($data->getChildElements) {
 		my $groupMembersLogins = processGroups $groupData;
 	}
 }
+
+#duplicities in emails are not allowed
+if($errorInDuplicity) { die "ERROR: There are some duplicities in emails:\n" . $errorInDuplicity; }
 
 # USERS: user_id login status e-mail display_name
 open FILE_USERS,">$fileUsers" or die "Cannot open $fileUsers: $! \n";
@@ -142,11 +147,17 @@ sub processUsers {
 			# change from SUSPENDED to EXPIRED
 			$userStruc->{$uid}->{$u_status} = $status;
 		}
-	}
-	else{
+	} else {
 		$userStruc->{$uid}->{$u_login} = $login;
 		$userStruc->{$uid}->{$u_status} = $status;
 		$userStruc->{$uid}->{$u_email} = $email;
+		#duplicity of two different users in email is not allowed
+		my $lowerCaseEmail = lc($email);
+		if($usedEmailsStruc->{$lowerCaseEmail}) {
+			$errorInDuplicity .= "Users with logins '$login' and '" . $usedEmailsStruc->{$lowerCaseEmail} . "' have same email '$email'\n";
+		} else {
+			$usedEmailsStruc->{$lowerCaseEmail}= $login;
+		}
 		$userStruc->{$uid}->{$u_name} = $d_name;
 		$userStruc->{$uid}->{$u_eppn} = $eppn;
 	}


### PR DESCRIPTION
 - when generating data for drupal_elixir service, we need to detect
   situations, where two or more users with different logins has the
   same email (in lower-case format). In such situation, we want to find
   all duplicities, print them as an error and end gen script with an error.