### PR TITLE
Removed loa and expiration handling from mailman_cesnet/meta

### DIFF
--- a/gen/mailman_cesnet
+++ b/gen/mailman_cesnet
@@ -9,7 +9,7 @@ use warnings;
 use perunServicesInit;
 use perunServicesUtils;
 use Text::Unidecode;
-use POSIX qw/strftime/; 
+use POSIX qw/strftime/;
 use Data::Dumper;
 
 local $::SERVICE_NAME = "mailman_cesnet";
@@ -26,14 +26,14 @@ our $A_USER_MAIL;                            *A_USER_MAIL =                     
 our $A_USER_LANG;                            *A_USER_LANG =                             \'urn:perun:user:attribute-def:def:preferredLanguage';
 our $A_USER_STATUS;                          *A_USER_STATUS =                           \'urn:perun:member:attribute-def:core:status';
 our $A_USER_EXPIRES;                         *A_USER_EXPIRES =                          \'urn:perun:member:attribute-def:def:membershipExpiration';
-our $A_USER_LOA;                             *A_USER_LOA =                              \'urn:perun:member:attribute-def:virt:loa';
+our $A_USER_LOA;                             *A_USER_LOA =                              \'urn:perun:user:attribute-def:virt:loa';
 our $A_USER_OPT_OUT;                         *A_USER_OPT_OUT =                          \'urn:perun:member_resource:attribute-def:def:optOutMailingList';
 
 our $A_RESOURCE_MAILING_LIST_NAME;           *A_RESOURCE_MAILING_LIST_NAME =            \'urn:perun:resource:attribute-def:def:mailingListName';
 our $A_RESOURCE_MAILING_LIST_VARIANTS;			 *A_RESOURCE_MAILING_LIST_VARIANTS =        \'urn:perun:resource:attribute-def:def:mailingListUsesLangVariants'; # true for -cs and -en variants
 our $A_RESOURCE_MAILING_LIST_NONVALID_USERS; *A_RESOURCE_MAILING_LIST_NONVALID_USERS =  \'urn:perun:resource:attribute-def:def:mailingListAllowInvalidUsers'; # true to allow users with status other than VALID
 
-my $mailinglistStruc = {};  # $mailinglistStruc->{"mailing list name including lang"}->{"user's e-mail"}->{A_USER_*} 
+my $mailinglistStruc = {};  # $mailinglistStruc->{"mailing list name including lang"}->{"user's e-mail"}->{A_USER_*}
 
 my $mailinglistsDirectory = "$DIRECTORY/mailinglists";
 mkdir $mailinglistsDirectory or die "Can't mkdir $mailinglistsDirectory: $!";

--- a/gen/mailman_cesnet
+++ b/gen/mailman_cesnet
@@ -13,8 +13,8 @@ use POSIX qw/strftime/;
 use Data::Dumper;
 
 local $::SERVICE_NAME = "mailman_cesnet";
-local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+local $::PROTOCOL_VERSION = "3.0.1";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
@@ -25,12 +25,10 @@ our $A_USER_NAME;                            *A_USER_NAME =                     
 our $A_USER_MAIL;                            *A_USER_MAIL =                             \'urn:perun:member:attribute-def:def:mail';
 our $A_USER_LANG;                            *A_USER_LANG =                             \'urn:perun:user:attribute-def:def:preferredLanguage';
 our $A_USER_STATUS;                          *A_USER_STATUS =                           \'urn:perun:member:attribute-def:core:status';
-our $A_USER_EXPIRES;                         *A_USER_EXPIRES =                          \'urn:perun:member:attribute-def:def:membershipExpiration';
-our $A_USER_LOA;                             *A_USER_LOA =                              \'urn:perun:user:attribute-def:virt:loa';
 our $A_USER_OPT_OUT;                         *A_USER_OPT_OUT =                          \'urn:perun:member_resource:attribute-def:def:optOutMailingList';
 
 our $A_RESOURCE_MAILING_LIST_NAME;           *A_RESOURCE_MAILING_LIST_NAME =            \'urn:perun:resource:attribute-def:def:mailingListName';
-our $A_RESOURCE_MAILING_LIST_VARIANTS;			 *A_RESOURCE_MAILING_LIST_VARIANTS =        \'urn:perun:resource:attribute-def:def:mailingListUsesLangVariants'; # true for -cs and -en variants
+our $A_RESOURCE_MAILING_LIST_VARIANTS;       *A_RESOURCE_MAILING_LIST_VARIANTS =        \'urn:perun:resource:attribute-def:def:mailingListUsesLangVariants'; # true for -cs and -en variants
 our $A_RESOURCE_MAILING_LIST_NONVALID_USERS; *A_RESOURCE_MAILING_LIST_NONVALID_USERS =  \'urn:perun:resource:attribute-def:def:mailingListAllowInvalidUsers'; # true to allow users with status other than VALID
 
 my $mailinglistStruc = {};  # $mailinglistStruc->{"mailing list name including lang"}->{"user's e-mail"}->{A_USER_*}
@@ -38,7 +36,6 @@ my $mailinglistStruc = {};  # $mailinglistStruc->{"mailing list name including l
 my $mailinglistsDirectory = "$DIRECTORY/mailinglists";
 mkdir $mailinglistsDirectory or die "Can't mkdir $mailinglistsDirectory: $!";
 
-my @membersAttributes;
 my @resourcesData = $data->getChildElements;
 foreach my $rData (@resourcesData) {
 	my %resourceAttributes  = attributesToHash $rData->getAttributes;
@@ -75,19 +72,6 @@ foreach my $rData (@resourcesData) {
 			}
 		}
 
-		#list-specific filters
-		if ($listName eq "metavo-membership") {
-			#list only members that have loa=2 and expires in less than 60 days or expired before less than 30 days
-			my $userLoa = $memberAttributes->{$A_USER_LOA};
-			next if not $userLoa eq "2" ;
-			my $userExpires = $memberAttributes->{$A_USER_EXPIRES};
-			my $in60days = strftime("%Y-%m-%d",localtime (time+(60*60*24*60)));
-			my $before30days = strftime("%Y-%m-%d",localtime (time-(60*60*24*30)));
-			next if ($userExpires gt $in60days);
-			next if ($userExpires lt $before30days);
-			$mailinglistStruc->{$listNameWithLang}->{$memberAttributes->{$A_USER_MAIL}}->{$A_USER_EXPIRES} = $memberAttributes->{$A_USER_EXPIRES};
-		}
-
 		$mailinglistStruc->{$listNameWithLang}->{$memberAttributes->{$A_USER_MAIL}}->{$A_USER_NAME} = $memberAttributes->{$A_USER_NAME};
 	}
 }
@@ -99,7 +83,6 @@ for my $listName (keys %$mailinglistStruc) {
 
 	for my $mail (keys %{$mailinglistStruc->{$listName}}) {
 		print FILE "\"", unidecode($mailinglistStruc->{$listName}->{$mail}->{$A_USER_NAME});
-		if(defined $mailinglistStruc->{$listName}->{$mail}->{$A_USER_EXPIRES}) { print FILE " expiring ", $mailinglistStruc->{$listName}->{$mail}->{$A_USER_EXPIRES}; }
 		print FILE "\" <", $mail, ">\n";
 	}
 

--- a/gen/mailman_meta
+++ b/gen/mailman_meta
@@ -27,7 +27,7 @@ our $A_USER_STATUS;                          *A_USER_STATUS =                   
 our $A_USER_OPT_OUT;                         *A_USER_OPT_OUT =                          \'urn:perun:member_resource:attribute-def:def:optOutMailingList';
 
 our $A_RESOURCE_MAILING_LIST_NAME;           *A_RESOURCE_MAILING_LIST_NAME =            \'urn:perun:resource:attribute-def:def:mailingListName';
-our $A_RESOURCE_MAILING_LIST_VARIANTS;			 *A_RESOURCE_MAILING_LIST_VARIANTS =        \'urn:perun:resource:attribute-def:def:mailingListUsesLangVariants'; # true for -cs and -en variants
+our $A_RESOURCE_MAILING_LIST_VARIANTS;       *A_RESOURCE_MAILING_LIST_VARIANTS =        \'urn:perun:resource:attribute-def:def:mailingListUsesLangVariants'; # true for -cs and -en variants
 our $A_RESOURCE_MAILING_LIST_NONVALID_USERS; *A_RESOURCE_MAILING_LIST_NONVALID_USERS =  \'urn:perun:resource:attribute-def:def:mailingListAllowInvalidUsers'; # true to allow users with status other than VALID
 
 my $mailinglistStruc = {};  # $mailinglistStruc->{"mailing list name including lang"}->{"user's e-mail"}->{A_USER_*}
@@ -53,7 +53,6 @@ foreach my $rData (@resourcesData) {
 		$mailinglistStruc->{$listNameCS} = {} unless $mailinglistStruc->{$listNameCS};
 		$mailinglistStruc->{$listNameEN} = {} unless $mailinglistStruc->{$listNameEN};
 	} else {
-		print "No list\n";
 		$mailinglistStruc->{$listName} = {} unless $mailinglistStruc->{$listName};
 	}
 

--- a/gen/mailman_meta
+++ b/gen/mailman_meta
@@ -12,8 +12,8 @@ use Text::Unidecode;
 use POSIX qw/strftime/;
 
 local $::SERVICE_NAME = "mailman_meta";
-local $::PROTOCOL_VERSION = "3.1.0";
-my $SCRIPT_VERSION = "3.2.0";
+local $::PROTOCOL_VERSION = "3.1.1";
+my $SCRIPT_VERSION = "3.2.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
@@ -24,8 +24,6 @@ our $A_USER_NAME;                            *A_USER_NAME =                     
 our $A_USER_MAIL;                            *A_USER_MAIL =                             \'urn:perun:user:attribute-def:def:preferredMail';
 our $A_USER_LANG;                            *A_USER_LANG =                             \'urn:perun:user:attribute-def:def:preferredLanguage';
 our $A_USER_STATUS;                          *A_USER_STATUS =                           \'urn:perun:member:attribute-def:core:status';
-our $A_USER_EXPIRES;                         *A_USER_EXPIRES =                          \'urn:perun:member:attribute-def:def:membershipExpiration';
-our $A_USER_LOA;                             *A_USER_LOA =                              \'urn:perun:user:attribute-def:virt:loa';
 our $A_USER_OPT_OUT;                         *A_USER_OPT_OUT =                          \'urn:perun:member_resource:attribute-def:def:optOutMailingList';
 
 our $A_RESOURCE_MAILING_LIST_NAME;           *A_RESOURCE_MAILING_LIST_NAME =            \'urn:perun:resource:attribute-def:def:mailingListName';
@@ -37,7 +35,6 @@ my $mailinglistStruc = {};  # $mailinglistStruc->{"mailing list name including l
 my $mailinglistsDirectory = "$DIRECTORY/mailinglists";
 mkdir $mailinglistsDirectory or die "Can't mkdir $mailinglistsDirectory: $!";
 
-my @membersAttributes;
 my @resourcesData = $data->getChildElements;
 foreach my $rData (@resourcesData) {
 	my %resourceAttributes  = attributesToHash $rData->getAttributes;
@@ -75,19 +72,6 @@ foreach my $rData (@resourcesData) {
 			}
 		}
 
-		#list-specific filters
-		if ($listName eq "metavo-membership") {
-			#list only members that have loa=2 and expires in less than 60 days or expired before less than 30 days
-			my $userLoa = $memberAttributes->{$A_USER_LOA};
-			next if not $userLoa eq "2" ;
-			my $userExpires = $memberAttributes->{$A_USER_EXPIRES};
-			my $in60days = strftime("%Y-%m-%d",localtime (time+(60*60*24*60)));
-			my $before30days = strftime("%Y-%m-%d",localtime (time-(60*60*24*30)));
-			next if ($userExpires gt $in60days);
-			next if ($userExpires lt $before30days);
-			$mailinglistStruc->{$listNameWithLang}->{$memberAttributes->{$A_USER_MAIL}}->{$A_USER_EXPIRES} = $memberAttributes->{$A_USER_EXPIRES};
-		}
-
 		$mailinglistStruc->{$listNameWithLang}->{$memberAttributes->{$A_USER_MAIL}}->{$A_USER_NAME} = $memberAttributes->{$A_USER_NAME};
 	}
 }
@@ -99,7 +83,6 @@ for my $listName (keys %$mailinglistStruc) {
 
 	for my $mail (keys %{$mailinglistStruc->{$listName}}) {
 		print FILE "\"", unidecode($mailinglistStruc->{$listName}->{$mail}->{$A_USER_NAME});
-		if(defined $mailinglistStruc->{$listName}->{$mail}->{$A_USER_EXPIRES}) { print FILE " expiring ", $mailinglistStruc->{$listName}->{$mail}->{$A_USER_EXPIRES}; }
 		print FILE "\" <", $mail, ">\n";
 	}
 

--- a/gen/mailman_meta
+++ b/gen/mailman_meta
@@ -9,7 +9,7 @@ use warnings;
 use perunServicesInit;
 use perunServicesUtils;
 use Text::Unidecode;
-use POSIX qw/strftime/; 
+use POSIX qw/strftime/;
 
 local $::SERVICE_NAME = "mailman_meta";
 local $::PROTOCOL_VERSION = "3.1.0";
@@ -25,14 +25,14 @@ our $A_USER_MAIL;                            *A_USER_MAIL =                     
 our $A_USER_LANG;                            *A_USER_LANG =                             \'urn:perun:user:attribute-def:def:preferredLanguage';
 our $A_USER_STATUS;                          *A_USER_STATUS =                           \'urn:perun:member:attribute-def:core:status';
 our $A_USER_EXPIRES;                         *A_USER_EXPIRES =                          \'urn:perun:member:attribute-def:def:membershipExpiration';
-our $A_USER_LOA;                             *A_USER_LOA =                              \'urn:perun:member:attribute-def:virt:loa';
+our $A_USER_LOA;                             *A_USER_LOA =                              \'urn:perun:user:attribute-def:virt:loa';
 our $A_USER_OPT_OUT;                         *A_USER_OPT_OUT =                          \'urn:perun:member_resource:attribute-def:def:optOutMailingList';
 
 our $A_RESOURCE_MAILING_LIST_NAME;           *A_RESOURCE_MAILING_LIST_NAME =            \'urn:perun:resource:attribute-def:def:mailingListName';
 our $A_RESOURCE_MAILING_LIST_VARIANTS;			 *A_RESOURCE_MAILING_LIST_VARIANTS =        \'urn:perun:resource:attribute-def:def:mailingListUsesLangVariants'; # true for -cs and -en variants
 our $A_RESOURCE_MAILING_LIST_NONVALID_USERS; *A_RESOURCE_MAILING_LIST_NONVALID_USERS =  \'urn:perun:resource:attribute-def:def:mailingListAllowInvalidUsers'; # true to allow users with status other than VALID
 
-my $mailinglistStruc = {};  # $mailinglistStruc->{"mailing list name including lang"}->{"user's e-mail"}->{A_USER_*} 
+my $mailinglistStruc = {};  # $mailinglistStruc->{"mailing list name including lang"}->{"user's e-mail"}->{A_USER_*}
 
 my $mailinglistsDirectory = "$DIRECTORY/mailinglists";
 mkdir $mailinglistsDirectory or die "Can't mkdir $mailinglistsDirectory: $!";
@@ -74,7 +74,7 @@ foreach my $rData (@resourcesData) {
 				$listNameWithLang = $listNameEN;
 			}
 		}
-		
+
 		#list-specific filters
 		if ($listName eq "metavo-membership") {
 			#list only members that have loa=2 and expires in less than 60 days or expired before less than 30 days

--- a/slave/process-mailman-cesnet/bin/process-mailman_cesnet.sh
+++ b/slave/process-mailman-cesnet/bin/process-mailman_cesnet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PROTOCOL_VERSION='3.0.0'
+PROTOCOL_VERSION='3.0.1'
 
 function process {
 	DST_DIR="/var/spool/mailinglists"

--- a/slave/process-mailman-cesnet/changelog
+++ b/slave/process-mailman-cesnet/changelog
@@ -1,3 +1,10 @@
+perun-slave-process-mailman-cesnet (3.1.6) stable; urgency=low
+
+  * Removed handling of expiration and loa for hardcoded
+    metavo-membership list. Updated script and protocol version.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Wed, 08 Apr 2020 10:00:00 +0200
+
 perun-slave-process-mailman-cesnet (3.1.5) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-mailman-meta/bin/process-mailman_meta.sh
+++ b/slave/process-mailman-meta/bin/process-mailman_meta.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PROTOCOL_VERSION='3.1.0'
+PROTOCOL_VERSION='3.1.1'
 
 function process {
 	DST_DIR="/var/spool/mailinglists"

--- a/slave/process-mailman-meta/changelog
+++ b/slave/process-mailman-meta/changelog
@@ -1,3 +1,10 @@
+perun-slave-process-mailman-meta (3.1.5) stable; urgency=low
+
+  * Removed handling of expiration and loa for hardcoded
+    metavo-membership list. Updated script and protocol version.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Wed, 08 Apr 2020 10:00:00 +0200
+
 perun-slave-process-mailman-meta (3.1.4) stable; urgency=medium
 
   * Changed architecture to all


### PR DESCRIPTION
- Removed hardcoded hack, which removed members of metavo-membership
  mailinglist based on loa and expiration in mailman_meta and mailman_cesnet.
- Updated script and protocol version.
- Updated slave script with new protocol version.
- Trailing whitespace cleanup.