### PR TITLE
Sort output of passwd_scp and passwd_nfs4* services

### DIFF
--- a/gen/passwd
+++ b/gen/passwd
@@ -62,7 +62,7 @@ foreach my $resourceId ($data->getResourceIds()) {
 	foreach my $memberId ($data->getMemberIdsForResource(resource => $resourceId)) {
 		my $login = $data->getUserFacilityAttributeValue(attrName => $A_USER_FACILITY_LOGIN, member => $memberId);
 		my $status = $data->getMemberAttributeValue(attrName => $A_MEMBER_STATUS, member => $memberId);
-		if($data->getMemberAttributeValue(attrName => $A_MEMBER_IS_SUSPENDED, member => $memberId)) { 
+		if($data->getMemberAttributeValue(attrName => $A_MEMBER_IS_SUSPENDED, member => $memberId)) {
 			$status = $STATUS_SUSPENDED;
 		}
 
@@ -112,7 +112,7 @@ foreach my $resourceId ($data->getResourceIds()) {
 }
 
 #print data to files
-#case-insesitive sort of logins
+#case-insensitive sort of logins
 foreach my $memberLogin (sort {"\U$a" cmp "\U$b"} keys %$memberAttributesByLogin) {
 	my $memberAttributes = $memberAttributesByLogin->{$memberLogin};
 	print PASSWD $memberAttributes->{$A_USER_FACILITY_LOGIN}.":x:";

--- a/gen/passwd_mu
+++ b/gen/passwd_mu
@@ -66,7 +66,7 @@ foreach my $resourceId ($data->getResourceIds()) {
 	foreach my $memberId ($data->getMemberIdsForResource(resource => $resourceId)) {
 		my $login = $data->getUserFacilityAttributeValue(attrName => $A_USER_FACILITY_LOGIN, member => $memberId);
 		my $status = $data->getMemberAttributeValue(attrName => $A_MEMBER_STATUS, member => $memberId);
-		if($data->getMemberAttributeValue(attrName => $A_MEMBER_IS_SUSPENDED, member => $memberId)) { 
+		if($data->getMemberAttributeValue(attrName => $A_MEMBER_IS_SUSPENDED, member => $memberId)) {
 			$status = $STATUS_SUSPENDED;
 		}
 
@@ -117,7 +117,7 @@ foreach my $resourceId ($data->getResourceIds()) {
 }
 
 #print data to files
-#case-insesitive sort of logins
+#case-insensitive sort of logins
 foreach my $memberLogin (sort {"\U$a" cmp "\U$b"} keys %$memberAttributesByLogin) {
 	my $memberAttributes = $memberAttributesByLogin->{$memberLogin};
 	print PASSWD $memberAttributes->{$A_USER_FACILITY_LOGIN}.":x:";

--- a/gen/passwd_nfs4
+++ b/gen/passwd_nfs4
@@ -73,12 +73,13 @@ foreach my $resourceId ($data->getResourceIds()) {
 		}
 	}
 }
-
+#print data to files
+#case-insensitive sort of logins
 open PASSWD,">$passwd_file_name" or die "Cannot open $passwd_file_name: $! \n";
-for my $passwdLine (keys %lines) {
+for my $passwdLine (sort {"\U$a" cmp "\U$b"} keys %lines) {
 	print PASSWD $passwdLine, "\n";
 }
-for my $nfsLine (keys %nfsLines) {
+for my $nfsLine (sort {"\U$a" cmp "\U$b"} keys %nfsLines) {
 	print PASSWD $nfsLine, "\n";
 }
 close(PASSWD);

--- a/gen/passwd_nfs4_mu
+++ b/gen/passwd_nfs4_mu
@@ -81,12 +81,13 @@ foreach my $resourceId ($data->getResourceIds()) {
 		}
 	}
 }
-
+#print data to files
+#case-insensitive sort of logins
 open PASSWD,">$passwd_file_name" or die "Cannot open $passwd_file_name: $! \n";
-for my $passwdLine (keys %lines) {
+for my $passwdLine (sort {"\U$a" cmp "\U$b"} keys %lines) {
 	print PASSWD $passwdLine, "\n";
 }
-for my $nfsLine (keys %nfsLines) {
+for my $nfsLine (sort {"\U$a" cmp "\U$b"} keys %nfsLines) {
 	print PASSWD $nfsLine, "\n";
 }
 close(PASSWD);

--- a/gen/passwd_scp
+++ b/gen/passwd_scp
@@ -68,8 +68,9 @@ foreach my $resourceId ($data->getResourceIds()) {
 		}
 	}
 }
-
-for my $login (sort keys %$memberAttributesByLogin) {
+#print data to files
+#case-insensitive sort of logins
+for my $login (sort {"\U$a" cmp "\U$b"} keys %$memberAttributesByLogin) {
 	my %memberAttributes = %{$memberAttributesByLogin->{$login}};
 	$memberAttributes{$A_USER_FACILITY_HOME_MOUNT_POINT} =~ s#^.*/\./#/#;
 


### PR DESCRIPTION
- Since output of passwd service is already sorted
  (case-insensitive by login) we now do the same for
  nfs4 and scp versions.
  Order of groups of standard logins and "nfs/" logins
  is kept and they are sorted within the group.
- Whitespace cleanup and typo fixes.