### PR TITLE
Handle paths with spaces in bbmri_collections

### DIFF
--- a/send/bbmri_collections
+++ b/send/bbmri_collections
@@ -24,11 +24,11 @@ fi
 
 # Specify command to tranfer the data
 TRANSPORT_COMMAND="curl --cacert /etc/ssl/chain_TERENA_SSL_CA_3.pem -i -H Content-Type:application/json -f -X POST"
-USER_TRANSPORT_COMMAND="$TRANSPORT_COMMAND -d @$USER_FILE -u `echo $DESTINATION | tr '@' ' '`$USER_ENDPOINT"
-GROUP_TRANSPORT_COMMAND="$TRANSPORT_COMMAND -d @$GROUP_FILE -u `echo $DESTINATION | tr '@' ' '`$GROUP_ENDPOINT"
+USER_TRANSPORT_COMMAND="$TRANSPORT_COMMAND -d @- -u `echo $DESTINATION | tr '@' ' '`$USER_ENDPOINT"
+GROUP_TRANSPORT_COMMAND="$TRANSPORT_COMMAND -d @- -u `echo $DESTINATION | tr '@' ' '`$GROUP_ENDPOINT"
 
 # HTTP Request with timeout for USERS
-timeout -k $TIMEOUT_KILL $TIMEOUT $USER_TRANSPORT_COMMAND
+cat "$USER_FILE" | timeout -k $TIMEOUT_KILL $TIMEOUT $USER_TRANSPORT_COMMAND
 # Catch errors
 ERR_CODE=$?
 #Error code 124 means - timeouted
@@ -39,7 +39,7 @@ else
 fi
 
 # HTTP Request with timeout for GROUPS
-timeout -k $TIMEOUT_KILL $TIMEOUT $GROUP_TRANSPORT_COMMAND
+cat "$GROUP_FILE" | timeout -k $TIMEOUT_KILL $TIMEOUT $GROUP_TRANSPORT_COMMAND
 # Catch errors
 ERR_CODE=$?
 #Error code 124 means - timeouted

--- a/send/bbmri_collections
+++ b/send/bbmri_collections
@@ -22,10 +22,13 @@ if [ "$DESTINATION_TYPE" != "url" ]; then
 	exit 1;
 fi
 
+# Read user name and password from configuration if it is present.
+[ -r /etc/perun/services/$SERVICE_NAME ] && . /etc/perun/services/$SERVICE_NAME
+
 # Specify command to tranfer the data
 TRANSPORT_COMMAND="curl --cacert /etc/ssl/chain_TERENA_SSL_CA_3.pem -i -H Content-Type:application/json -f -X POST"
-USER_TRANSPORT_COMMAND="$TRANSPORT_COMMAND -d @- -u `echo $DESTINATION | tr '@' ' '`$USER_ENDPOINT"
-GROUP_TRANSPORT_COMMAND="$TRANSPORT_COMMAND -d @- -u `echo $DESTINATION | tr '@' ' '`$GROUP_ENDPOINT"
+USER_TRANSPORT_COMMAND="$TRANSPORT_COMMAND -d @- -u $USERNAME_AND_PASSWORD $DESTINATION$USER_ENDPOINT"
+GROUP_TRANSPORT_COMMAND="$TRANSPORT_COMMAND -d @- -u $USERNAME_AND_PASSWORD $DESTINATION$GROUP_ENDPOINT"
 
 # HTTP Request with timeout for USERS
 cat "$USER_FILE" | timeout -k $TIMEOUT_KILL $TIMEOUT $USER_TRANSPORT_COMMAND

--- a/send/bbmri_collections
+++ b/send/bbmri_collections
@@ -22,20 +22,20 @@ if [ "$DESTINATION_TYPE" != "url" ]; then
 	exit 1;
 fi
 
-# Read user name and password from configuration if it is present.
+# Read user name and password from configuration if it is present ( expect string "-u user:pass" )
 [ -r /etc/perun/services/$SERVICE_NAME ] && . /etc/perun/services/$SERVICE_NAME
 
-# Specify command to tranfer the data
-TRANSPORT_COMMAND="curl --cacert /etc/ssl/chain_TERENA_SSL_CA_3.pem -i -H Content-Type:application/json -f -X POST"
-USER_TRANSPORT_COMMAND="$TRANSPORT_COMMAND -d @- -u $USERNAME_AND_PASSWORD $DESTINATION$USER_ENDPOINT"
-GROUP_TRANSPORT_COMMAND="$TRANSPORT_COMMAND -d @- -u $USERNAME_AND_PASSWORD $DESTINATION$GROUP_ENDPOINT"
+# Specify command to transfer the data
+TRANSPORT_COMMAND="curl -i -H Content-Type:application/json -f -X POST"
+USER_TRANSPORT_COMMAND="$TRANSPORT_COMMAND -d @- $USERNAME_AND_PASSWORD $DESTINATION$USER_ENDPOINT"
+GROUP_TRANSPORT_COMMAND="$TRANSPORT_COMMAND -d @- $USERNAME_AND_PASSWORD $DESTINATION$GROUP_ENDPOINT"
 
 # HTTP Request with timeout for USERS
 cat "$USER_FILE" | timeout -k $TIMEOUT_KILL $TIMEOUT $USER_TRANSPORT_COMMAND
 # Catch errors
 ERR_CODE=$?
-#Error code 124 means - timeouted
-if [ $ERR_CODE -e 124 ]; then
+#Error code 124 means - timed out
+if [ $ERR_CODE -eq 124 ]; then
 	echo "Communication with the peer has timed out with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
 else
 	echo "Communication with the peer ends with return code: $ERR_CODE" >&2
@@ -45,9 +45,9 @@ fi
 cat "$GROUP_FILE" | timeout -k $TIMEOUT_KILL $TIMEOUT $GROUP_TRANSPORT_COMMAND
 # Catch errors
 ERR_CODE=$?
-#Error code 124 means - timeouted
-if [ $ERR_CODE -e 124 ]; then
-  echo "Communication with the peer has timed out with return code: $ERR_CODE" >&2
+#Error code 124 means - timed out
+if [ $ERR_CODE -eq 124 ]; then
+	echo "Communication with the peer has timed out with return code: $ERR_CODE" >&2
 else
 	echo "Communication with the peer ends with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
 fi

--- a/send/bbmri_collections
+++ b/send/bbmri_collections
@@ -33,9 +33,9 @@ cat "$USER_FILE" | timeout -k $TIMEOUT_KILL $TIMEOUT $USER_TRANSPORT_COMMAND
 ERR_CODE=$?
 #Error code 124 means - timeouted
 if [ $ERR_CODE -e 124 ]; then
-	echo "Communication with the peer was timeouted with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
+	echo "Communication with the peer has timed out with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
 else
-	echo "Communcation with the peer ends with return code: $ERR_CODE" >&2
+	echo "Communication with the peer ends with return code: $ERR_CODE" >&2
 fi
 
 # HTTP Request with timeout for GROUPS
@@ -44,9 +44,9 @@ cat "$GROUP_FILE" | timeout -k $TIMEOUT_KILL $TIMEOUT $GROUP_TRANSPORT_COMMAND
 ERR_CODE=$?
 #Error code 124 means - timeouted
 if [ $ERR_CODE -e 124 ]; then
-  echo "Communication with the peer was timeouted with return code: $ERR_CODE" >&2
+  echo "Communication with the peer has timed out with return code: $ERR_CODE" >&2
 else
-	echo "Communcation with the peer ends with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
+	echo "Communication with the peer ends with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
 fi
 
 exit $ERR_CODE


### PR DESCRIPTION
- Handle facility names (as a part of path) with spaces.
  Space was recognized as a divider by curl ending with
  invalid usage.
- Now we pass file on STDIN of curl and we quote path
  to the file before pasting it.
- Include service configuration file from expected location
  /etc/perun/services/[service_name] into the main send script
  of bbmri_collections.
- Modified $TRANSPORT_COMMAND to contain $USERNAME_AND_PASSWORD
  which is expected to be set in configuration.
  I believe it can be dependent on previously defined $DESTINATION
  in the main script, so it should be configurable per destination.