### PR TITLE
Fixed sorting of output in sshkeys_root

### DIFF
--- a/gen/sshkeys_root
+++ b/gen/sshkeys_root
@@ -25,9 +25,13 @@ foreach my $memberId ($data->getMemberIdsForFacility()) {
 		push @sshKeys, @{$sshkeys} if defined $sshkeys;
 }
 
+# sort output to be comparable
+@sshKeys = uniqList @sshKeys;
+@sshKeys = sort @sshKeys;
+
 ####### output file ######################
 open SERVICE_FILE,">$service_file_name" or die "Cannot open $service_file_name: $! \n";
-foreach my $sshKey (sort uniqList @sshKeys) {
+foreach my $sshKey (@sshKeys) {
 	print SERVICE_FILE $sshKey . "\n";
 }
 close(SERVICE_FILE);


### PR DESCRIPTION
- Using uniqueList and sort together in a foreach didn't
  work, so we perform each operation separately, before
  the cycle, and assign the results back to sourcing array.