### PR TITLE
Fixed missing $ in variable name

### DIFF
--- a/gen/bbmri_collections
+++ b/gen/bbmri_collections
@@ -71,7 +71,7 @@ foreach my $resourceData ($data->getChildElements) {
 my @users;
 foreach my $uid (sort keys %$userStruc) {
 	my $user = {};
-	$user->{"id"} = $uid; 
+	$user->{"id"} = $uid;
 	$user->{"displayName"} = $userStruc->{$uid}->{$u_name};
 	$user->{"status"} = $userStruc->{$uid}->{$u_status};
 	$user->{"mail"} = $userStruc->{$uid}->{$u_email};
@@ -103,10 +103,10 @@ foreach my $gid (sort keys %$groupStruc) {
 		$struct->{"userId"} = $uid;
 		push @members, $struct;
 	}
-	
+
 	$group->{"members"} = \@members;
 	push @groups, $group;
-}	
+}
 
 # PRINT GROUPS TO JSON
 open FILE_GROUPS,">$fileGroups" or die "Cannot open $fileGroups: $! \n";
@@ -123,11 +123,11 @@ perunServicesInit::finalize;
 ## creates structure for users.csv file
 sub processUsers {
 	my ($gid, $memberData) = @_;
-	
+
 	my %memberAttributes = attributesToHash $memberData->getAttributes;
 	my $uid = $memberAttributes{$A_USER_ID};
 	my $status = $memberAttributes{$A_USER_STATUS};
-	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = $STATUS_SUSPENDED; }
 	my $email = $memberAttributes{$A_USER_EMAIL};
 	my $d_name = $memberAttributes{$A_USER_D_NAME};
 	my $organization = $memberAttributes{$A_USER_ORGANIZATION};
@@ -139,7 +139,7 @@ sub processUsers {
 		my $memberStatus = $userStruc->{$uid}->{$u_status};
 
 		if ($memberStatus eq $STATUS_EXPIRED && $status eq $STATUS_VALID){
-			# change from EXPIRED to VALID  
+			# change from EXPIRED to VALID
 			$userStruc->{$uid}->{$u_status} = $status;
 		} elsif ($memberStatus eq $STATUS_SUSPENDED && $status eq $STATUS_VALID){
 			# change from SUSPENDED to VALID
@@ -170,7 +170,7 @@ sub processGroups {
 		my $collectionID = $groupAttributes{$A_COLLECTION_ID};
 		my $collectionDirName = $groupAttributes{$A_COLLECTION_DIR_NAME};
 		my $gid = $groupAttributes{$A_GROUP_ID};
-		
+
 		unless(exists $groupStruc->{$gid}) {
 			$groupStruc->{$gid}->{$g_collection_id} = $collectionID;
 		}

--- a/gen/bbmri_networks
+++ b/gen/bbmri_networks
@@ -67,11 +67,11 @@ foreach my $resourceData ($data->getChildElements) {
 my @users;
 foreach my $uid (sort keys %$userStruc) {
 	my $user = {};
-	$user->{"id"} = $uid; 
+	$user->{"id"} = $uid;
 	$user->{"displayName"} = $userStruc->{$uid}->{$u_name};
 	$user->{"status"} = $userStruc->{$uid}->{$u_status};
 	$user->{"mail"} = $userStruc->{$uid}->{$u_email};
-	$user->{"identities"} = $userStruc->{$uid}->{$u_eppn}; 
+	$user->{"identities"} = $userStruc->{$uid}->{$u_eppn};
 
 	push @users, $user;
 }
@@ -96,10 +96,10 @@ foreach my $gid (sort keys %$groupStruc) {
 		$struct->{"userId"} = $uid;
 		push @members, $struct;
 	}
-	
+
 	$group->{"members"} = \@members;
 	push @groups, $group;
-}	
+}
 
 # PRINT GROUPS TO JSON
 open FILE_GROUPS,">$fileGroups" or die "Cannot open $fileGroups: $! \n";
@@ -116,11 +116,11 @@ perunServicesInit::finalize;
 ## creates structure for users.csv file
 sub processUsers {
 	my ($gid, $memberData) = @_;
-	
+
 	my %memberAttributes = attributesToHash $memberData->getAttributes;
 	my $uid = $memberAttributes{$A_USER_ID};
 	my $status = $memberAttributes{$A_USER_STATUS};
-	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = $STATUS_SUSPENDED; }
 	my $email = $memberAttributes{$A_USER_EMAIL};
 	my $d_name = $memberAttributes{$A_USER_D_NAME};
 
@@ -131,7 +131,7 @@ sub processUsers {
 		my $memberStatus = $userStruc->{$uid}->{$u_status};
 
 		if ($memberStatus eq $STATUS_EXPIRED && $status eq $STATUS_VALID){
-			# change from EXPIRED to VALID  
+			# change from EXPIRED to VALID
 			$userStruc->{$uid}->{$u_status} = $status;
 		} elsif ($memberStatus eq $STATUS_SUSPENDED && $status eq $STATUS_VALID){
 			# change from SUSPENDED to VALID
@@ -160,10 +160,10 @@ sub processGroups {
 	if($groupAttributes{$A_NETWORK_ID}) {
 		my $networkID = $groupAttributes{$A_NETWORK_ID};
 		my $gid = $groupAttributes{$A_GROUP_ID};
-		
+
 		unless(exists $groupStruc->{$gid}) {
 			$groupStruc->{$gid}->{$g_network_id} = $networkID;
-		}		
+		}
 
 		foreach my $memberData ($membersElement->getChildElements) {
 			processUsers $gid, $memberData;

--- a/gen/coffeeroom
+++ b/gen/coffeeroom
@@ -110,7 +110,7 @@ sub processUsers {
         my %memberAttributes = attributesToHash $memberData->getAttributes;
         my $uid = $memberAttributes{$A_USER_ID};
         my $status = $memberAttributes{$A_USER_STATUS};
-        if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
+        if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = $STATUS_SUSPENDED; }
         my $email = $memberAttributes{$A_USER_EMAIL};
         my $d_name = $memberAttributes{$A_USER_D_NAME};
         my $login = $memberAttributes{$A_USER_LOGIN};

--- a/gen/drupal_elixir
+++ b/gen/drupal_elixir
@@ -132,7 +132,7 @@ sub processUsers {
 	my $uid = $memberAttributes{$A_USER_ID};
 	my $login = $memberAttributes{$A_USER_LOGIN};
 	my $status = $memberAttributes{$A_USER_STATUS};
-	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = $STATUS_SUSPENDED; }
 	my $email = $memberAttributes{$A_USER_EMAIL};
 	my $d_name = $memberAttributes{$A_USER_D_NAME};
 
@@ -142,12 +142,12 @@ sub processUsers {
 
 	#select first eppn which ends with '@elixir-europe.org', if there is no one matching select first eppn, if there is no eppn at all use empty string
 	my $eppn = (grep /\@elixir-europe.org$/, @eppns)[0] || $eppns[0] || "";
-	
+
 	if(exists $userStruc->{$uid}) {
 		my $memberStatus = $userStruc->{$uid}->{$u_status};
 
 		if ($memberStatus eq $STATUS_EXPIRED && $status eq $STATUS_VALID){
-			# change from EXPIRED to VALID  
+			# change from EXPIRED to VALID
 			$userStruc->{$uid}->{$u_status} = $status;
 		} elsif ($memberStatus eq $STATUS_SUSPENDED && $status eq $STATUS_VALID){
 			# change from SUSPENDED to VALID

--- a/gen/kypo_portal
+++ b/gen/kypo_portal
@@ -114,7 +114,7 @@ sub processUsers {
 	my %memberAttributes = attributesToHash $memberData->getAttributes;
 	my $uid = $memberAttributes{$A_USER_ID};
 	my $status = $memberAttributes{$A_USER_STATUS};
-	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = $STATUS_SUSPENDED; }
 	my $email = $memberAttributes{$A_USER_EMAIL};
 	my $d_name = $memberAttributes{$A_USER_D_NAME};
 	my $lf_name = $memberAttributes{$A_USER_LF_NAME};
@@ -137,7 +137,7 @@ sub processUsers {
 		$userStruc->{$uid}->{$u_status} = $status;
 		$userStruc->{$uid}->{$u_email} = $email;
 		$userStruc->{$uid}->{$u_name} = $d_name;
-		$userStruc->{$uid}->{$u_lf_name} = $lf_name; 
+		$userStruc->{$uid}->{$u_lf_name} = $lf_name;
 	}
 
 	processMemberships $gid, $uid;

--- a/gen/pakiti
+++ b/gen/pakiti
@@ -52,7 +52,7 @@ my $userStruc = {};
 my $directoryName = "$DIRECTORY/data/";
 mkdir $directoryName or die "Cannot create $directoryName";
 
-my @resourcesData = $data->getChildElements; 
+my @resourcesData = $data->getChildElements;
 foreach my $resourceData (@resourcesData) {
 	my %resourceAttributes= attributesToHash $resourceData->getAttributes;
 
@@ -110,7 +110,7 @@ sub processUser {
 	my $displayName = $memberAttributes{$A_USER_NAME};
 	my $eppns = $memberAttributes{$A_USER_EPPNS};
 	my $status = $memberAttributes{$A_USER_STATUS};
-	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = $STATUS_SUSPENDED; }
 
 	if(!$userStruc->{$pakitiInstance}->{$uid}) {
 		$userStruc->{$pakitiInstance}->{$uid}->{$HEADER_EMAIL} = $email;
@@ -128,7 +128,7 @@ sub processUser {
 		} elsif ($actualStatus eq $STATUS_SUSPENDED && $status eq $STATUS_EXPIRED){
 			# change from SUSPENDED to EXPIRED
 			$userStruc->{$pakitiInstance}->{$uid}->{$HEADER_STATUS} = $status;
-		}	
+		}
 	}
 
 	#always add pakiti admin info if it is set to true

--- a/gen/passwd
+++ b/gen/passwd
@@ -70,7 +70,7 @@ my %memberAttributesByLogin = ();
 foreach my $memberAttributes (@membersAttributes) {
 	my $login = $memberAttributes->{$A_USER_LOGIN};
 	my $status = $memberAttributes{$A_USER_STATUS};
-	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = $STATUS_SUSPENDED; }
 
 	#set $memberAttributes->{$A_USER_EXPIRATION} to number of days since epoch
 	#if member is not valid set expiration to 1

--- a/gen/passwd_mu
+++ b/gen/passwd_mu
@@ -73,7 +73,7 @@ my %memberAttributesByLogin = ();
 foreach my $memberAttributes (@membersAttributes) {
 	my $login = $memberAttributes->{$A_USER_LOGIN};
 	my $status = $memberAttributes{$A_USER_STATUS};
-	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
+	if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = $STATUS_SUSPENDED; }
 
 	#set $memberAttributes->{$A_USER_EXPIRATION} to number of days since epoch
 	#if member is not valid set expiration to 1

--- a/gen/scim
+++ b/gen/scim
@@ -117,7 +117,7 @@ sub processUsers {
         my %memberAttributes = attributesToHash $memberData->getAttributes;
         my $uid = $memberAttributes{$A_USER_ID};
         my $status = $memberAttributes{$A_USER_STATUS};
-        if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = STATUS_SUSPENDED; }
+        if($memberAttributes{$A_MEMBER_IS_SUSPENDED}) { $status = $STATUS_SUSPENDED; }
         my $email = $memberAttributes{$A_USER_EMAIL};
         my $d_name = $memberAttributes{$A_USER_D_NAME};
         my $login = $memberAttributes{$A_USER_LOGIN};


### PR DESCRIPTION
- There was missing $ in variable name in recently changed
  services, which handle member status.
  It caused data generating to fail.
- Now all variable usages are prepended with $.