### PR TITLE
Suppress unnecessary TAR warnings about timestamps

### DIFF
--- a/slave/base/bin/perun
+++ b/slave/base/bin/perun
@@ -383,7 +383,7 @@ WORK_DIR=`mktemp -d ${TMPDIR:-/tmp}/${NAME}.XXXXXXXXXX`
 add_on_exit "rm -rf ${WORK_DIR}"
 
 ### Receive and process data
-catch_error E_TAR_FILES tar --no-same-owner --no-same-permissions -x -C "${WORK_DIR}" <&0
+catch_error E_TAR_FILES tar --no-same-owner --no-same-permissions --warning=no-timestamp -x -C "${WORK_DIR}" <&0
 SERVICE=`head -n 1 "${WORK_DIR}/SERVICE"`
 SEND_TO_HOSTNAME=`head -n 1 "${WORK_DIR}/HOSTNAME"`
 FACILITY=`head -n 1 "${WORK_DIR}/FACILITY"`

--- a/slave/base/changelog
+++ b/slave/base/changelog
@@ -1,3 +1,9 @@
+perun-slave-base (3.1.15) stable; urgency=low
+
+  * Suppress unnecessary TAR warnings about timestamps in the future.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Wed, 30 Sep 2020 10:20:00 +0200
+
 perun-slave-base (3.1.14) stable; urgency=medium
 
   * Changed architecture to all


### PR DESCRIPTION
- Do not warn about file timestamps in the future
  when unpacking compressed data from Perun in the
  main slave script.
  It causes propagation to stay in WARNING state
  instead of DONE.