### PR TITLE
Fix new line in gen script for fs_scratch_local

### DIFF
--- a/gen/fs_scratch_local
+++ b/gen/fs_scratch_local
@@ -45,7 +45,7 @@ foreach my $rData (@resourcesData) {
 		# Print attributes
 		print SERVICE_FILE $memberAttributes{$A_USER_LOGIN} . "\t";
 		print SERVICE_FILE $memberAttributes{$A_UID} . "\t";
-		print SERVICE_FILE $memberAttributes{$A_GID} . "\t";
+		print SERVICE_FILE $memberAttributes{$A_GID} . "\n";
 	}
 }
 


### PR DESCRIPTION
 - there must be new line for every record generated by this gen script
 (by typo in the last change of this script was removed)