### PR TITLE
Updated slave scripts for fs_home and k5login

### DIFF
--- a/slave/process-fs-home/bin/process-fs_home.sh
+++ b/slave/process-fs-home/bin/process-fs_home.sh
@@ -84,7 +84,9 @@ function process {
 	while IFS=`echo -e "\t"` read U_HOME_MNT_POINT U_LOGNAME U_UID U_GID USER_STATUS USER_GROUPS REST_OF_LINE; do
 		HOME_DIR="${U_HOME_MNT_POINT}/${U_LOGNAME}"
 
+		CONT=0
 		run_mid_hooks
+		if [[ $CONT -eq 1 ]]; then continue; fi
 
 		if [ ! -d "${HOME_DIR}" ]; then
 

--- a/slave/process-fs-home/changelog
+++ b/slave/process-fs-home/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-fs-home (3.1.10) stable; urgency=low
+
+  * It is now possible to skip creating a home directory from mid hook.
+
+ -- Radoslav Cerhak <r.cerhak@gmail.com>  Fri, 30 Apr 2021 10:45:00 +0200
+
 perun-slave-process-fs-home (3.1.9) stable; urgency=high
 
   * main file with data was divided into two files - first with data to create

--- a/slave/process-k5login/bin/process-k5login.sh
+++ b/slave/process-k5login/bin/process-k5login.sh
@@ -26,6 +26,9 @@ function process {
 		PRINCIPALS=`echo "${line}" | sed -e 's/^[^\t]*[\t]//'`
 		K5LOGIN="${HOME_DIR}/.k5login"
 
+		# skip creation if homedir does not exist
+		if [[ ! -d ${HOME_DIR} ]]; then continue; fi
+
 		#set home dir of user as current working directory
 		catch_error E_DIR_NOT_EXISTS cd "${HOME_DIR}"
 

--- a/slave/process-k5login/changelog
+++ b/slave/process-k5login/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-k5login (3.1.7) stable; urgency=low
+
+  * Skip creating k5login files in home directories that don't exist.
+
+ -- Radoslav Cerhak <r.cerhak@gmail.com>  Fri, 30 Apr 2021 10:45:00 +0200
+
 perun-slave-process-k5login (3.1.6) stable; urgency=low
 
   * Skip information about not changed k5login files. This information is


### PR DESCRIPTION
- In process-fs_home it is now possible to skip creating a home
directory from mid hook.
- process-k5login now skips creating k5login files in home directories
that don't exist.