### PR TITLE
New service netbox

### DIFF
--- a/gen/netbox
+++ b/gen/netbox
@@ -1,0 +1,82 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use perunServicesInit;
+use perunServicesUtils;
+use Perun::Agent;
+use JSON::XS;
+use Data::Dumper;
+
+our $SERVICE_NAME     = "netbox";
+our $PROTOCOL_VERSION = "3.0.0";
+my  $SCRIPT_VERSION   = "3.0.0";
+
+my $file_name_users = "netbox_users";
+my $file_name_groups = "netbox_groups";
+
+perunServicesInit::init;
+my $DIRECTORY = perunServicesInit::getDirectory;
+my $data =      perunServicesInit::getHashedHierarchicalData(1);
+
+#Constants
+our $A_RESOURCE_GROUP_NAME;       *A_RESOURCE_GROUP_NAME =   \'urn:perun:resource:attribute-def:def:netboxGroupName';
+our $A_RESOURCE_IS_STAFF;         *A_RESOURCE_IS_STAFF =     \'urn:perun:resource:attribute-def:def:netboxIsStaff';
+
+our $A_USER_FACILITY_LOGIN;       *A_USER_FACILITY_LOGIN =   \'urn:perun:user_facility:attribute-def:virt:login';
+
+our $A_USER_FIRSTNAME;            *A_USER_FIRSTNAME =        \'urn:perun:user:attribute-def:core:firstName';
+our $A_USER_LASTNAME;             *A_USER_LASTNAME =         \'urn:perun:user:attribute-def:core:lastName';
+our $A_USER_MAIL;                 *A_USER_MAIL =             \'urn:perun:user:attribute-def:def:preferredMail';
+
+our $IS_ACTIVE;                   *IS_ACTIVE =                \JSON::XS::true;
+
+my $users = {};
+my $groups = {};
+
+foreach my $resourceId ($data->getResourceIds()) {
+
+	my $groupName = $data->getResourceAttributeValue(resource => $resourceId, attrName => $A_RESOURCE_GROUP_NAME);
+	my $isStaff   = $data->getResourceAttributeValue(resource => $resourceId, attrName => $A_RESOURCE_IS_STAFF) || JSON::XS::false;
+	next unless $groupName;
+	$groups->{$groupName} = 1;
+
+	foreach my $memberId ($data->getMemberIdsForResource(resource => $resourceId)) {
+
+		my $uco = $data->getUserFacilityAttributeValue(member => $memberId, attrName => $A_USER_FACILITY_LOGIN);
+		my $login = "$uco\@muni.cz";
+
+		if ($users->{$login}) {
+			if ($isStaff){
+				$users->{$login}->{"is_staff"} = $isStaff;
+			}
+			push @{$users->{$login}->{"groups"}}, $groupName;
+		} else {
+			my $firstName = $data->getUserAttributeValue(member => $memberId, attrName => $A_USER_FIRSTNAME);
+			my $lastName  = $data->getUserAttributeValue(member => $memberId, attrName => $A_USER_LASTNAME);
+			my $mail      = $data->getUserAttributeValue(member => $memberId, attrName => $A_USER_MAIL);
+
+			my $user = {};
+			$user->{"username"}   = $login;
+			$user->{"first_name"} = $firstName || "";
+			$user->{"last_name"}  = $lastName  || "";
+			$user->{"email"}      = $mail      || "";
+			$user->{"is_active"}  = $IS_ACTIVE;
+			$user->{"is_staff"}   = $isStaff;
+			$user->{"groups"}   = [$groupName];
+
+			$users->{$login} = $user;
+		}
+	}
+}
+
+my $file_users = "$DIRECTORY/$file_name_users";
+open FILE, ">$file_users" or die "Cannot open $file_users: $! \n";
+print FILE JSON::XS->new->utf8->pretty->canonical->encode($users);
+close FILE or die "Cannot close $file_users: $! \n";
+
+my $file_groups = "$DIRECTORY/$file_name_groups";
+open FILE, ">$file_groups" or die "Cannot open $file_groups: $! \n";
+print FILE JSON::XS->new->utf8->pretty->canonical->encode($groups);
+close FILE or die "Cannot close $file_groups: $! \n";
+
+perunServicesInit::finalize;

--- a/send/netbox
+++ b/send/netbox
@@ -1,0 +1,262 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use Getopt::Long qw(:config no_ignore_case);
+use LWP::UserAgent;
+use HTTP::Request;
+use HTTP::Headers;
+use JSON;
+use POSIX qw(strftime);
+use Encode qw(decode_utf8);
+
+#We want to have data in UTF8 on output
+binmode STDOUT, ':utf8';
+binmode STDERR, ':utf8';
+
+#parse arguments in utf8
+@ARGV = map { decode_utf8($_, 1) } @ARGV;
+
+# define service
+my $service_name = "netbox";
+
+# facility name
+my $facility_name = $ARGV[0];
+chomp($facility_name);
+
+# propagation destination
+my $destination = $ARGV[1];
+chomp($destination);
+
+# GEN folder location
+my $service_files_base_dir="../gen/spool";
+my $service_files_dir="$service_files_base_dir/$facility_name/$service_name";
+my $users_file_name = "$service_files_dir/netbox_users";
+my $groups_file_name = "$service_files_dir/netbox_groups";
+
+# Authorization TOKEN
+open(my $file, '<', "/etc/perun/$service_name")
+	or die("Can't open /etc/perun/$service_name: $!\n");
+my $TOKEN = <$file>;
+chomp($TOKEN);
+close $file;
+
+#Constants
+my $URL = $destination;
+my $USERS_API = "$URL/api/users/users/";
+my $GROUPS_API = "$URL/api/users/groups/";
+my $RESULTS = "results";
+my $NEXT = "next";
+my $TYPE_GET = 'GET';
+my $TYPE_POST = 'POST';
+my $TYPE_PATCH = 'PATCH';
+
+#All possible exceptions
+my $ERROR_COM_PROBLEM = "Communication problem with server, before processing command itself!\n";
+
+###################### MAIN CODE ######################
+
+# Fetch users data from perun
+my $json_users = do {
+	open(my $json_fh, "<:encoding(UTF-8)", $users_file_name)
+		or die("Can't open \$users_file_name\": $!\n");
+	local $/;
+	<$json_fh>
+};
+
+# Fetch Groups data from perun
+my $json_groups = do {
+	open(my $json_fh, "<:encoding(UTF-8)", $groups_file_name)
+		or die("Can't open \$groups_file_name\": $!\n");
+	local $/;
+	<$json_fh>
+};
+
+# Transform data from perun into hash
+my $perun_users = JSON->new->decode($json_users);
+my $perun_groups = JSON->new->decode($json_groups);
+
+# Fetch users data from netbox
+my $response_users = call_server($USERS_API, $TYPE_GET, {});
+my @netbox_users = @{$response_users->{$RESULTS}};
+while($response_users->{$NEXT}) {
+	$response_users = call_server($response_users->{$NEXT}, $TYPE_GET, {});
+	push @netbox_users, @{$response_users->{$RESULTS}};
+}
+
+# Fetch groups data from netbox
+my $response_groups = call_server($GROUPS_API, $TYPE_GET, {});
+my @netbox_groups = @{$response_groups->{$RESULTS}};
+while($response_groups->{$NEXT}) {
+	$response_groups = call_server($response_groups->{$NEXT}, $TYPE_GET, {});
+	push @netbox_groups, @{$response_groups->{$RESULTS}};
+}
+
+# Create hash of users for easier manipulation
+my $netbox_users_hash = {};
+for my $netbox_user (@netbox_users) {
+	$netbox_users_hash->{$netbox_user->{"username"}} = $netbox_user;
+}
+
+# Create hash of groups for easier manipulation
+my $netbox_groups_hash = {};
+for my $netbox_group (@netbox_groups) {
+	$netbox_groups_hash->{$netbox_group->{"name"}} = $netbox_group->{"id"};
+}
+
+# Create groups in netbox and associate all netbox groups ids with perun group names
+foreach (keys %$perun_groups) {
+	if (exists $netbox_groups_hash->{$_}) {
+		$perun_groups->{$_} = $netbox_groups_hash->{$_};
+	} else {
+		my $created_group = call_server($GROUPS_API, $TYPE_POST, {"name" => $_});
+		$perun_groups->{$created_group->{"name"}} = $created_group->{"id"};
+	}
+}
+
+# Create users in netbox
+foreach (keys %$perun_users) {
+	unless (exists $netbox_users_hash->{$_}) {
+		my $user = $perun_users->{$_};
+		my @alphanumeric = ('a'..'z', 'A'..'Z', 0..9);
+		my $randpassword = join '', map $alphanumeric[rand @alphanumeric], 0..10;
+		$user->{"password"} = $randpassword;
+		my @groups_ids = ();
+		for my $name (@{$user->{"groups"}}) {
+			my $group_id = $perun_groups->{$name};
+			push @groups_ids, int($group_id);
+		}
+		$user->{"groups"} = \@groups_ids;
+		call_server($USERS_API, $TYPE_POST, $user);
+	}
+}
+
+# Update existing netbox users
+foreach (keys %$netbox_users_hash) {
+	my @users_to_update = ();
+	if (exists $perun_users->{$_}) {
+		my $user = $perun_users->{$_};
+		$user->{"id"} = $netbox_users_hash->{$_}->{"id"};
+		my @groups_ids = ();
+		for my $name (@{$user->{"groups"}}) {
+			my $group_id = $perun_groups->{$name};
+			push @groups_ids, int($group_id);
+		}
+		$user->{"groups"} = \@groups_ids;
+		push @users_to_update, $user;
+	} else {
+		my $user = $netbox_users_hash->{$_};
+		$user->{"is_active"} = \0;
+		$user->{"groups"} = [];
+		push @users_to_update, $user;
+	}
+	call_server($USERS_API, $TYPE_PATCH, \@users_to_update);
+}
+
+###################### SUBROUTINES ######################
+
+#Name:
+# callServer
+#-----------------------
+#Parameters:
+# url     - url of server and method address to call
+# type    - GET, POST or PATCH
+# content - hash content of request, will be encoded to json output
+#-----------------------
+#Returns:
+# hash of response content
+# die in case of an error
+#-----------------------
+#Description:
+# This method calls specific url with GET, POST or PATCH connection type and predefined content in json.
+# After that it check response, if there is correct answer or error.
+# If there is no server error, it returns resolved status of this call.
+#-----------------------
+sub call_server {
+	my $url = shift;
+	my $type = shift;
+	my $content = shift;
+
+	my $json_content = JSON->new->utf8->encode( $content );
+
+	my $server_response = create_connection( $url, $type, $json_content );
+	return check_server_response( $server_response );
+}
+
+#Name:
+# createConnection
+#-----------------------
+#Parameters:
+# url     - url of server and method address to call
+# type    - GET, POST or PATCH
+# content - json with data
+#-----------------------
+#Returns: Response of server on our request.
+#-----------------------
+#Description:
+# This method just takes all parameters and creates connection to the server.
+# Then returns it's repsonse.
+#-----------------------
+sub create_connection {
+	my $url = shift;
+	my $type = shift;
+	my $content = shift;
+
+	my $headers = HTTP::Headers->new;
+	$headers->header('Content-Type' => 'application/json');
+	$headers->header('Accept' => 'application/json,text/json');
+	$headers->header('Authorization' => 'Token ' . $TOKEN);
+
+	my $ua = LWP::UserAgent->new;
+	my $request = HTTP::Request->new( $type, $url, $headers, $content );
+	return $ua->request($request);
+}
+
+#Name:
+# checkServerResponse
+#-----------------------
+#Parameters:
+# response - response from server in JSON format
+#-----------------------
+#Returns: decoded json respons if response is success, die if response of server is not success
+#-----------------------
+#Description:
+# This method checks if response of server was success. If yes, return decoded json response,
+# if not, die with error.
+#-----------------------
+sub check_server_response {
+	my $response = shift;
+	my $response_json;
+
+	if ($response->is_success) {
+		$response_json = JSON->new->utf8->decode( $response->content );
+	} else {
+		my $response_info = $response->status_line . "\n" . $response->decoded_content . "\n";
+		die_pretty( $ERROR_COM_PROBLEM, $response_info );
+	}
+	return $response_json;
+}
+
+#Name:
+# diePretty
+#-----------------------
+#Parameters:
+# errorMessage  - basic error information (one of predefined errors)
+# moreErrorInfo - more specific information about basic error
+#-----------------------
+#Returns:
+#-----------------------
+#Description:
+# This is just exit with error with more information and human readable text formating.
+#-----------------------
+sub die_pretty {
+	my $error_message = shift;
+	my $more_error_info = shift;
+	my $date_string = strftime "%D %H:%M:%S \n", localtime;
+	my $row_delimeter = "------------------------------------------------------------------------\n";                                                    #OK
+	my $status =       "               STATUS = ERROR\n";
+
+	$error_message = "\n" . $row_delimeter . $status . $row_delimeter . $date_string . $error_message . $row_delimeter . $more_error_info  . $row_delimeter . "\n";
+
+	die $error_message;
+}


### PR DESCRIPTION
- gen script fetches resources and their assigned members. For resources
  fetches netboxGroupName which serves as a group name in the destination
  and netboxIsStaff which indicates is_staff value for its members.
  Resources without the name attribute are skipped. We fetch name, email
  login, for each user. is_active is set to true and is_staff to false. These two
  are attributes in netbox. We set them in gen script in case, we will
  fill them from perun in the future. groups list is filled with
  netboxGroupName attribute for each member's resource.
- send script creates missing groups first. Then creates missing users.
  In this part we generate also password and set group membership. In
  the end we update users. If user does not exists in perun but exists
  in netbox he is set to inactive and his group list is erased. If he
  exists both in perun and netbox, his attributes are updated except
  password. laso group membership is updated in this part. We do not
  delete users and groups. When group does not exists in perun but
  exists in netbox. It will be empty in the end of the process.
- for this service is needed file with name netbox in /etc/perun/, which
  contains authorization token. Destination needs to be set to without
  trailing "/".