### PR TITLE
Services arcgis_mu, hadoop*, hml_json edited to use hashed data

### DIFF
--- a/gen/arcgis_mu
+++ b/gen/arcgis_mu
@@ -9,15 +9,16 @@ use utf8;
 
 local $::SERVICE_NAME = "arcgis_mu";
 local $::PROTOCOL_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
-my $data = perunServicesInit::getHierarchicalData;
+my $data = perunServicesInit::getHashedHierarchicalData;
 
 #Constants
 our $A_USER_FIRST_NAME;           *A_USER_FIRST_NAME =      \'urn:perun:user:attribute-def:core:firstName';
 our $A_USER_LAST_NAME;            *A_USER_LAST_NAME =       \'urn:perun:user:attribute-def:core:lastName';
-our $A_USER_LOGIN;                *A_USER_LOGIN =           \'urn:perun:user_facility:attribute-def:virt:login';
+our $A_USER_FACILITY_LOGIN;       *A_USER_FACILITY_LOGIN =  \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_RESOURCE_ARCGIS_ROLE;      *A_RESOURCE_ARCGIS_ROLE = \'urn:perun:resource:attribute-def:def:arcGISRole';
 
 #Headers
@@ -30,20 +31,16 @@ my $rolesHeader = "roles";
 my $usersWithRoles = {};
 
 #Prepare data to structure
-my @resourcesData = $data->getChildElements;
-foreach my $resourceData (@resourcesData) {
-	my %resourceAttributes = attributesToHash $resourceData->getAttributes;
-	my $roleOnResource = $resourceAttributes{$A_RESOURCE_ARCGIS_ROLE};
+foreach my $resourceId ($data->getResourceIds()) {
+	my $roleOnResource = $data->getResourceAttributeValue(attrName => $A_RESOURCE_ARCGIS_ROLE, resource => $resourceId);
 
 	#skip resources without rules
-	next unless($roleOnResource);
+	next unless(defined $roleOnResource);
 
-	my @membersData = $resourceData->getChildElements;
-	for my $memberData (@membersData) {
-		my %memberAttributes = attributesToHash $memberData->getAttributes;
-		my $firstName = $memberAttributes{$A_USER_FIRST_NAME};
-		my $lastName = $memberAttributes{$A_USER_LAST_NAME};
-		my $uco = $memberAttributes{$A_USER_LOGIN};
+	foreach my $memberId ($data->getMemberIdsForResource(resource => $resourceId)) {
+		my $firstName = $data->getUserAttributeValue(attrName => $A_USER_FIRST_NAME, member => $memberId);
+		my $lastName = $data->getUserAttributeValue(attrName => $A_USER_LAST_NAME, member => $memberId);
+		my $uco = $data->getUserFacilityAttributeValue(attrName => $A_USER_FACILITY_LOGIN, member => $memberId);
 
 		if($usersWithRoles->{$uco}) {
 			#user is already there, update his roles
@@ -75,7 +72,7 @@ for my $key (keys %{$usersWithRoles}) {
 my $file = "$DIRECTORY/$::SERVICE_NAME.json";
 open FILE,">$file" or die "Cannot open $file: $! \n";
 binmode(FILE);
-print FILE JSON::XS->new->utf8->pretty->encode(\@data);
+print FILE JSON::XS->new->utf8->pretty->canonical->encode(\@data);
 close (FILE) or die "Cannot close $file: $! \n";
 
 perunServicesInit::finalize;

--- a/gen/hadoop_hbase
+++ b/gen/hadoop_hbase
@@ -7,28 +7,22 @@ use perunServicesUtils;
 
 local $::SERVICE_NAME = "hadoop_hbase";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
-my $data = perunServicesInit::getHierarchicalData;
+my $data = perunServicesInit::getHashedHierarchicalData;
 
 #Constants
-our $A_USER_LOGIN;                    *A_USER_LOGIN =                \'urn:perun:user_facility:attribute-def:virt:login';
+our $A_USER_FACILITY_LOGIN;           *A_USER_FACILITY_LOGIN =       \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_FACILITY_LOGIN_NAMESPACE;      *A_FACILITY_LOGIN_NAMESPACE  = \'urn:perun:facility:attribute-def:def:loginNamespace';
 
 my $fileName = "$DIRECTORY/$::SERVICE_NAME";
 open FILE,">$fileName" or die "Cannot open $fileName: $! \n";
 
-my $sortingFunction = getAttributeSorting $A_USER_LOGIN, 1;
-
 my @logins;
-my @resourcesData = $data->getChildElements;
-foreach my $rData (@resourcesData) {
-	my @membersData = $rData->getChildElements;
-	for my $memberAttributes (dataToAttributesHashes @membersData) {
-		push(@logins, $memberAttributes->{$A_USER_LOGIN});
-	}
+foreach my $memberId ($data->getMemberIdsForFacility) {
+	push(@logins, $data->getUserFacilityAttributeValue(attrName => $A_USER_FACILITY_LOGIN, member => $memberId));
 }
 
 my @uniqueLogins = uniqList @logins;

--- a/gen/hadoop_hdfs
+++ b/gen/hadoop_hdfs
@@ -7,28 +7,22 @@ use perunServicesUtils;
 
 local $::SERVICE_NAME = "hadoop_hdfs";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
-my $data = perunServicesInit::getHierarchicalData;
+my $data = perunServicesInit::getHashedHierarchicalData;
 
 #Constants
-our $A_USER_LOGIN;                    *A_USER_LOGIN =                \'urn:perun:user_facility:attribute-def:virt:login';
+our $A_USER_FACILITY_LOGIN;           *A_USER_FACILITY_LOGIN =       \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_FACILITY_LOGIN_NAMESPACE;      *A_FACILITY_LOGIN_NAMESPACE  = \'urn:perun:facility:attribute-def:def:loginNamespace';
 
 my $fileName = "$DIRECTORY/$::SERVICE_NAME";
 open FILE,">$fileName" or die "Cannot open $fileName: $! \n";
 
-my $sortingFunction = getAttributeSorting $A_USER_LOGIN, 1;
-
 my @logins;
-my @resourcesData = $data->getChildElements;
-foreach my $rData (@resourcesData) {
-	my @membersData = $rData->getChildElements;
-	for my $memberAttributes (dataToAttributesHashes @membersData) {
-		push(@logins, $memberAttributes->{$A_USER_LOGIN});
-	}
+foreach my $memberId ($data->getMemberIdsForFacility) {
+	push(@logins, $data->getUserFacilityAttributeValue(attrName => $A_USER_FACILITY_LOGIN, member => $memberId));
 }
 
 my @uniqueLogins = uniqList @logins;

--- a/gen/hml_json
+++ b/gen/hml_json
@@ -8,11 +8,11 @@ use JSON::XS;
 
 our $SERVICE_NAME = "hml_json";
 our $PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
-my $data = perunServicesInit::getHierarchicalData;
+my $data = perunServicesInit::getHashedHierarchicalData;
 
 #Constants
 our $A_USER_FIRSTNAME;            *A_USER_FIRSTNAME =        \'urn:perun:user:attribute-def:core:firstName';
@@ -20,32 +20,27 @@ our $A_USER_LASTNAME;             *A_USER_LASTNAME =         \'urn:perun:user:at
 our $A_USER_LOGIN;                *A_USER_LOGIN=             \'urn:perun:user:attribute-def:def:login-namespace:mu';
 our $A_USER_MAIL;                 *A_USER_MAIL =             \'urn:perun:user:attribute-def:def:preferredMail';
 
-my %attributesByLogin;
+my %usersByLogin;
 
-my @resourcesData = $data->getChildElements;
-foreach my $rData (@resourcesData) {
-	my @membersData = $rData->getChildElements;
-	foreach my $mData (@membersData) {
-		my %memberAttributes = attributesToHash $mData->getAttributes;
-		$attributesByLogin{$memberAttributes{$A_USER_LOGIN}} = \%memberAttributes;
-	}
+foreach my $memberId ($data->getMemberIdsForFacility) {
+	my $user = {};
+	$user->{"firstname"} = $data->getUserAttributeValue(attrName => $A_USER_FIRSTNAME, member => $memberId) || "";
+	$user->{"lastname"} = $data->getUserAttributeValue(attrName => $A_USER_LASTNAME, member => $memberId) || "";
+	my $login = $data->getUserAttributeValue(attrName => $A_USER_LOGIN, member => $memberId);
+	$user->{"UCO"} = $login;
+	$user->{"email"} = $data->getUserAttributeValue(attrName => $A_USER_MAIL, member => $memberId);
+	$usersByLogin{$login} = $user;
 }
 
 
 my @users;
-for my $login (sort keys %attributesByLogin) {
-	my $values = $attributesByLogin{$login};
-	my $user = {};
-	$user->{"firstname"} = $values->{$A_USER_FIRSTNAME} || "";
-	$user->{"lastname"}  = $values->{$A_USER_LASTNAME} || "";
-	$user->{"UCO"}       = $values->{$A_USER_LOGIN};
-	$user->{"email"}     = $values->{$A_USER_MAIL};
-	push @users, $user;
+for my $login (sort keys %usersByLogin) {
+	push @users, $usersByLogin{$login};
 }
 
 my $fileName = "$DIRECTORY/$SERVICE_NAME";
 open FILE, ">$fileName" or die "Cannot open $fileName: $! \n";
-print FILE JSON::XS->new->utf8->pretty->encode(\@users);
+print FILE JSON::XS->new->utf8->pretty->canonical->encode(\@users);
 close FILE or die "Cannot close $fileName: $! \n";
 
 perunServicesInit::finalize;


### PR DESCRIPTION
- Services arcgis_mu, hadoop_hbase, hadoop_hdfs and hml_json are now
using getHashedHierarchicalData.
- Services arcgis_mu and hml_json were not manually tested.