### PR TITLE
Don't fail on empty o365 mails attribute

### DIFF
--- a/gen/o365_mail_forward_export
+++ b/gen/o365_mail_forward_export
@@ -44,17 +44,19 @@ foreach my $memberId ($data->getMemberIdsForFacility()) {
 	}
 
 	#members email addresses - for more members with same login can differ
-	my @memberEmailAddresses = @{$data->getMemberAttributeValue( member => $memberId, attrName => $A_MEMBER_O365_EMAIL_ADDRESSES_MU )};
-	#filter only allowed email addresses
-	foreach my $mail (@memberEmailAddresses) {
-		my $domainOfEmail = $mail;
-		$domainOfEmail =~ s/^.*@//;
-		#this email is in allowed domain, add it
-		if($allowedForwardDomains{$domainOfEmail}) {
-			$userStruc->{$login}->{$A_MEMBER_O365_EMAIL_ADDRESSES_MU}->{$mail} = 1;
+	my $memberEmailAddresses = $data->getMemberAttributeValue( member => $memberId, attrName => $A_MEMBER_O365_EMAIL_ADDRESSES_MU );
+	if (defined $memberEmailAddresses) {
+		#filter only allowed email addresses
+		foreach my $mail (@{$memberEmailAddresses}) {
+			my $domainOfEmail = $mail;
+			$domainOfEmail =~ s/^.*@//;
+			#this email is in allowed domain, add it
+			if($allowedForwardDomains{$domainOfEmail}) {
+				$userStruc->{$login}->{$A_MEMBER_O365_EMAIL_ADDRESSES_MU}->{$mail} = 1;
+			}
 		}
 	}
-} 
+}
 
 my $fileName = "$DIRECTORY/$::SERVICE_NAME";
 open FILE,">$fileName" or die "Cannot open $fileName: $! \n";


### PR DESCRIPTION
- o365 member mail addresses to forward can be
  filtered by the facility setting to empty, hence
  the script shouldn't fail on non-empty value from input.
  Especially, when it supports processing of multiple
  members for the same user (its always possible, that
  one of user members has non-empty value).