### PR TITLE
Added grace period for groups in ad_mu

### DIFF
--- a/send/ad_mu
+++ b/send/ad_mu
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 
 my @today = Today();
+my $groups_grace_period_date = Date_to_Text(Add_Delta_Days(@today, 30));  # grace period for groups
 #@today = Add_Delta_Days(@today, 155);  #DEBUG - add more day 
 #@today = (2016, 1, 1); #DEBUG - set fo fixed date
 
@@ -31,7 +32,7 @@ use Net::LDAP::LDIF;
 use Net::LDAP::Control::Paged;
 use Net::LDAP::Constant qw( LDAP_CONTROL_PAGED );
 use File::Copy;
-use Date::Calc qw/ Today Delta_Days Add_Delta_Days Date_to_Days /;
+use Date::Calc qw/ Today Delta_Days Add_Delta_Days Date_to_Days Date_to_Text Decode_Date_EU /;
 use LockFile::Simple;
 no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
@@ -660,7 +661,7 @@ sub process_groups() {
 
 	my @perun_entries_groups = load_perun($service_files_dir."/".$service_name."_groups_".$ouName.".ldif");
 	my @ad_entries_groups = load_ad($ldap, "OU=".$ouName.",".$base_dn_groups, $filter_groups,
-		[ 'cn', 'samAccountName', 'displayName', 'MailNickName', 'msExchRequireAuthToSendTo', 'publicDelegates' , 'ProxyAddresses', 'mail', 'extensionAttribute1']);
+		[ 'cn', 'samAccountName', 'displayName', 'MailNickName', 'msExchRequireAuthToSendTo', 'publicDelegates' , 'ProxyAddresses', 'mail', 'extensionAttribute1', 'extensionAttribute2']);
 
 	my %ad_entries_group_map = ();
 	my %perun_entries_group_map = ();
@@ -710,7 +711,7 @@ sub process_groups() {
 			my $perun_entry = $perun_entries_group_map{$cn};
 
 			# attrs without cn!
-			my @attrs = ('samAccountName', 'displayName', 'MailNickName', 'msExchRequireAuthToSendTo', 'publicDelegates', 'ProxyAddresses', 'mail', 'extensionAttribute1');
+			my @attrs = ('samAccountName', 'displayName', 'MailNickName', 'msExchRequireAuthToSendTo', 'publicDelegates', 'ProxyAddresses', 'mail', 'extensionAttribute1', 'extensionAttribute2');
 			# stored log messages to check if entry should be updated
 			my @entry_changed = ();
 
@@ -771,10 +772,21 @@ sub process_groups() {
 				$ad_entry->replace(
 					'member' => \@empty_members
 				);
-				# set this attribute to FALSE
-				$ad_entry->replace(
-					'extensionAttribute1' => 'FALSE'
-				);
+
+				my $grace_period = $ad_entry->get_value('extensionAttribute2');
+				unless (defined $grace_period) {
+					$ad_entry->replace(
+						'extensionAttribute2' => $groups_grace_period_date
+					);
+				} else {
+					my @grace_period_array = Decode_Date_EU($grace_period);
+					if(Delta_Days(@today, @grace_period_array) < 0) {
+						# set this attribute to FALSE
+						$ad_entry->replace(
+							'extensionAttribute1' => 'FALSE'
+						);
+					}
+				}
 
 				my $response = $ad_entry->update($ldap);
 				unless ($response->is_error()) {


### PR DESCRIPTION
- Groups in ad_mu were not deleted from AD but attribute extensionAttribute1 was
  set to FALSE instead. That caused that further process in O365 removed
  these groups from MUNI internal systems.
- When someone accidentaly removed some group in Perun, then the group was
  deleted by the O365 even that the group still existed in AD. When the
  group was created again in Perun, ad_mu script set extensionAttribute1
  to TRUE (in AD), but the O365 created completely new group with a new
  identifier so the internal MUNI systems did not know that it is the
  same group.
- To prevent these accidental removals, grace period was implemented for
  all groups propagated by the ad_mu script. When a group is deleted in
  Perun, the attribute mentioned above is not set immediately to FALSE.
  Instead of that current date + 30 days is set to the new attribute
  extensionAttribute2, which represents grace period for the given group.
  This attribute is initially undef and when the group is restored in
  Perun, it is again set to undef. When a date is set in this attribute
  and this date is before today (meaning when the scripts run), then the
  extensionAttribute1 is set to FALSE.