### PR TITLE
Replacing deprecated method in du_users_export

### DIFF
--- a/gen/du_users_export
+++ b/gen/du_users_export
@@ -99,7 +99,11 @@ foreach my $resourceId ($data->getResourceIds()) {
 			my $serviceUser = $data->getUserAttributeValue(attrName => $A_USER_SERVICE_USER, member => $memberId);
 			if($serviceUser) {
 				my @specificUsers = $usersAgent->getUsersBySpecificUser(specificUser => $userId);
-				my @richAssocUsersWithAttributes = $usersAgent->getRichUsersFromListOfUsersWithAttributes(users => \@specificUsers);
+				my @specificUsersIds = ();
+				foreach my $user (@specificUsers) {
+					push @specificUsersIds, $user->getId();
+				}
+				my @richAssocUsersWithAttributes = $usersAgent->getRichUsersWithAttributesByIds(ids => \@specificUsersIds);
 				foreach my $richUser (@richAssocUsersWithAttributes) {
 				
 					#prepare attributes to hash


### PR DESCRIPTION
- du_users_export used method getRichUsersFromListOfUsersWithAttributes,
which is now deprecated and therefore it was replaced by new method
getRichUsersWithAttributesByIds.