### PR TITLE
LDAP request changes

### DIFF
--- a/send/ad_group
+++ b/send/ad_group
@@ -46,8 +46,8 @@ my $lock = ScriptLock->new($facility_name . "_" . $service_name . "_" . $namespa
 
 # init configuration
 my @conf = init_config($namespace);
-my $ldap_location = resolve_pdc($conf[0]);
-my $ldap = ldap_connect($ldap_location);
+my @ldap_locations = resolve_domain_controlers($conf[0]);
+my $ldap = ldap_connect_multiple_options(\@ldap_locations);
 my $filter = '(objectClass=group)';
 
 # connect

--- a/send/ad_group_mu_ucn
+++ b/send/ad_group_mu_ucn
@@ -66,8 +66,8 @@ my $lock = ScriptLock->new($facility_name . "_" . $service_name . "_" . $namespa
 
 # init configuration
 my @conf = init_config($namespace);
-my $ldap_location = resolve_pdc($conf[0]);
-my $ldap = ldap_connect($ldap_location);
+my @ldap_locations = resolve_domain_controlers($conf[0]);
+my $ldap = ldap_connect_multiple_options(\@ldap_locations);
 my $filter = '(objectClass=group)';
 
 # connect

--- a/send/ad_mu
+++ b/send/ad_mu
@@ -377,8 +377,8 @@ $lockManager->lock($errorLockFile) || die "There were an error in previous run. 
 
 # init configuration
 my @conf = init_config($namespace);
-my $ldap_location = resolve_pdc($conf[0]);
-my $ldap = ldap_connect($ldap_location);
+my @ldap_locations = resolve_domain_controlers($conf[0]);
+my $ldap = ldap_connect_multiple_options(\@ldap_locations);
 
 # bind
 ldap_bind($ldap, $conf[1], $conf[2]);

--- a/send/ad_user_mu
+++ b/send/ad_user_mu
@@ -52,8 +52,8 @@ my $lock = ScriptLock->new($facility_name . "_" . $service_name . "_" . $namespa
 
 # init configuration
 my @conf = init_config($namespace);
-my $ldap_location = resolve_pdc($conf[0]);
-my $ldap = ldap_connect($ldap_location);
+my @ldap_locations = resolve_domain_controlers($conf[0]);
+my $ldap = ldap_connect_multiple_options(\@ldap_locations);
 my $filter = '(objectClass=person)';
 
 # connect

--- a/send/ad_user_mu_ucn
+++ b/send/ad_user_mu_ucn
@@ -46,8 +46,8 @@ my $lock = ScriptLock->new($facility_name . "_" . $service_name . "_" . $namespa
 
 # init configuration
 my @conf = init_config($namespace);
-my $ldap_location = resolve_pdc($conf[0]);
-my $ldap = ldap_connect($ldap_location);
+my @ldap_locations = resolve_domain_controlers($conf[0]);
+my $ldap = ldap_connect_multiple_options(\@ldap_locations);
 my $filter = '(&(objectClass=person)(cn=9*))'; # this will minimize loaded users but still can contain normal UČO users !
 
 # connect


### PR DESCRIPTION
- Added new functionality resolve_domain_controlers to ADConnector.pm,
  which resolve all available domain controlers from a hostname.
  Added also method ldap_connect_multiple_options which try to connect
  to the first available controler from the list of controlers.
- Updated services for this functionality used in MUNI AD.
  ad_ceitec is set up manually and vsup services cannot be updated yet because,
  the NET::DNS::Resolver perl module need to be installed on the server first.