### PR TITLE
Use expiration + 1 day in vsup_rav service

### DIFF
--- a/gen/vsup_rav
+++ b/gen/vsup_rav
@@ -134,6 +134,9 @@ sub calculateExpiration() {
 		return undef;
 	}
 
+	# add one day, since we want users to be valid during the last day
+	$latest_expiration = $latest_expiration + 86400;
+
 	return localtime($latest_expiration)->ymd;
 
 }


### PR DESCRIPTION
- We want users to be valid even during their last day (expiration date).
  Hence we must add +1 day to the expiration date when its pushed
  to the RAV.