### PR TITLE
Fix encoding and return code in o365_mu service

### DIFF
--- a/send/o365-connector.pl
+++ b/send/o365-connector.pl
@@ -12,9 +12,14 @@ use URI;
 use JSON;
 use Data::Dumper;
 use POSIX qw(strftime);
+use Encode qw(decode_utf8);
 
 #We want to have data in UTF8 on output
 binmode STDOUT, ':utf8';
+binmode STDERR, ':utf8';
+
+#parse arguments in utf8
+@ARGV = map { decode_utf8($_, 1) } @ARGV;
 
 sub shellEscape($);
 

--- a/send/o365_mu_process.pl
+++ b/send/o365_mu_process.pl
@@ -461,7 +461,7 @@ sub processResourceMail {
 		
 		if($DEBUG) { print "CHANGE RESOURCE-MAIL: " . $resourceMailObject->{$RES_NAME_TEXT} . " - STARTED\n"; }
 		`$command`;
-		if($@) { 
+		if($?) { 
 			print "CHANGE RESOURCE-MAIL: " . $resourceMailObject->{$RES_NAME_TEXT} . " - ERROR - $@\n";
 			return 0; 
 		}


### PR DESCRIPTION
 - use utf8 decoding of arguments in o365-connector
 - use utf8 for STDERR in o365-connector
 - fix checking of return code in o365_mu_process to correctly react on
   error