### PR TITLE
Send empty mailing lists in mailman_mu in order to clear them

### DIFF
--- a/gen/mailman_mu
+++ b/gen/mailman_mu
@@ -45,6 +45,10 @@ foreach my $rData (@resourcesData) {
 	# Store the admin's mail
 	$mailinglistAdminMailStruc->{$listName} = $adminMail;
 
+	# store empty mailing list
+	$mailinglistStruc->{$listName} = ();
+
+	# fill mailing list
 	foreach my $memberAttributes (dataToAttributesHashes @membersData) {
 		#list only VALID members except if allowNonvalidUsers is true
 		next unless($memberAttributes->{$A_USER_STATUS} eq "VALID");


### PR DESCRIPTION
- When all members were removed from the resource, we didn't print
  mailing list file at all. Hence it was not managed and the list
  was not cleared.