### PR TITLE
Do not print to STDERR in generic_send if return code is zero

### DIFF
--- a/send/appdb
+++ b/send/appdb
@@ -39,6 +39,8 @@ cp "$SERVICE_FILES_DIR"/vos "$SERVICE_FILES_DIR"/users /var/www/external/appdb/
 
 ERR_CODE=$?
 
-echo "Slave script ends with return code: $ERR_CODE" >&2
+if [ $ERR_CODE -ne 0 ]; then
+    echo "Slave script ends with return code: $ERR_CODE" >&2
+fi
 
 exit $ERR_CODE

--- a/send/bbmri_collections
+++ b/send/bbmri_collections
@@ -38,7 +38,9 @@ ERR_CODE=$?
 if [ $ERR_CODE -eq 124 ]; then
 	echo "Communication with the peer has timed out with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
 else
-	echo "Communication with the peer ends with return code: $ERR_CODE" >&2
+	if [ $ERR_CODE -ne 0 ]; then
+    echo "Communication with the peer ends with return code: $ERR_CODE" >&2
+  fi
 fi
 
 # HTTP Request with timeout for GROUPS
@@ -47,9 +49,11 @@ cat "$GROUP_FILE" | timeout -k $TIMEOUT_KILL $TIMEOUT $GROUP_TRANSPORT_COMMAND
 ERR_CODE=$?
 #Error code 124 means - timed out
 if [ $ERR_CODE -eq 124 ]; then
-	echo "Communication with the peer has timed out with return code: $ERR_CODE" >&2
-else
 	echo "Communication with the peer ends with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
+else
+	if [ $ERR_CODE -ne 0 ]; then
+    echo "Communication with the peer ends with return code: $ERR_CODE" >&2
+  fi
 fi
 
 exit $ERR_CODE

--- a/send/bbmri_networks
+++ b/send/bbmri_networks
@@ -39,7 +39,9 @@ ERR_CODE=$?
 if [ $ERR_CODE -eq 124 ]; then
 	echo "Communication with the peer has timed out with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
 else
-	echo "Communication with the peer ends with return code: $ERR_CODE" >&2
+	if [ $ERR_CODE -ne 0 ]; then
+    echo "Communication with the peer ends with return code: $ERR_CODE" >&2
+  fi
 fi
 
 # HTTP Request with timeout for GROUPS
@@ -48,9 +50,11 @@ cat "$GROUP_FILE" | timeout -k $TIMEOUT_KILL $TIMEOUT $GROUP_TRANSPORT_COMMAND
 ERR_CODE=$?
 #Error code 124 means - timed out
 if [ $ERR_CODE -eq 124 ]; then
-	echo "Communication with the peer has timed out with return code: $ERR_CODE" >&2
-else
 	echo "Communication with the peer ends with return code: $ERR_CODE (Warning: this error can mask original error 124 from peer!)" >&2
+else
+	if [ $ERR_CODE -ne 0 ]; then
+    echo "Communication with the peer ends with return code: $ERR_CODE" >&2
+  fi
 fi
 
 exit $ERR_CODE

--- a/send/generic_send
+++ b/send/generic_send
@@ -178,7 +178,7 @@ else
 	#In all other cases we need to resolve if 'ssh' or 'curl' was used
 	if [ "$DESTINATION_TYPE" = "$DESTINATION_TYPE_URL" ]; then
 		#In this situation 'curl' was used
-		if [ $ERR_CODE -eq "0" ]; then 
+		if [ $ERR_CODE -eq "0" ]; then
 			#Check if curl ended without an error (ERR_CODE = 0) (if not, we can continue as usual, because there is an error on STDERR)
 			if [ 200 -ne "$STDOUT" ]; then
 				#Check if HTTP_CODE is different from OK (200)
@@ -196,8 +196,10 @@ else
 		#In this situation 'ssh' was used, STDOUT has to be printed
 		echo "$STDOUT"
 	fi
-	#For all situations different from timouted by our side we can return value from ERR_CODE as the result
-	echo "Communication with slave script ends with return code: $ERR_CODE" >&2
+	#For all situations different from time-out by our side we can return value from ERR_CODE as the result
+  if [ $ERR_CODE -ne 0 ]; then
+    echo "Communication with slave script ends with return code: $ERR_CODE" >&2
+  fi
 fi
 
 exit $ERR_CODE

--- a/send/tinia
+++ b/send/tinia
@@ -19,7 +19,7 @@ fi
 if [ -z "$DESTINATION_TYPE" ]; then
 	echo "Destination type of this service can't be empty" >&2
 	exit 255;
-else 
+else
 	TYPE="service-specific"
 	if [ "$DESTINATION_TYPE" != "$TYPE" ]; then
 		echo "Destination type of this service need to be $TYPE" >&2
@@ -112,6 +112,8 @@ fi
 
 ERR_CODE=$?
 
-echo "Slave script ends with return code: $ERR_CODE" >&2
+if [ $ERR_CODE -ne 0 ]; then
+    echo "Slave script ends with return code: $ERR_CODE" >&2
+fi
 
 exit $ERR_CODE

--- a/send/topdesk
+++ b/send/topdesk
@@ -35,7 +35,9 @@ ERR_CODE=$?
 if [ $ERR_CODE -eq 124 ]; then
 	echo "Communication with slave script has timed out with return code: $ERR_CODE (Warning: this error can mask original error 124 from slave script!)" >&2
 else
-	echo "Communication with slave script ends with return code: $ERR_CODE" >&2
+	if [ $ERR_CODE -ne 0 ]; then
+    echo "Slave script ends with return code: $ERR_CODE" >&2
+  fi
 fi
 
 exit $ERR_CODE


### PR DESCRIPTION
- Printing to STDERR with return code 0 switches Tasks
  to the WARNING state instead of DONE. We must print
  to STDERR only on non-zero return code.