### PR TITLE
Services afs*, affiliation*, apache* edited to use hashed data

### DIFF
--- a/gen/afs
+++ b/gen/afs
@@ -7,14 +7,14 @@ use File::Basename;
 
 our $SERVICE_NAME = basename($0);
 our $PROTOCOL_VERSION = "3.1.1";
-my $SCRIPT_VERSION = "3.0.2";
+my $SCRIPT_VERSION = "3.0.3";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
-my $data = perunServicesInit::getHierarchicalData;
+my $data = perunServicesInit::getHashedHierarchicalData;
 
 #Constants
-our $A_USER_LOGIN;                *A_USER_LOGIN =              \'urn:perun:user_facility:attribute-def:virt:login';
+our $A_UF_LOGIN;                  *A_UF_LOGIN =                \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_F_CELL;                    *A_F_CELL =                  \'urn:perun:facility:attribute-def:def:afsCell';
 our $A_F_PARTITION;               *A_F_PARTITION =             \'urn:perun:facility:attribute-def:def:afsPartition';
 our $A_F_SERVER;                  *A_F_SERVER =                \'urn:perun:facility:attribute-def:def:afsServer';
@@ -28,49 +28,45 @@ our $A_U_ORGANIZATIONSWITHLOA;    *A_U_ORGANIZATIONSWITHLOA =  \'urn:perun:user:
 
 my $service_file_name = "$DIRECTORY/$::SERVICE_NAME";
 
-my %facilityAttributes = attributesToHash $data->getAttributes;
 #####################################
 
 ####### output file ######################
 open SERVICE_FILE,">$service_file_name" or die "Cannot open $service_file_name: $! \n";
 
-my @resourcesData = $data->getChildElements;
-foreach my $rData (@resourcesData) {
-	my %resourceAttributes = attributesToHash $rData->getAttributes;
-
-	my @membersData = $rData->getChildElements;
-	foreach my $mData (@membersData) {
-		my %memberAttributes = attributesToHash $mData->getAttributes;
-
-		print SERVICE_FILE $facilityAttributes{$A_F_SERVER} . "\t";
-		print SERVICE_FILE $facilityAttributes{$A_F_CELL} . "\t";
-		print SERVICE_FILE $facilityAttributes{$A_F_PARTITION} . "\t";
-		print SERVICE_FILE $resourceAttributes{$A_R_DEFAULT_USERS_REALM} . "\t";
-		print SERVICE_FILE ($resourceAttributes{$A_R_USERS_MOUNT_POINT} || '') . "\t";
-		print SERVICE_FILE ($resourceAttributes{$A_R_USERS_VOLUME} || '') . "\t";
-		print SERVICE_FILE ($resourceAttributes{$A_R_VOLUME} || '') . "\t";
-		print SERVICE_FILE $memberAttributes{$A_USER_LOGIN} . "\t";
+foreach my $resourceId ($data->getResourceIds()) {
+	foreach my $memberId ($data->getMemberIdsForResource(resource => $resourceId)) {
+		print SERVICE_FILE $data->getFacilityAttributeValue(attrName => $A_F_SERVER) . "\t";
+		print SERVICE_FILE $data->getFacilityAttributeValue(attrName => $A_F_CELL) . "\t";
+		print SERVICE_FILE $data->getFacilityAttributeValue(attrName => $A_F_PARTITION) . "\t";
+		print SERVICE_FILE $data->getResourceAttributeValue(attrName => $A_R_DEFAULT_USERS_REALM, resource => $resourceId) . "\t";
+		print SERVICE_FILE ($data->getResourceAttributeValue(attrName => $A_R_USERS_MOUNT_POINT, resource => $resourceId) || '') . "\t";
+		print SERVICE_FILE ($data->getResourceAttributeValue(attrName => $A_R_USERS_VOLUME, resource => $resourceId) || '') . "\t";
+		print SERVICE_FILE ($data->getResourceAttributeValue(attrName => $A_R_VOLUME, resource => $resourceId) || '') . "\t";
+		print SERVICE_FILE $data->getUserFacilityAttributeValue(attrName => $A_UF_LOGIN, member => $memberId) . "\t";
 
 		my $quota = 0;
-		if (defined($resourceAttributes{$A_R_DEFAULT_QUOTA})) {
-			if (defined($memberAttributes{$A_UF_USER_QUOTA})) {
-				if (quotaToKb($memberAttributes{$A_UF_USER_QUOTA}) > quotaToKb($resourceAttributes{$A_R_DEFAULT_QUOTA})) {
-					$quota = quotaToKb($memberAttributes{$A_UF_USER_QUOTA});
+		my $defaultQuota = $data->getResourceAttributeValue(attrName => $A_R_DEFAULT_QUOTA, resource => $resourceId);
+		my $usersQuota = $data->getUserFacilityAttributeValue(attrName => $A_UF_USER_QUOTA, member => $memberId);
+		if (defined($defaultQuota)) {
+			if (defined($usersQuota)) {
+				if (quotaToKb($usersQuota) > quotaToKb($defaultQuota)) {
+					$quota = quotaToKb($usersQuota);
 				} else {
-					$quota = quotaToKb($resourceAttributes{$A_R_DEFAULT_QUOTA});
+					$quota = quotaToKb($defaultQuota);
 				}
 			} else {
-				$quota = quotaToKb($resourceAttributes{$A_R_DEFAULT_QUOTA});
+				$quota = quotaToKb($defaultQuota);
 			}
 		}
 		print SERVICE_FILE "$quota\t";
 
-		if(defined $memberAttributes{$A_U_ORGANIZATIONSWITHLOA}->{"University of West Bohemia"}) {
+		my $organizationsWithLoa = $data->getUserAttributeValue(attrName => $A_U_ORGANIZATIONSWITHLOA, member => $memberId);
+		if(defined $organizationsWithLoa->{"University of West Bohemia"}) {
 			print SERVICE_FILE "zcu.cz" . "\n";
-		} elsif(defined $memberAttributes{$A_U_ORGANIZATIONSWITHLOA}->{"Charles University in Prague"}) {
+		} elsif(defined $organizationsWithLoa->{"Charles University in Prague"}) {
 			print SERVICE_FILE "ruk.cuni.cz" . "\n";
 		} else {
-			print SERVICE_FILE $facilityAttributes{$A_F_CELL} . "\n";
+			print SERVICE_FILE $data->getFacilityAttributeValue(attrName => $A_F_CELL) . "\n";
 		}
 	}
 }

--- a/gen/afs_group
+++ b/gen/afs_group
@@ -12,26 +12,24 @@ sub processResourceData;
 
 our $SERVICE_NAME = "afs_group";
 our $PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
-my $data = perunServicesInit::getDataWithGroups;
+my $data = perunServicesInit::getHashedDataWithGroups;
 
 #Constants
-our $A_GROUP_AFS_GROUP_NAME;      *A_GROUP_AFS_GROUP_NAME =   \'urn:perun:group_resource:attribute-def:def:afsGroupName';
+our $A_GR_AFS_GROUP_NAME;         *A_GR_AFS_GROUP_NAME =      \'urn:perun:group_resource:attribute-def:def:afsGroupName';
 our $A_USER_KERBEROS_LOGINS;      *A_USER_KERBEROS_LOGINS =   \'urn:perun:user:attribute-def:virt:kerberosLogins';
-our $A_USER_LOGIN;                *A_USER_LOGIN =             \'urn:perun:user_facility:attribute-def:virt:login';
+our $A_USER_FACILITY_LOGIN;       *A_USER_FACILITY_LOGIN =    \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_R_DEFAULT_USERS_REALM;     *A_R_DEFAULT_USERS_REALM =  \'urn:perun:resource:attribute-def:def:afsDefaultUsersRealm';
 
 #Global data structure
 our $groupStruc = {};     #$groupStruc->{$groupName}->{$login} = 1;
 
-foreach my $resourceData ($data->getChildElements) {
-	my %resourceAttrs = attributesToHash $resourceData->getAttributes;
-
-	foreach my $groupData (($resourceData->getChildElements)[0]->getChildElements) {
-		my $groupMembersLogins = processGroupData $groupData, $resourceAttrs{$A_R_DEFAULT_USERS_REALM};
+foreach my $resourceId ($data->getResourceIds()) {
+	foreach my $groupId ($data->getGroupIdsForResource(resource => $resourceId)) {
+		processGroupData $groupId, $resourceId, $data->getResourceAttributeValue(attrName => $A_R_DEFAULT_USERS_REALM, resource => $resourceId);
 	}
 }
 
@@ -52,25 +50,22 @@ perunServicesInit::finalize;
 ##############################################################################
 
 sub processGroupData {
-	my $groupData = shift;
-	my $defaultUserRealm = shift;
-	my $membersElement = ($groupData->getChildElements)[1];
-	my %groupAttributes = attributesToHash $groupData->getAttributes;
+	my ($groupId, $resourceId, $defaultUserRealm) = @_;
+	my @memberIds = $data->getMemberIdsForResourceAndGroup(resource => $resourceId, group => $groupId);
 
-	my $groupName = $groupAttributes{$A_GROUP_AFS_GROUP_NAME};
+	my $groupName = $data->getGroupResourceAttributeValue(attrName => $A_GR_AFS_GROUP_NAME, group => $groupId, resource => $resourceId);
 
 	if(defined $groupName) {
-		processMembersData $membersElement, $groupName, $defaultUserRealm;
+		processMembersData \@memberIds, $groupName, $defaultUserRealm;
 	}
 }
 
-# input: (members serviceAttributes, groupName)
+# input: (reference to member ids array, groupName, defaultUserRealm)
 # stores memers logins into $groupStruc structure
 sub processMembersData {
-	my ($membersElement, $groupName, $defaultUserRealm) = @_;
-	for my $memberData ($membersElement->getChildElements) {
-		my %memberAttributes = attributesToHash $memberData->getAttributes;
-		my $login = $memberAttributes{$A_USER_LOGIN} . '@' . $defaultUserRealm;
+	my ($memberIdsRef, $groupName, $defaultUserRealm) = @_;
+	for my $memberId (@$memberIdsRef) {
+		my $login = $data->getUserFacilityAttributeValue(attrName => $A_USER_FACILITY_LOGIN, member => $memberId) . '@' . $defaultUserRealm;
 		$groupStruc->{$groupName}->{$login} = 1;
 	}
 }

--- a/gen/apache_basic_auth
+++ b/gen/apache_basic_auth
@@ -6,31 +6,34 @@ use perunServicesUtils;
 
 local $::SERVICE_NAME = "apache_basic_auth";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
-my $data = perunServicesInit::getHierarchicalData;
+my $data = perunServicesInit::getHashedHierarchicalData;
 
 my $dir = "$DIRECTORY/$::SERVICE_NAME";
 mkdir $dir or die "Can't create dir $dir: $!";
 
 #Constants
-our $A_U_LOGIN;               *A_U_LOGIN =                 \'urn:perun:user_facility:attribute-def:virt:login';
+our $A_UF_LOGIN;              *A_UF_LOGIN =                \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_R_APACHE_AUTHZ_FILE;   *A_R_APACHE_AUTHZ_FILE =     \'urn:perun:resource:attribute-def:def:apacheAuthzFile';
 
 my $i = 0;
 my %allApacheAuthzFilesNames;
 
-foreach my $rData ($data->getChildElements) {
-	my %resourceAttributes = attributesToHash $rData->getAttributes;
-
-	# Check if there are not two same apacheAuthzFiles 
-	if(defined $allApacheAuthzFilesNames{$resourceAttributes{$A_R_APACHE_AUTHZ_FILE}}) {
-		die "Duplicate apacheAuthzFileName detected: $resourceAttributes{$A_R_APACHE_AUTHZ_FILE}";
+foreach my $resourceId ($data->getResourceIds()) {
+	# Check if there are not two same apacheAuthzFiles
+	my $apacheAuthzFile = $data->getResourceAttributeValue(attrName => $A_R_APACHE_AUTHZ_FILE, resource => $resourceId);
+	if(defined $allApacheAuthzFilesNames{$apacheAuthzFile}) {
+		die "Duplicate apacheAuthzFileName detected: $apacheAuthzFile";
 	} else {
-		$allApacheAuthzFilesNames{$resourceAttributes{$A_R_APACHE_AUTHZ_FILE}} = 1;
+		$allApacheAuthzFilesNames{$apacheAuthzFile} = $resourceId;
 	}
+}
+
+foreach my $apacheAuthzFile (sort keys %allApacheAuthzFilesNames) {
+	my $resourceId = $allApacheAuthzFilesNames{$apacheAuthzFile};
 
 	$i++;
 	my $authzFileDir = "$dir/$i";
@@ -40,18 +43,19 @@ foreach my $rData ($data->getChildElements) {
 	my $pathFile = "$authzFileDir/path";
 
 	open FILE,">$pathFile" or die "Cannot open $pathFile: $!";
-	print FILE $resourceAttributes{$A_R_APACHE_AUTHZ_FILE}, "\n";
+	print FILE $apacheAuthzFile, "\n";
 	close FILE or die "Cannot close $pathFile: $!";
 
 	my $authzFile = "$authzFileDir/authz";
 	open FILE,">$authzFile" or die "Cannot open $authzFile: $!";
 
 	my @allowedLogins = ();
-	foreach my $memberAttributes (dataToAttributesHashes $rData->getChildElements) {
-		push @allowedLogins, $memberAttributes->{$A_U_LOGIN};
+	foreach my $memberId ($data->getMemberIdsForResource(resource => $resourceId)) {
+		push @allowedLogins, $data->getUserFacilityAttributeValue(attrName => $A_UF_LOGIN, member => $memberId);
 	}
 
 	print FILE "require user ";
+	@allowedLogins = sort @allowedLogins;
 	print FILE join " ", @allowedLogins;
 	print FILE "\n";
 

--- a/gen/apache_shibboleth
+++ b/gen/apache_shibboleth
@@ -6,11 +6,11 @@ use perunServicesUtils;
 
 local $::SERVICE_NAME = "apache_shibboleth";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
-my $data = perunServicesInit::getHierarchicalData;
+my $data = perunServicesInit::getHashedHierarchicalData;
 
 my $dir = "$DIRECTORY/$::SERVICE_NAME";
 mkdir $dir or die "Can't create dir $dir: $!";
@@ -24,15 +24,18 @@ my $i = 0;
 
 my %allApacheAuthzDirNames;
 
-foreach my $rData ($data->getChildElements) {
-	my %resourceAttributes = attributesToHash $rData->getAttributes;
-
+foreach my $resourceId ($data->getResourceIds()) {
 	# Check if there are not two same apacheAuthzDirs
-	if(defined $allApacheAuthzDirNames{$resourceAttributes{$A_R_APACHE_AUTHZ_FILE}}) {
-		die "Duplicate apacheAuthzFile detected: $resourceAttributes{$A_R_APACHE_AUTHZ_FILE}";
+	my $apacheAuthzFile = $data->getResourceAttributeValue(attrName => $A_R_APACHE_AUTHZ_FILE, resource => $resourceId);
+	if(defined $allApacheAuthzDirNames{$apacheAuthzFile}) {
+		die "Duplicate apacheAuthzFile detected: $apacheAuthzFile";
 	} else {
-		$allApacheAuthzDirNames{$resourceAttributes{$A_R_APACHE_AUTHZ_FILE}} = 1;
+		$allApacheAuthzDirNames{$apacheAuthzFile} = $resourceId;
 	}
+}
+
+foreach my $apacheAuthzFile (sort keys %allApacheAuthzDirNames) {
+	my $resourceId = $allApacheAuthzDirNames{$apacheAuthzFile};
 
 	$i++;
 	my $authzFileDir = "$dir/$i";
@@ -42,21 +45,23 @@ foreach my $rData ($data->getChildElements) {
 	my $pathFile = "$authzFileDir/path";
 
 	open FILE,">$pathFile" or die "Cannot open $pathFile: $!";
-	print FILE $resourceAttributes{$A_R_APACHE_AUTHZ_FILE};
+	print FILE $apacheAuthzFile;
 	close FILE or die "Cannot close $pathFile: $!";
 
 	my $authzFile = "$authzFileDir/authz";
 	open FILE,">$authzFile" or die "Cannot open $authzFile: $!";
 
 	my @output = ();
-	foreach my $memberAttributes (dataToAttributesHashes $rData->getChildElements) {
-		my @eppns = @{$memberAttributes->{$A_U_EPPNS}};
-		push @output, "require user " . join(" ", @eppns) . " # " . $memberAttributes->{$A_U_D_NAME};
+	foreach my $memberId ($data->getMemberIdsForResource(resource => $resourceId)) {
+		my @eppns = @{$data->getUserAttributeValue(attrName => $A_U_EPPNS, member => $memberId)};
+		@eppns = sort @eppns;
+		push @output, "require user " . join(" ", @eppns) . " # " . $data->getUserAttributeValue(attrName => $A_U_D_NAME, member => $memberId);
 	}
 
 	if(@output) {
 		@output = map { convertNonAsciiToEscapedUtf8Form $_ }  @output;
 		s/\\x/\\\\x/g foreach @output;  #replace \x with \\x  (escape unicode chars)
+		@output = sort @output;
 		print FILE join "\n", @output;
 		print FILE "\n";
 	}

--- a/gen/apache_ssl
+++ b/gen/apache_ssl
@@ -6,11 +6,11 @@ use perunServicesUtils;
 
 local $::SERVICE_NAME = "apache_ssl";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
-my $data = perunServicesInit::getHierarchicalData;
+my $data = perunServicesInit::getHashedHierarchicalData;
 
 my $dir = "$DIRECTORY/$::SERVICE_NAME";
 mkdir $dir or die "Can't create dir $dir: $!";
@@ -23,15 +23,18 @@ my $i = 0;
 
 my %allApacheAuthzDirNames;
 
-foreach my $rData ($data->getChildElements) {
-	my %resourceAttributes = attributesToHash $rData->getAttributes;
-
+foreach my $resourceId ($data->getResourceIds()) {
 	# Check if there are not two same apacheAuthzDirs
-	if(defined $allApacheAuthzDirNames{$resourceAttributes{$A_R_APACHE_AUTHZ_FILE}}) {
-		die "Duplicate apacheAuthzFile detected: $resourceAttributes{$A_R_APACHE_AUTHZ_FILE}";
+	my $apacheAuthzFile = $data->getResourceAttributeValue(attrName => $A_R_APACHE_AUTHZ_FILE, resource => $resourceId);
+	if(defined $allApacheAuthzDirNames{$apacheAuthzFile}) {
+		die "Duplicate apacheAuthzFile detected: $apacheAuthzFile";
 	} else {
-		$allApacheAuthzDirNames{$resourceAttributes{$A_R_APACHE_AUTHZ_FILE}} = 1;
+		$allApacheAuthzDirNames{$apacheAuthzFile} = $resourceId;
 	}
+}
+
+foreach my $apacheAuthzFile (sort keys %allApacheAuthzDirNames) {
+	my $resourceId = $allApacheAuthzDirNames{$apacheAuthzFile};
 
 	$i++;
 	my $authzFileDir = "$dir/$i";
@@ -41,16 +44,17 @@ foreach my $rData ($data->getChildElements) {
 	my $pathFile = "$authzFileDir/path";
 
 	open FILE,">$pathFile" or die "Cannot open $pathFile: $!";
-	print FILE $resourceAttributes{$A_R_APACHE_AUTHZ_FILE}, "\n";
+	print FILE $apacheAuthzFile, "\n";
 	close FILE or die "Cannot close $pathFile: $!";
 
 	my $authzFile = "$authzFileDir/authz";
 	open FILE,">$authzFile" or die "Cannot open $authzFile: $!";
 
 	my @output = ();
-	foreach my $memberAttributes (dataToAttributesHashes $rData->getChildElements) {
-		foreach my $subjectDN (keys %{$memberAttributes->{$A_U_CERT_DNS}}) {
-			my $caDN = $memberAttributes->{$A_U_CERT_DNS}->{$subjectDN};
+	foreach my $memberId ($data->getMemberIdsForResource(resource => $resourceId)) {
+		my $userCertDns = $data->getUserAttributeValue(attrName => $A_U_CERT_DNS, member => $memberId);
+		foreach my $subjectDN (keys %$userCertDns) {
+			my $caDN = $userCertDns->{$subjectDN};
 			#strip prefixes from subjectDN
 			my $subjectDNWithoutPrefix = $subjectDN;
 			$subjectDNWithoutPrefix =~ s/^[0-9]+[:]//;
@@ -62,6 +66,7 @@ foreach my $rData ($data->getChildElements) {
 		@output = map { convertNonAsciiToEscapedUtf8Form $_ }  @output;
 		s/\\x/\\\\x/g foreach @output;  #replace \x with \\x  (escape unicode chars)
 		print FILE "SSLRequire \\\n";
+		@output = sort @output;
 		print FILE join " \\\n|| ", @output;
 		print FILE "\n";
 	}

--- a/gen/perunDataGenerator.pm
+++ b/gen/perunDataGenerator.pm
@@ -18,18 +18,58 @@ sub generateUsersDataInJSON {
 	perunServicesInit::init;
 
 	my $DIRECTORY = perunServicesInit::getDirectory;
-	my $data = perunServicesInit::getFlatData;
+	my $data = perunServicesInit::getHashedHierarchicalData;
+	my $agent = perunServicesInit->getAgent;
+	my $attributesAgent = $agent->getAttributesAgent;
+	my $servicesAgent = $agent->getServicesAgent;
+	my $service = $servicesAgent->getServiceByName( name => $::SERVICE_NAME);
+
+	my @requiredAttributesDefinitions = $attributesAgent->getRequiredAttributesDefinition(service => $service->getId);
+	my @userRequiredAttributes = ();
+	my @userFacilityRequiredAttributes = ();
+	foreach my $attrDef (@requiredAttributesDefinitions) {
+		# if attribute's namespace starts with "urn:perun:user:"
+		my $o = index $attrDef->getNamespace, "urn:perun:user:";
+		if ($o == 0) {
+			push @userRequiredAttributes, $attrDef;
+			next;
+		}
+		$o = index $attrDef->getNamespace, "urn:perun:user_facility:";
+		if ($o == 0) {
+			push @userFacilityRequiredAttributes, $attrDef;
+			next;
+		}
+	}
 	my @users;
 
 	####### prepare data ######################
-	foreach my $user (($data->getChildElements)[1]->getChildElements) {
+	my %usersIds = ();
+	foreach my $memberId ($data->getMemberIdsForFacility()) {
+		my $userId = $data->getUserIdForMember(member => $memberId);
+		if (exists($usersIds{$userId})) {
+			next;
+		} else {
+			$usersIds{$userId} = 0;
+		}
 		my $userData = {};
-		foreach my $uAttribute ($user->getAttributes) {
+
+		foreach my $userAttribute (@userRequiredAttributes) {
+			my $attrValue = $data->getUserAttributeValue(member => $memberId, attrName => $userAttribute->getName);
 			# In case there is an undefined boolean attribute, we have to change it to false
-			if ($uAttribute->getType eq "boolean" && !defined $uAttribute->getValue) {
-				$userData->{$uAttribute->getName} = \0;
+			if ($userAttribute->getType eq "boolean" && !defined $attrValue) {
+				$userData->{$userAttribute->getName} = \0;
 			} else {
-				$userData->{$uAttribute->getName} = $uAttribute->getValue;
+				$userData->{$userAttribute->getName} = $attrValue;
+			}
+		}
+
+		foreach my $userFacilityAttribute (@userFacilityRequiredAttributes) {
+			my $attrValue = $data->getUserFacilityAttributeValue(member => $memberId, attrName => $userFacilityAttribute->getName);
+			# In case there is an undefined boolean attribute, we have to change it to false
+			if ($userFacilityAttribute->getType eq "boolean" && !defined $attrValue) {
+				$userData->{$userFacilityAttribute->getName} = \0;
+			} else {
+				$userData->{$userFacilityAttribute->getName} = $attrValue;
 			}
 		}
 		push @users, $userData;
@@ -38,7 +78,7 @@ sub generateUsersDataInJSON {
 	####### output file ######################
 	my $fileName = "$DIRECTORY/$::SERVICE_NAME";
 	open FILE, ">$fileName" or die "Cannot open $fileName: $! \n";
-	print FILE JSON::XS->new->utf8->pretty->encode(\@users);
+	print FILE JSON::XS->new->utf8->pretty->canonical->encode(\@users);
 	close FILE or die "Cannot close $fileName: $! \n";
 
 	perunServicesInit::finalize;


### PR DESCRIPTION
- Services afs, afs_group, apache_basic_auth, apache_shibboleth,
apache_ssl, affiliation_mapping and affiliation_mapping_mu are now using
getHashedHierarchicalData.
- Services affiliation_mapping and affiliation_mapping_mu use subroutine
generateUsersDataInJSON from perunDataGenerator, which was edited to use
hashed data as well.