### PR TITLE
Service tinia will user virtual attribute login instead of defined one

### DIFF
--- a/gen/tinia
+++ b/gen/tinia
@@ -18,7 +18,7 @@ my $data = perunServicesInit::getHierarchicalData;
 #Constants
 our $A_USER_FIRSTNAME;     *A_USER_FIRSTNAME =      \'urn:perun:user:attribute-def:core:firstName';
 our $A_USER_LASTNAME;      *A_USER_LASTNAME =       \'urn:perun:user:attribute-def:core:lastName';
-our $A_USER_LOGIN_MU;      *A_USER_LOGIN_MU =       \'urn:perun:user:attribute-def:def:login-namespace:mu';
+our $A_USER_LOGIN_MU;      *A_USER_LOGIN_MU =       \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_USER_CHIP_NUMBERS;  *A_USER_CHIP_NUMBERS =   \'urn:perun:user:attribute-def:def:chipNumbers';
 
 our $A_RESOURCE_ACC_GROUP; *A_RESOURCE_ACC_GROUP =   \'urn:perun:resource:attribute-def:def:tiniaAccessGroup';


### PR DESCRIPTION
 - When syntax and semantic for attribute's dependencies are checked,
 we can work only with entities of the attribute. If attribute is in
 user namespace, it must be checked for all users in system Perun. For
 this reason it is faster to check any user_facility attribute than
 user attribute. Service tinia is now using user_facility:virt:login
 attribute instead user:def:login:mu attribute