### PR TITLE
Sort mails within the list in mailman like services

### DIFF
--- a/gen/mailman
+++ b/gen/mailman
@@ -1,4 +1,4 @@
-#!/usr/bin/perl                                                                                                                     
+#!/usr/bin/perl
 #
 # Generates members of a mailing list
 #
@@ -7,7 +7,7 @@ use warnings;
 use perunServicesInit;
 use perunServicesUtils;
 use Text::Unidecode;
-use POSIX qw/strftime/; 
+use POSIX qw/strftime/;
 
 local $::SERVICE_NAME = "mailman";
 local $::PROTOCOL_VERSION = "3.1.0";
@@ -27,8 +27,8 @@ our $A_RESOURCE_MAILING_LIST_MANAGER_MAIL;       *A_RESOURCE_MAILING_LIST_MANAGE
 
 
 
-my $mailinglistStruc = {};  # $mailinglistStruc->{"mailing list name"}->{"user's e-mail"}->{A_USER_*} 
-my $mailinglistAdminMailStruc = {};  # $mailinglistAdminMailStruc->{"mailing list name"}->{"admin's e-mail"} 
+my $mailinglistStruc = {};  # $mailinglistStruc->{"mailing list name"}->{"user's e-mail"}->{A_USER_*}
+my $mailinglistAdminMailStruc = {};  # $mailinglistAdminMailStruc->{"mailing list name"}->{"admin's e-mail"}
 
 
 my $mailinglistsDirectory = "$DIRECTORY/mailinglists";
@@ -65,7 +65,7 @@ for my $listName (keys %$mailinglistStruc) {
     # As a first line, print header
     print FILE "#MANAGERS_MAIL=", $mailinglistAdminMailStruc->{$listName},"\n";
 
-    for my $mail (keys %{$mailinglistStruc->{$listName}}) {
+    for my $mail (sort keys %{$mailinglistStruc->{$listName}}) {
       print FILE "\"", unidecode($mailinglistStruc->{$listName}->{$mail}->{$A_USER_NAME});
       print FILE "\" <", $mail, ">\n";
     }

--- a/gen/mailman_cesnet
+++ b/gen/mailman_cesnet
@@ -99,7 +99,7 @@ for my $listName (keys %$mailinglistStruc) {
 	my $fileName = "$mailinglistsDirectory/$listName";
 	open FILE,">$fileName" or die "Cannot open $fileName: $! \n";
 
-	for my $mail (keys %{$mailinglistStruc->{$listName}}) {
+	for my $mail (sort keys %{$mailinglistStruc->{$listName}}) {
 		print FILE "\"", unidecode($mailinglistStruc->{$listName}->{$mail}->{$A_USER_NAME});
 		print FILE "\" <", $mail, ">\n";
 	}

--- a/gen/mailman_cesnet_user_mail
+++ b/gen/mailman_cesnet_user_mail
@@ -98,7 +98,7 @@ for my $listName (keys %$mailinglistStruc) {
 	my $fileName = "$mailinglistsDirectory/$listName";
 	open FILE,">$fileName" or die "Cannot open $fileName: $! \n";
 
-	for my $mail (keys %{$mailinglistStruc->{$listName}}) {
+	for my $mail (sort keys %{$mailinglistStruc->{$listName}}) {
 		print FILE "\"", unidecode($mailinglistStruc->{$listName}->{$mail}->{$A_USER_NAME});
 		print FILE "\" <", $mail, ">\n";
 	}

--- a/gen/mailman_elixir
+++ b/gen/mailman_elixir
@@ -75,7 +75,7 @@ for my $listName (keys %$mailinglistStruc) {
        }
        print FILE "\n";
 
-       for my $mail (keys %{$mailinglistStruc->{$listName}}) {
+       for my $mail (sort keys %{$mailinglistStruc->{$listName}}) {
          print FILE '"', unidecode($mailinglistStruc->{$listName}->{$mail}->{$A_USER_NAME});
          print FILE '" <', $mail, ">\n";
        }

--- a/gen/mailman_meta
+++ b/gen/mailman_meta
@@ -87,7 +87,7 @@ for my $listName (keys %$mailinglistStruc) {
 	my $fileName = "$mailinglistsDirectory/$listName";
 	open FILE,">$fileName" or die "Cannot open $fileName: $! \n";
 
-	for my $mail (keys %{$mailinglistStruc->{$listName}}) {
+	for my $mail (sort keys %{$mailinglistStruc->{$listName}}) {
 		print FILE "\"", unidecode($mailinglistStruc->{$listName}->{$mail}->{$A_USER_NAME});
 		print FILE "\" <", $mail, ">\n";
 	}

--- a/gen/mailman_mu
+++ b/gen/mailman_mu
@@ -65,7 +65,7 @@ for my $listName (keys %$mailinglistStruc) {
 	# As a first line, print header
 	print FILE "#MANAGERS_MAIL=", $mailinglistAdminMailStruc->{$listName},"\n";
 
-	for my $mail (keys %{$mailinglistStruc->{$listName}}) {
+	for my $mail (sort keys %{$mailinglistStruc->{$listName}}) {
 		print FILE "\"", unidecode($mailinglistStruc->{$listName}->{$mail}->{$A_USER_NAME});
 		print FILE "\" <", $mail, ">\n";
 	}

--- a/gen/mailman_vsup
+++ b/gen/mailman_vsup
@@ -59,7 +59,7 @@ for my $listName (keys %$mailinglistStruc) {
     # As a first line, print header
     print FILE "#MANAGERS_MAIL=", $mailinglistAdminMailStruc->{$listName},"\n";
 
-    for my $mail (keys %{$mailinglistStruc->{$listName}}) {
+    for my $mail (sort keys %{$mailinglistStruc->{$listName}}) {
       print FILE "\"", unidecode($mailinglistStruc->{$listName}->{$mail}->{$A_USER_NAME});
       print FILE "\" <", $mail, ">\n";
     }


### PR DESCRIPTION
- We want to compare script results when script implementation
  changes, so we should sort output (list of mails within
  each mailing list).