### PR TITLE
fix(slave): prevent unnecessary update of modification timestamps on k5login files

### DIFF
--- a/slave/process-k5login/bin/process-k5login.sh
+++ b/slave/process-k5login/bin/process-k5login.sh
@@ -32,6 +32,23 @@ function process {
 		#set home dir of user as current working directory
 		catch_error E_DIR_NOT_EXISTS cd "${HOME_DIR}"
 
+		#is there anything new to be added?
+		ADDED_PRINCIPALS=""
+		for PRINCIPAL in ${PRINCIPALS}; do
+			grep "^${PRINCIPAL}\\s*\$" "${K5LOGIN}" > /dev/null
+			if [ "$?" -eq 1 ]; then
+				ADDED_PRINCIPALS="${PRINCIPAL}"
+				break
+			fi
+		done
+
+		#if nothing to add, can skip to another user
+		if [ -z "${ADDED_PRINCIPALS}" ]; then
+			#skip this log, not important information for administrators
+			#log_msg I_K5LOGIN_NOT_UPDATED
+			continue
+		fi
+
 		#prepare empty temporary file
 		TMP_K5LOGIN=`mktemp --tmpdir=${HOME_DIR} .k5login-from-perun.XXXXXXXXX`
 		if [ "$?" -ne 0 ]; then

--- a/slave/process-k5login/changelog
+++ b/slave/process-k5login/changelog
@@ -1,3 +1,10 @@
+perun-slave-process-k5login (3.1.8) stable; urgency=medium
+
+  * Do not overwrite k5login files that have not changed.
+    It prevents unnecessary change in modification timestamps.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Mon, 23 Aug 2021 11:58:00 +0200
+
 perun-slave-process-k5login (3.1.7) stable; urgency=low
 
   * Skip creating k5login files in home directories that don't exist.
@@ -9,7 +16,7 @@ perun-slave-process-k5login (3.1.6) stable; urgency=low
   * Skip information about not changed k5login files. This information is
     not important for administrators of a service.
 
- -- Michal Stava <stavamichal@gmail.com> Wed, 03 Jun 2020 14:57:00 +0200
+ -- Michal Stava <stavamichal@gmail.com>  Wed, 03 Jun 2020 14:57:00 +0200
 
 perun-slave-process-k5login (3.1.5) stable; urgency=medium
 


### PR DESCRIPTION
If there is no change to the .k5login file, we shouldn't replace it.