### PR TITLE
Fix problem with processing of duplicates in drupal_elixir slave script

### DIFF
--- a/slave/process-drupal-elixir/bin/process-drupal_elixir.sh
+++ b/slave/process-drupal-elixir/bin/process-drupal_elixir.sh
@@ -5,7 +5,6 @@ PROTOCOL_VERSION='3.1.0'
 
 function process {
 	FILE_USERS="users.csv"
-	FILE_USERS_DUPLICITIES="users-duplicities.csv"
 	FILE_GROUPS="groups.csv"
 	FILE_MEMBERSHIPS="memberships.csv"
 
@@ -13,8 +12,7 @@ function process {
 	I_CHANGED=(0 '${FILE} updated')
 	I_NOT_CHANGED=(0 '${FILE} has not changed')
 	E_CHMOD=(51 'Cannot chmod on $WORK_DIR/$FILE')
-	E_DUPLICITIES=(52 '')
-
+	E_DUPLICATES=(52 'Email duplicates: ${DUPLICATES}')
 
 	create_lock
 
@@ -39,9 +37,10 @@ function process {
 		fi
 	done
 
-	#there are some duplicities, need to end with error
-	if [ -s "$FILE_USERS_DUPLICITIES" ]; then
-		cat "${FILE_USERS_DUPLICITIES}" >&2;
-		log_msg E_DUPLICITIES
+	FILE_USER_DUPLICATES="$WORK_DIR/users-duplicities.csv"
+	#there are some duplicates between emails, need to end with error
+	if [ -s "${FILE_USER_DUPLICATES}" ]; then
+		DUPLICATES=`cat $FILE_USER_DUPLICATES`
+		log_msg E_DUPLICATES
 	fi
 }

--- a/slave/process-drupal-elixir/changelog
+++ b/slave/process-drupal-elixir/changelog
@@ -1,3 +1,11 @@
+perun-slave-process-drupal-elixir (3.1.6) stable; urgency=high
+  * catching of duplicates on slave side were not working correctly, because
+    there was wrong path to file with duplicates
+  * using word 'duplicates' instead of 'duplicities'
+  * fix text in an exception
+
+ -- Michal Stava <stavamichal@gmail.com>  Tue, 15 Sep 2020 13:42:00 +0200
+
 perun-slave-process-drupal-elixir (3.1.5) stable; urgency=medium
 
   * process file with duplicities and send them on error output if any exists


### PR DESCRIPTION
 - catching of duplicates on slave side were not working correctly, because
 there was wrong path to file with duplicates
 - using word 'duplicates' instead of 'duplicities'
 - fix text in an exception