### PR TITLE
Removed unimportant logs for service k5login

### DIFF
--- a/slave/process-k5login/bin/process-k5login.sh
+++ b/slave/process-k5login/bin/process-k5login.sh
@@ -58,7 +58,8 @@ function process {
 
 		#nothing to add, can skip to another user
 		if [ -z "${ADDED_PRINCIPALS}" ]; then
-			log_msg I_K5LOGIN_NOT_UPDATED
+			#skip this log, not important information for administrators
+			#log_msg I_K5LOGIN_NOT_UPDATED
 			continue
 		fi
 

--- a/slave/process-k5login/changelog
+++ b/slave/process-k5login/changelog
@@ -1,3 +1,10 @@
+perun-slave-process-k5login (3.1.6) stable; urgency=low
+
+  * Skip information about not changed k5login files. This information is
+    not important for administrators of a service.
+
+ -- Michal Stava <stavamichal@gmail.com> Wed, 03 Jun 2020 14:57:00 +0200
+
 perun-slave-process-k5login (3.1.5) stable; urgency=medium
 
   * Changed architecture to all


### PR DESCRIPTION
 - skip information about not changed k5login files. This
 information is not important for administrators of a service