### PR TITLE
build: fixed priority in debian packaging

### DIFF
--- a/other/generic-package/debian/control
+++ b/other/generic-package/debian/control
@@ -1,6 +1,6 @@
 Source: generic-package
 Section: utils
-Priority: extra
+Priority: optional
 Maintainer: Michal Stava <stavamichal@gmail.com>
 Build-Depends: debhelper (>= 8.0.0)
 Standards-Version: 3.9.5

--- a/other/perun-propagate/debian/changelog
+++ b/other/perun-propagate/debian/changelog
@@ -1,3 +1,9 @@
+perun-propagate (3.0.9) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-propagate (3.0.8) stable; urgency=medium
 
   * define missing lsb functions for rhel compatibility

--- a/other/perun-propagate/debian/control
+++ b/other/perun-propagate/debian/control
@@ -1,8 +1,8 @@
 Source: perun-propagate
 Section: utils
-Priority: extra
+Priority: optional
 Maintainer: Pavel Zlamal <zlamal@cesnet.cz>
-Build-Depends: debhelper (>= 7)
+Build-Depends: debhelper (>= 8.0.0)
 Standards-Version: 3.9.5
 
 Package: perun-propagate

--- a/other/perun-slave-metacentrum/debian/changelog
+++ b/other/perun-slave-metacentrum/debian/changelog
@@ -1,3 +1,9 @@
+perun-slave-metacentrum (3.0.8) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-metacentrum (3.0.7) stable; urgency=medium
 
   * removed pbs-phys-cluster and pbs-pre

--- a/other/perun-slave-metacentrum/debian/control
+++ b/other/perun-slave-metacentrum/debian/control
@@ -1,6 +1,6 @@
 Source: perun-slave-metacentrum
 Section: utils
-Priority: extra
+Priority: optional
 Maintainer: Michal Stava <stavamichal@gmail.com>
 Build-Depends: debhelper (>= 8.0.0)
 Standards-Version: 3.9.5
@@ -10,5 +10,5 @@ Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Conflicts: perun-slave-meta, perun-slave
 Description: Package with required dependencies for slave scripts in Metacentrum.
- Package containing all dependencies needed for regular 
+ Package containing all dependencies needed for regular
  work of Perun in the Metacentrum.

--- a/slave/base/changelog
+++ b/slave/base/changelog
@@ -1,3 +1,9 @@
+perun-slave-base (3.1.18) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 19 Jan 2023 08:30:00 +0100
+
 perun-slave-base (3.1.17) stable; urgency=low
 
   * Added function log_warn_to_err_exit() that prints message to

--- a/slave/meta/changelog
+++ b/slave/meta/changelog
@@ -1,3 +1,9 @@
+perun-slave-full (3.1.17) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-full (3.1.16) stable; urgency=medium
 
   * new service oidc-with-groups-einfra

--- a/slave/process-affiliation-mapping-mu/changelog
+++ b/slave/process-affiliation-mapping-mu/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-affiliation-mapping-mu (3.1.2) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-affiliation-mapping-mu (3.1.1) stable; urgency=low
 
   * New package version for perun-slave-process-affiliation-mapping-mu

--- a/slave/process-affiliation-mapping/changelog
+++ b/slave/process-affiliation-mapping/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-affiliation-mapping (3.1.2) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-affiliation-mapping (3.1.1) stable; urgency=low
 
   * New package version for perun-slave-process-affiliation-mapping

--- a/slave/process-afs-group/changelog
+++ b/slave/process-afs-group/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-afs-group (3.1.5) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-afs-group (3.1.4) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-afs/changelog
+++ b/slave/process-afs/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-afs (3.1.9) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-afs (3.1.8) stable; urgency=medium
 
   * Fixed escaping in echo of failed commands

--- a/slave/process-apache-basic-auth/changelog
+++ b/slave/process-apache-basic-auth/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-apache-basic-auth (3.1.5) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-apache-basic-auth (3.1.4) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-apache-shibboleth/changelog
+++ b/slave/process-apache-shibboleth/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-apache-shibboleth (3.1.3) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-apache-shibboleth (3.1.2) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-apache-ssl/changelog
+++ b/slave/process-apache-ssl/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-apache-ssl (3.1.5) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-apache-ssl (3.1.4) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-drupal-elixir/changelog
+++ b/slave/process-drupal-elixir/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-drupal-elixir (3.1.8) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 19 Jan 2023 08:30:00 +0100
+
 perun-slave-process-drupal-elixir (3.1.7) stable; urgency=low
   * upon finding duplicates the script now exits with an ok error code
     to prevent rerun of propagation with the same data

--- a/slave/process-eduroam-block/changelog
+++ b/slave/process-eduroam-block/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-eduroam-block (3.0.3) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-eduroam-block (3.0.2) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-eduroam-radius/changelog
+++ b/slave/process-eduroam-radius/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-eduroam-radius (3.1.5) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-eduroam-radius (3.1.4) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-fs-home/changelog
+++ b/slave/process-fs-home/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-fs-home (3.1.11) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-fs-home (3.1.10) stable; urgency=low
 
   * It is now possible to skip creating a home directory from mid hook.
@@ -15,12 +21,12 @@ perun-slave-process-fs-home (3.1.9) stable; urgency=high
   * some arguments as user login, home mount point, gid etc. were removed from
     quotas template in script and also in pre script
   * this version of service fs_home supports new quotas attributes in Perun,
-    although format of data in the file is the same. To active it administrator 
+    although format of data in the file is the same. To active it administrator
     has to set attribute readyForNewQuotas on Facility to 'true'
   * Protocol version was increased, new format is not supported with older
     versions of protocol communication
-  * IMPORTANT: pre|post scripts and mid hooks can be also affected by these 
-    changes and administrator should check and modify their behavior before 
+  * IMPORTANT: pre|post scripts and mid hooks can be also affected by these
+    changes and administrator should check and modify their behavior before
     updating to this version
 
  -- Michal Stava <stavamichal@gmail.com>  Tue, 02 Apr 2019 13:25:00 +0200

--- a/slave/process-fs-project/changelog
+++ b/slave/process-fs-project/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-fs-project (3.1.8) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-fs-project (3.1.7) stable; urgency=medium
 
   * Changed architecture to all
@@ -6,7 +12,7 @@ perun-slave-process-fs-project (3.1.7) stable; urgency=medium
 
 perun-slave-process-fs-project (3.1.6) stable; urgency=high
 
-  * setfacl need to set also permissions for owner itself, not just user. 
+  * setfacl need to set also permissions for owner itself, not just user.
     This will prevent situation where owner can't access own directory.
 
  -- Michal Stava <Michal.Stava@cesnet.cz>  Tue, 09 Oct 2018 14:10:00 +0200

--- a/slave/process-fs-quotas/changelog
+++ b/slave/process-fs-quotas/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-fs-quotas (3.1.5) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-fs-quotas (3.1.4) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-fs-scratch-local/changelog
+++ b/slave/process-fs-scratch-local/changelog
@@ -1,6 +1,12 @@
+perun-slave-process-fs-scratch-local (3.1.8) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-fs-scratch-local (3.1.7) stable; urgency=low
 
-  * Remove quotas from slave script. This part of service fs-scratch-local 
+  * Remove quotas from slave script. This part of service fs-scratch-local
 	  is not used correctly and will be reworked in the future.
   * Protocol version was increased because input data were changed.
 

--- a/slave/process-fs-scratch/changelog
+++ b/slave/process-fs-scratch/changelog
@@ -1,6 +1,12 @@
+perun-slave-process-fs-scratch (3.1.8) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-fs-scratch (3.1.7) stable; urgency=low
 
-  * Remove quotas from slave script. This part of service fs-scratch 
+  * Remove quotas from slave script. This part of service fs-scratch
     is not used correctly and will be reworked in the future.
   * Protocol version was increased because input data were changed.
 

--- a/slave/process-group-nfs4/changelog
+++ b/slave/process-group-nfs4/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-group-nfs4 (3.1.7) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-group-nfs4 (3.1.6) stable; urgency=medium
 
   * Changed architecture to all
@@ -13,7 +19,7 @@ perun-slave-process-group-nfs4 (3.1.5) stable; urgency=low
 perun-slave-process-group-nfs4 (3.1.4) stable; urgency=high
 
   * Use more gidRanges instead of one limited by min and max gid.
-  * Major protocol version was increased (this change will not work with 
+  * Major protocol version was increased (this change will not work with
    older protocol versions)
 
  -- Michal Stava <stavamichal@gmail.com>  Wed, 17 Jan 2018 15:31:00 +0100

--- a/slave/process-group/changelog
+++ b/slave/process-group/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-group (3.1.7) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-group (3.1.6) stable; urgency=medium
 
   * Changed architecture to all
@@ -13,7 +19,7 @@ perun-slave-process-group (3.1.5) stable; urgency=low
 perun-slave-process-group (3.1.4) stable; urgency=high
 
   * Use more gidRanges instead of one limited by min and max gid.
-  * Major protocol version was increased (this change will not work with 
+  * Major protocol version was increased (this change will not work with
     older protocol versions)
 
  -- Michal Stava <stavamichal@gmail.com>  Wed, 17 Jan 2018 15:31:00 +0100

--- a/slave/process-hadoop-hbase/changelog
+++ b/slave/process-hadoop-hbase/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-hadoop-hbase (1.0.2) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-hadoop-hbase (1.0.1) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-hadoop-hdfs/changelog
+++ b/slave/process-hadoop-hdfs/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-hadoop-hdfs (1.0.2) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-hadoop-hdfs (1.0.1) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-k5login-generic/changelog
+++ b/slave/process-k5login-generic/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-k5login-generic (3.1.6) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-k5login-generic (3.1.5) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-k5login-root/changelog
+++ b/slave/process-k5login-root/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-k5login-root (3.1.6) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-k5login-root (3.1.5) stable; urgency=low
 
   * Add possibility to change destination file (default is /root/.k5login).

--- a/slave/process-k5login/changelog
+++ b/slave/process-k5login/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-k5login (3.1.10) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-k5login (3.1.9) stable; urgency=medium
 
   * Check k5login file exists before trying to crosscheck its entries

--- a/slave/process-kerberos-renewal-principals/changelog
+++ b/slave/process-kerberos-renewal-principals/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-kerberos-renewal-principals (3.0.2) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-kerberos-renewal-principals (3.0.1) stable; urgency=low
 
   * Handled receive of many files from perun.

--- a/slave/process-ldap-vsb-vi/changelog
+++ b/slave/process-ldap-vsb-vi/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-ldap-vsb-vi (3.1.6) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-ldap-vsb-vi (3.1.5) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-ldap/changelog
+++ b/slave/process-ldap/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-ldap (3.1.4) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-ldap (3.1.3) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-mailaliases-generic/changelog
+++ b/slave/process-mailaliases-generic/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-mailaliases-generic (3.1.6) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-mailaliases-generic (3.1.5) stable; urgency=low
 
   * Add possibility to change destination file (default is

--- a/slave/process-mailaliases/changelog
+++ b/slave/process-mailaliases/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-mailaliases (3.1.5) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-mailaliases (3.1.4) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-mailman-cesnet-user-mail/changelog
+++ b/slave/process-mailman-cesnet-user-mail/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-mailman-cesnet-user-mail (3.0.1) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-mailman-cesnet-user-mail (3.0.0) stable; urgency=low
 
   * Service manages mailing lists in mailman.

--- a/slave/process-mailman-cesnet/changelog
+++ b/slave/process-mailman-cesnet/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-mailman-cesnet (3.1.7) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-mailman-cesnet (3.1.6) stable; urgency=low
 
   * Removed handling of expiration and loa for hardcoded

--- a/slave/process-mailman-meta/changelog
+++ b/slave/process-mailman-meta/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-mailman-meta (3.1.6) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-mailman-meta (3.1.5) stable; urgency=low
 
   * Removed handling of expiration and loa for hardcoded

--- a/slave/process-mailman-mu/changelog
+++ b/slave/process-mailman-mu/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-mailman-mu (3.1.1) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-mailman-mu (3.1.0) stable; urgency=low
 
   * New package version for perun-slave-process-mu

--- a/slave/process-mailman-owners/changelog
+++ b/slave/process-mailman-owners/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-mailman-owners (3.1.5) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-mailman-owners (3.1.4) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-mailman/changelog
+++ b/slave/process-mailman/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-mailman (3.1.4) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-mailman (3.1.3) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-o365-contacts-export/changelog
+++ b/slave/process-o365-contacts-export/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-o365-contacts-export (3.0.2) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-o365-contacts-export (3.0.1) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-o365-mail-forward-export/changelog
+++ b/slave/process-o365-mail-forward-export/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-o365-mail-forward-export (3.1.2) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-o365-mail-forward-export (3.1.1) stable; urgency=low
 
   * New package for service o365-mail-forward-export

--- a/slave/process-o365-mu-account-status/changelog
+++ b/slave/process-o365-mu-account-status/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-o365-mu-account-status (3.1.2) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-o365-mu-account-status (3.1.1) stable; urgency=low
 
   * New package version for perun-slave-process-o365-mu-account-status

--- a/slave/process-o365/changelog
+++ b/slave/process-o365/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-o365 (3.1.3) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-o365 (3.1.2) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-oidc-with-groups-einfra/changelog
+++ b/slave/process-oidc-with-groups-einfra/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-oidc-with-groups-einfra (3.0.1) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-oidc-with-groups-einfra (3.0.0) stable; urgency=low
 
   * New slave script for oidc-with-groups-einfra

--- a/slave/process-operations-portal-egi/changelog
+++ b/slave/process-operations-portal-egi/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-operations-portal-egi (3.1.6) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-operations-portal-egi (3.1.5) stable; urgency=medium
 
   * Changed architecture to all
@@ -21,7 +27,7 @@ perun-slave-process-operations-portal-egi (3.1.3) stable; urgency=low
 
 perun-slave-process-operations-portal-egi (3.1.2) stable; urgency=medium
 
-  * Fix detection whether DST_FILE variable is set. 
+  * Fix detection whether DST_FILE variable is set.
 
  -- Slavek Licehammer <slavek@ics.muni.cz>  Mon, 21 Mar 2016 11:05:17 +0100
 

--- a/slave/process-passwd-nfs4/changelog
+++ b/slave/process-passwd-nfs4/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-passwd-nfs4 (3.1.5) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-passwd-nfs4 (3.1.4) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-passwd-scp/changelog
+++ b/slave/process-passwd-scp/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-passwd-scp (3.1.5) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-passwd-scp (3.1.4) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-passwd/changelog
+++ b/slave/process-passwd/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-passwd (3.1.5) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-passwd (3.1.4) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-pbs-publication-fairshare/changelog
+++ b/slave/process-pbs-publication-fairshare/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-pbs-publication-fairshare (3.1.6) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-pbs-publication-fairshare (3.1.5) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-pbsmon-json/changelog
+++ b/slave/process-pbsmon-json/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-pbsmon-json (3.1.5) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-pbsmon-json (3.1.4) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-pbsmon-users/changelog
+++ b/slave/process-pbsmon-users/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-pbsmon-users (3.1.5) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-pbsmon-users (3.1.4) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-puppet-dashboard/changelog
+++ b/slave/process-puppet-dashboard/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-puppet-dashboard (3.1.3) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-puppet-dashboard (3.1.2) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-rt-bbmri/changelog
+++ b/slave/process-rt-bbmri/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-rt-bbmri (3.1.4) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-rt-bbmri (3.1.3) stable; urgency=low
 
   * Updated protocol version to match new data format.

--- a/slave/process-rt-data-vocesnet/changelog
+++ b/slave/process-rt-data-vocesnet/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-rt-data-vocesnet (3.0.2) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-rt-data-vocesnet (3.0.1) stable; urgency=low
 
   * Define variables before error messages so they get expanded

--- a/slave/process-rt/changelog
+++ b/slave/process-rt/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-rt (3.1.3) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-rt (3.1.2) stable; urgency=low
 
   * Support changing of the output-file name. We are still using the same

--- a/slave/process-scim/changelog
+++ b/slave/process-scim/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-scim (3.0.1) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-scim (3.0.0) stable; urgency=low
 
   * Added service perun-slave-scim, it process data sent by the Perun in SCIM format.

--- a/slave/process-sshkeys-generic/changelog
+++ b/slave/process-sshkeys-generic/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-sshkeys-generic (3.1.2) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-sshkeys-generic (3.1.1) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-sshkeys-root/changelog
+++ b/slave/process-sshkeys-root/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-sshkeys-root (3.1.7) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-sshkeys-root (3.1.6) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-sshkeys/changelog
+++ b/slave/process-sshkeys/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-sshkeys (3.1.8) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-sshkeys (3.1.7) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-sympa/changelog
+++ b/slave/process-sympa/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-sympa (3.1.7) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-sympa (3.1.6) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-users-emails/changelog
+++ b/slave/process-users-emails/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-users-emails (3.1.3) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-users-emails (3.1.2) stable; urgency=low
 
   * Define variables before error messages so they get expanded

--- a/slave/process-vmware-ldap/changelog
+++ b/slave/process-vmware-ldap/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-vmware-ldap (1.0.1) stable; urgency=low
+
+ * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-vmware-ldap (1.0.0) stable; urgency=low
 
   * New service for provisioning of LDAP for VMware.

--- a/slave/process-voms-dirac/changelog
+++ b/slave/process-voms-dirac/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-voms-dirac (1.0.6) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-voms-dirac (1.0.5) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/process-voms/changelog
+++ b/slave/process-voms/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-voms (3.1.14) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-voms (3.1.13) stable; urgency=medium
 
   * Sort user records by CA, so that matching DNs issued by different
@@ -23,9 +29,9 @@ perun-slave-process-voms (3.1.10) stable; urgency=high
   * change path for exec script to be manually set on "voms", because the value
     in the variable $SERVICE can be set to different value if "voms_dirac"
     service has been called and executing script then can't be found.
-  * set correct protocol version (was forgotten to increase it) in voms slave 
-    script to 3.1.1. This is just a minor difference in protocol version is 
-    it has no impact on script behavior. 
+  * set correct protocol version (was forgotten to increase it) in voms slave
+    script to 3.1.1. This is just a minor difference in protocol version is
+    it has no impact on script behavior.
 
  -- Michal Stava <stavamichal@gmail.com>  Tue, 30 Jan 2018 17:12:00 +0100
 

--- a/slave/process-yubikey-root/changelog
+++ b/slave/process-yubikey-root/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-yubikey-root (3.1.3) stable; urgency=low
+
+  * Fixed package priority from 'extra' to 'optional'.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 09:00:00 +0200
+
 perun-slave-process-yubikey-root (3.1.2) stable; urgency=medium
 
   * Changed architecture to all

--- a/slave/templates/dh_make/control
+++ b/slave/templates/dh_make/control
@@ -1,6 +1,6 @@
 Source: #PACKAGE#
 Section: utils
-Priority: extra
+Priority: optional
 Maintainer: #USERNAME# <#EMAIL#>
 Build-Depends: #BUILD_DEPS#
 Standards-Version: #POLICY#

--- a/slave/templates/equivs/control
+++ b/slave/templates/equivs/control
@@ -1,8 +1,8 @@
 Source: ${PACKAGE_NAME}
 Section: utils
-Priority: extra
+Priority: optional
 Maintainer: Michal Stava <stavamichal@gmail.com>
-Standards-Version: 3.9.2
+Standards-Version: 3.9.5
 
 Package: ${PACKAGE_NAME}
 Architecture: all


### PR DESCRIPTION
- Priority 'optional' replaces older 'extra'.
- Unified dependency on debhelper.
- Cleanup trailing whitespace.