### PR TITLE
Remove sorting of emails for resource-mails in o365_mu

### DIFF
--- a/gen/o365_mu
+++ b/gen/o365_mu
@@ -222,7 +222,7 @@ sub processResourceMail {
 	my $addAdditionalResponse = $data->getResourceAttributeValue( resource => $resourceId, attrName => $A_R_O365_RES_ADD_ADDITIONAL_RESPONSE );
 
 	$resourceMails->{$resName}->{$RES_ALIAS_TEXT}  = $alias ? $alias : "";
-	$resourceMails->{$resName}->{$RES_EMAIL_ADDRESES_TEXT} = $emailAddreses ? join(' ', sort @{$emailAddreses}) : "";
+	$resourceMails->{$resName}->{$RES_EMAIL_ADDRESES_TEXT} = $emailAddreses ? join(' ', @{$emailAddreses}) : "";
 	$resourceMails->{$resName}->{$RES_DISPLAY_NAME_TEXT} = $displayName ? $displayName : "";
 	$resourceMails->{$resName}->{$RES_TYPE_TEXT} = $type ? $type : "";
 	$resourceMails->{$resName}->{$RES_CAPACITY_TEXT} = $capacity ? $capacity : "";


### PR DESCRIPTION
 - there is order of emails we need to use from the Perun (for this
 reason we can't sort emails here)