### PR TITLE
New service o365_mail_forward_export

### DIFF
--- a/gen/o365_mail_forward_export
+++ b/gen/o365_mail_forward_export
@@ -1,0 +1,78 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use perunServicesInit;
+use perunServicesUtils;
+use Data::Dumper;
+
+local $::SERVICE_NAME = "o365_mail_forward_export";
+local $::PROTOCOL_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.0";
+
+perunServicesInit::init;
+my $DIRECTORY = perunServicesInit::getDirectory;
+my $data = perunServicesInit::getHierarchicalData;
+
+#Constants
+our $A_MEMBER_O365_EMAIL_ADDRESSES_MU;     *A_MEMBER_O365_EMAIL_ADDRESSES_MU =     \'urn:perun:member:attribute-def:def:o365EmailAddresses:mu';
+our $A_USER_FACILITY_LOGIN;                *A_USER_FACILITY_LOGIN =                \'urn:perun:user_facility:attribute-def:virt:login';
+our $A_USER_FACILITY_MAIL_FORWARD;         *A_USER_FACILITY_MAIL_FORWARD =         \'urn:perun:user_facility:attribute-def:def:o365MailForward';
+our $A_USER_FACILITY_DISABLE_MAIL_FORWARD; *A_USER_FACILITY_DISABLE_MAIL_FORWARD = \'urn:perun:user_facility:attribute-def:def:disableO365MailForward';
+our $A_FACILITY_FORWARD_EXPORT_DOMAINS;    *A_FACILITY_FORWARD_EXPORT_DOMAINS =    \'urn:perun:facility:attribute-def:def:o365MailForwardExportDomains';
+
+our $DEFAULT_FORWARDING_DOMAIN = '@mo.muni.cz';
+our $userStruc = {};
+
+my %facilityAttributes = attributesToHash $data->getAttributes;
+my %allowedForwardDomains = map { $_ => 1 } @{$facilityAttributes{$A_FACILITY_FORWARD_EXPORT_DOMAINS}};
+
+#go through all resources
+my @resourcesData = $data->getChildElements;
+foreach my $resourceData (@resourcesData) {
+	
+	my @membersData = $resourceData->getChildElements;
+	foreach my $memberData (@membersData) {
+		my %memberAttributes = attributesToHash $memberData->getAttributes;
+
+		#skip this user if disabled forward is set to true
+		next if $memberAttributes{$A_USER_FACILITY_DISABLE_MAIL_FORWARD};
+
+		#login in MU is UCO
+		my $login = $memberAttributes{$A_USER_FACILITY_LOGIN};
+
+		#mailForward is unique for the same login, don't need to be loaded more than once
+		unless ($userStruc->{$login}) {
+			my $mailForward = $memberAttributes{$A_USER_FACILITY_MAIL_FORWARD} || $login . $DEFAULT_FORWARDING_DOMAIN;
+			$userStruc->{$login}->{$A_USER_FACILITY_MAIL_FORWARD} = $mailForward;
+
+		}
+
+		#members email addresses - for more members with same login can differ
+		my @memberEmailAddresses = @{$memberAttributes{$A_MEMBER_O365_EMAIL_ADDRESSES_MU}};
+		#filter only allowed email addresses
+		foreach my $mail (@memberEmailAddresses) {
+			my $domainOfEmail = $mail;
+			$domainOfEmail =~ s/^.*@//;
+			#this email is in allowed domain, add it
+			if($allowedForwardDomains{$domainOfEmail}) {
+				$userStruc->{$login}->{$A_MEMBER_O365_EMAIL_ADDRESSES_MU}->{$mail} = 1;
+			}
+		}
+	} 
+}
+
+my $fileName = "$DIRECTORY/$::SERVICE_NAME";
+open FILE,">$fileName" or die "Cannot open $fileName: $! \n";
+
+#	$email $forward
+foreach my $login (sort keys %$userStruc) {
+	next unless $userStruc->{$login}->{$A_MEMBER_O365_EMAIL_ADDRESSES_MU};
+	my $mailForward = $userStruc->{$login}->{$A_USER_FACILITY_MAIL_FORWARD};
+	foreach my $email (sort keys %{$userStruc->{$login}->{$A_MEMBER_O365_EMAIL_ADDRESSES_MU}}) {
+		print FILE $email, " ", $mailForward, "\n";
+	}
+}
+
+close (FILE);
+perunServicesInit::finalize;

--- a/send/o365_mail_forward_export
+++ b/send/o365_mail_forward_export
@@ -1,0 +1,4 @@
+#!/bin/bash
+SERVICE_NAME="o365_mail_forward_export"
+
+. generic_send

--- a/slave/process-o365-mail-forward-export/bin/process-o365_mail_forward_export.sh
+++ b/slave/process-o365-mail-forward-export/bin/process-o365_mail_forward_export.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+PROTOCOL_VERSION='3.0.0'
+
+
+function process {
+	
+	DST_FILE="/etc/mail/perun/muni"
+	FROM_PERUN="${WORK_DIR}/o365_mail_forward_export"
+
+	### Status codes
+	I_CHANGED=(0 "${DST_FILE} updated")
+	I_NOT_CHANGED=(0 "${DST_FILE} has not changed")
+	E_DOALIASES=(50 '/etc/mail/doaliases ended with an error')
+
+	create_lock
+
+	#move file if there was any change in it
+	diff_mv_sync "${FROM_PERUN}" "${DST_FILE}"
+
+	if [ $? -eq 0 ]; then
+		log_msg I_CHANGED
+		#if file have changed, reload aliases
+		catch_error E_DOALIASES /etc/mail/doaliases -p
+	else
+		#if file have not changed, do nothing
+		log_msg I_NOT_CHANGED
+	fi
+}

--- a/slave/process-o365-mail-forward-export/changelog
+++ b/slave/process-o365-mail-forward-export/changelog
@@ -1,0 +1,6 @@
+perun-slave-process-o365-mail-forward-export (3.1.1) stable; urgency=low
+
+  * New package for service o365-mail-forward-export
+  * Purpose of this service is pre-loading forwarding rules for o365
+
+ -- Michal Stava <stavamichal@gmail.com>  Fri, 29 Nov 2019 10:10:00 +0100

--- a/slave/process-o365-mail-forward-export/dependencies
+++ b/slave/process-o365-mail-forward-export/dependencies
@@ -1,0 +1,1 @@
+perun-slave-base

--- a/slave/process-o365-mail-forward-export/rpm.dependencies
+++ b/slave/process-o365-mail-forward-export/rpm.dependencies
@@ -1,0 +1,1 @@
+perun-slave-base

--- a/slave/process-o365-mail-forward-export/short_desc
+++ b/slave/process-o365-mail-forward-export/short_desc
@@ -1,0 +1,1 @@
+Package for perun service - o365_mail_forward_export


### PR DESCRIPTION
 - purpose of this service is pre-loading forwarding rules for users in
 o365 service (it can be done faster than waiting for o365_mu service
 to load all data together)
 - gen, send and slave were created for this service