### PR TITLE
For o365 service we need to skip users without licenses

### DIFF
--- a/gen/o365_mu
+++ b/gen/o365_mu
@@ -258,6 +258,9 @@ sub processResourceMail {
 
 		foreach my $memberId($data->getMemberIdsForResourceAndGroup( resource => $resourceId, group => $groupId )) {
 			my $UCO = $data->getUserFacilityAttributeValue( member => $memberId, attrName => $A_UF_LOGIN );
+
+			#Skip all users without licenses (they can't be inside o365)
+			next unless( $users->{$UCO} );
 			my $UPN = $users->{$UCO}->{$UPN_TEXT};
 
 			if($onResourceBookInPolicy) { push @resBookInPolicy, $UPN; }


### PR DESCRIPTION
 - at this moment we can't use users without licenses for deleagetes and
 other similar purposes, we need to skip them