### PR TITLE
feat: support 3 group representations in ad_group_mu_ucn

### DIFF
--- a/gen/ad_group_mu_ucn
+++ b/gen/ad_group_mu_ucn
@@ -1,33 +1,56 @@
 #!/usr/bin/perl
 use feature "switch";
+use Switch;
 use strict;
 use warnings;
 use perunServicesInit;
 use perunServicesUtils;
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
 local $::SERVICE_NAME = "ad_group_mu_ucn";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.2";
+my $SCRIPT_VERSION = "3.0.3";
+
+sub addMemberToGroup;
+sub processWorkplaces;
+sub processGroup;
+sub createGroup;
+sub processTree;
+sub writeDebug;
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
 my $fileName = "$DIRECTORY/$::SERVICE_NAME".".ldif";
 my $baseDnFileName = "$DIRECTORY/baseDN";
 
-#Get hierarchical data without expired members
-my $data = perunServicesInit::getHashedHierarchicalData(1);
+# Get hierarchical data without expired members
+my $data = perunServicesInit::getHashedDataWithGroups(1);
+my $DEBUG = 0;
 
 #Constants
 our $A_LOGIN; *A_LOGIN = \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_F_BASE_DN;  *A_F_BASE_DN = \'urn:perun:facility:attribute-def:def:adBaseDN';
 our $A_F_GROUP_BASE_DN;  *A_F_GROUP_BASE_DN = \'urn:perun:facility:attribute-def:def:adGroupBaseDN';
 our $A_R_GROUP_NAME;  *A_R_GROUP_NAME = \'urn:perun:resource:attribute-def:def:adGroupName';
+our $A_G_GROUP_NAME_COMPUTED; *A_G_GROUP_NAME_COMPUTED = \'urn:perun:group:attribute-def:virt:adGroupName';
+# Tree / Workplace / Group (Default)
+our $A_R_REPRESENTATION;  *A_R_REPRESENTATION = \'urn:perun:resource:attribute-def:def:adResourceRepresentation';
 our $A_MR_V_IS_BANNED;  *A_MR_V_IS_BANNED = \'urn:perun:member_resource:attribute-def:virt:isBanned';
 our $A_MEMBER_STATUS; *A_MEMBER_STATUS = \'urn:perun:member:attribute-def:core:status';
-our $A_ALLOW_INACTIVE;  *A_ALLOW_INACTIVE = \'urn:perun:resource:attribute-def:def:allowInactiveMembers';
+our $A_R_ALLOW_INACTIVE;  *A_R_ALLOW_INACTIVE = \'urn:perun:resource:attribute-def:def:allowInactiveMembers';
 
 our $STATUS_VALID;      *STATUS_VALID =        \'VALID';
 our $STATUS_EXPIRED;    *STATUS_EXPIRED =      \'EXPIRED';
+
+our $A_R_ADOUNAME; *A_R_ADOUNAME = \'urn:perun:resource:attribute-def:def:adOuName';
+our $A_G_INETCISPR; *A_G_INETCISPR = \'urn:perun:group:attribute-def:def:inetCispr';
+our $A_G_DESCRIPTION; *A_G_DESCRIPTION = \'urn:perun:group:attribute-def:core:description';
+our $A_R_DESCRIPTION; *A_R_DESCRIPTION = \'urn:perun:resource:attribute-def:core:description';
+
+# Default description of group in Active Directory
+my $defaultDescription = "no-desc in Perun";
+# Default representation of resource in Active Directory
+my $defaultRepresentation = "group";
 
 # CHECK ON FACILITY ATTRIBUTES
 if (!defined($data->getFacilityAttributeValue( attrName => $A_F_GROUP_BASE_DN ))) {
@@ -47,45 +70,22 @@ open FILE,">:encoding(UTF-8)","$baseDnFileName" or die "Cannot open $baseDnFileN
 print FILE $baseGroupDN;
 close(FILE);
 
-my $groups = {};
-my $usersByResource = {};
+our $groups = {};
+our $usersByGroups = {};
 
 # FOR EACH RESOURCE
 foreach my $resourceId ($data->getResourceIds()) {
+	# Default value for representation is "group".
+	# Possible values: tree / workplace / group (Default)
+	my $representation = lc ($data->getResourceAttributeValue( resource => $resourceId, attrName => $A_R_REPRESENTATION ) || $defaultRepresentation);
 
-	my $allowInactiveMembers = $data->getResourceAttributeValue( resource => $resourceId, attrName => $A_ALLOW_INACTIVE );
-	my $group = $data->getResourceAttributeValue( resource => $resourceId, attrName => $A_R_GROUP_NAME );
-	$groups->{$group} = 1;
+	writeDebug("Resource ID: $resourceId (represented as: $representation)", 0);
 
-	# FOR EACH MEMBER ON RESOURCE
-	foreach my $memberId ($data->getMemberIdsForResource( resource => $resourceId )) {
-
-		my $login = $data->getUserFacilityAttributeValue( member => $memberId, attrName => $A_LOGIN );
-		my $isBanned = $data->getMemberResourceAttributeValue( member => $memberId, resource => $resourceId, attrName => $A_MR_V_IS_BANNED );
-		my $memberStatus = $data->getMemberAttributeValue( member => $memberId, attrName => $A_MEMBER_STATUS );
-
-		#skip banned members
-		next if $isBanned;
-
-		next unless ( ($memberStatus eq $STATUS_VALID) || (($memberStatus eq $STATUS_EXPIRED) && $allowInactiveMembers) );
-
-		# allow only UČO, 9UČO and s-[smth] logins
-
-		if ($login =~ /^9[0-9]{6}$/ or $login =~ /^[0-9]{1,6}$/) {
-
-			# store UČO and 9UČO users
-			$usersByResource->{$group}->{"CN=" . $login . "," . $baseDN} = 1
-
-		} elsif ($login =~ /^s-/) {
-
-			# store "s-[something]" users - hack to be compatible with existing accounts
-			$usersByResource->{$group}->{"CN=" . $login . "," . $baseDNforSpecial} = 1
-
-		}
-
-
+	switch($representation){
+		case "tree"			{processTree($resourceId)}
+		case "workplace" 	{processWorkplaces($resourceId)}
+		case "group" 		{processGroup($resourceId)}
 	}
-
 }
 
 #
@@ -95,13 +95,15 @@ open FILE,">:encoding(UTF-8)","$fileName" or die "Cannot open $fileName: $! \n";
 
 for my $group (sort keys %$groups) {
 
-	print FILE "dn: CN=" . $group . "," . $baseGroupDN . "\n";
+	print FILE "dn: CN=" . $group . "," . $groups->{$group}->{$A_R_ADOUNAME} . "\n";
 	print FILE "cn: " . $group . "\n";
 	print FILE "samAccountName: " . $group . "\n";
+	print FILE "description: " . $groups->{$group}->{"description"} . "\n";
+	print FILE "info: perun\@muni.cz\n";
 	print FILE "objectClass: group\n";
 	print FILE "objectClass: top\n";
 
-	my @groupMembers = sort keys %{$usersByResource->{$group}};
+	my @groupMembers = sort keys %{$usersByGroups->{$group}};
 	for my $member (@groupMembers) {
 		print FILE "member: " . $member . "\n";
 	}
@@ -114,3 +116,128 @@ for my $group (sort keys %$groups) {
 close FILE;
 
 perunServicesInit::finalize;
+
+####################
+# Helper functions #
+####################
+
+sub addMemberToGroup {
+	my $memberId = shift;
+	my $group = shift;
+	my $resourceId = shift;
+
+	my $login = $data->getUserFacilityAttributeValue( member => $memberId, attrName => $A_LOGIN );
+	my $isBanned = $data->getMemberResourceAttributeValue( member => $memberId, resource => $resourceId, attrName => $A_MR_V_IS_BANNED );
+
+	my $allowInactiveMembers = $data->getResourceAttributeValue( resource => $resourceId, attrName => $A_R_ALLOW_INACTIVE );
+	my $memberStatus = $data->getMemberAttributeValue( member => $memberId, attrName => $A_MEMBER_STATUS );
+
+	# Add only VALID members or EXPIRED members if allowed by Resource
+	return unless ( ($memberStatus eq $STATUS_VALID) || (($memberStatus eq $STATUS_EXPIRED) && $allowInactiveMembers) );
+
+	addMember($login, $group, $isBanned)
+}
+
+sub processTree {
+	my $resourceId = shift;
+
+	foreach my $groupId ( $data->getGroupIdsForResource( resource => $resourceId ) ) {
+		writeDebug("Process Tree Group: $groupId", 1);
+		my $group = $data->getGroupAttributeValue(group => $groupId, attrName => $A_G_GROUP_NAME_COMPUTED);
+		my $description = $data->getGroupAttributeValue( group => $groupId, attrName => $A_G_DESCRIPTION );
+		my $adOuName = $data->getResourceAttributeValue( resource => $resourceId, attrName => $A_R_ADOUNAME );
+
+		writeDebug("Obtained data group '$group'.", 2);
+		createGroup($group, $description, $adOuName);
+
+		writeDebug("Continue to add members", 3);
+		for my $memberId ( $data->getMemberIdsForResourceAndGroup( resource => $resourceId, group => $groupId )) {
+			addMemberToGroup($memberId, $group, $resourceId);
+		}
+	}
+
+
+}
+
+sub processWorkplaces {
+	my $resourceId = shift;
+
+	foreach my $groupId ( $data->getGroupIdsForResource( resource => $resourceId ) ) {
+		writeDebug("Process Workplace Group: $groupId", 1);
+
+		my $inetCispr = $data->getGroupAttributeValue( group => $groupId, attrName => $A_G_INETCISPR );
+		my $group = "Wplace-$inetCispr";
+		my $description = $data->getGroupAttributeValue( group => $groupId, attrName => $A_G_DESCRIPTION );
+
+		writeDebug("Obtained data group '$group'.", 2);
+		createGroup($group, $description, undef);
+
+		writeDebug("Continue to add members", 3);
+		for my $memberId ( $data->getMemberIdsForResourceAndGroup( resource => $resourceId, group => $groupId )) {
+			addMemberToGroup($memberId, $group, $resourceId);
+		}
+	}
+}
+
+sub processGroup {
+	my $resourceId = shift;
+
+	my $group = $data->getResourceAttributeValue( resource => $resourceId, attrName => $A_R_GROUP_NAME );
+	my $description = $data->getResourceAttributeValue( resource => $resourceId, attrName => $A_R_DESCRIPTION );
+	my $adOuName = $data->getResourceAttributeValue( resource => $resourceId, attrName => $A_R_ADOUNAME );
+
+	writeDebug("Process Standard Group: '$group'", 1);
+	createGroup($group, $description, $adOuName);
+
+	writeDebug("Continue to add members", 3);
+	foreach my $memberId ($data->getMemberIdsForResource( resource => $resourceId )) {
+		addMemberToGroup($memberId, $group, $resourceId);
+	}
+}
+
+sub createGroup {
+	my $name = shift;
+	my $description = shift;
+	my $adOuName = shift;
+
+	# Ensure that there is one group with specific name
+	$groups->{$name}->{"description"} =  $description || $defaultDescription;
+	# Is expected that adOuName and baseGroupDN cotains valid DN.
+	# The groups can be created in custom DN path, if the adOuName is not specified
+	# baseGroupDN should be used.
+	$groups->{$name}->{$A_R_ADOUNAME} = $adOuName || $baseGroupDN;
+	writeDebug("Group created", 3);
+}
+
+sub addMember {
+	my $login = shift;
+	my $group = shift;
+	my $isBanned = shift;
+
+	#skip banned members
+	return if $isBanned;
+
+	# allow only UČO, 9UČO and s-[smth] logins
+
+	if ($login =~ /^9[0-9]{6}$/ or $login =~ /^[0-9]{1,6}$/) {
+
+		# store UČO and 9UČO users
+		$usersByGroups->{$group}->{"CN=" . $login . "," . $baseDN} = 1
+
+	} elsif ($login =~ /^s-/) {
+
+		# store "s-[something]" users - hack to be compatible with existing accounts
+		$usersByGroups->{$group}->{"CN=" . $login . "," . $baseDNforSpecial} = 1
+
+	}
+}
+
+sub writeDebug {
+	my $message = shift;
+	my $indentation = shift;
+
+	return unless $DEBUG;
+
+	print "\t" x $indentation;
+	print $message . "\n";
+}

--- a/send/ad_group_mu_ucn
+++ b/send/ad_group_mu_ucn
@@ -60,24 +60,30 @@ my @conf = init_config($namespace);
 my @ldap_locations = resolve_domain_controlers($conf[0]);
 my $ldap = ldap_connect_multiple_options(\@ldap_locations);
 my $filter = '(objectClass=group)';
+my @baseAttrs = ('cn', 'samAccountName', 'objectClass', 'info', 'description');
+
 
 # connect
 ldap_bind($ldap, $conf[1], $conf[2]);
 
 # load all data
 my @perun_entries = load_perun($service_files_dir . "/" . $service_name . ".ldif");
-my @ad_entries = load_ad($ldap, $base_dn, $filter, ['cn']);
+my @groups_ad_entries = load_ad($ldap, "OU=Groups,OU=MU,DC=ucn,DC=muni,DC=cz", $filter, ['cn', 'info', 'description']);
+my @types_ad_entries = load_ad($ldap, "OU=Types,OU=MU,DC=ucn,DC=muni,DC=cz", $filter, ['cn', 'info', 'description']);
+my @perun_groups_ad_entries = load_ad($ldap, "OU=Groups,OU=Perun,OU=MU,DC=ucn,DC=muni,DC=cz", $filter, ['cn', 'info', 'description']);
+my @ad_entries = (@groups_ad_entries, @perun_groups_ad_entries);
+@ad_entries = (@ad_entries, @types_ad_entries);
 
 my %ad_entries_map = ();
 my %perun_entries_map = ();
 
 foreach my $ad_entry (@ad_entries) {
 	my $cn = $ad_entry->get_value('cn');
-	$ad_entries_map{ $cn } = $ad_entry;
+	$ad_entries_map{ lc $cn } = $ad_entry;
 }
 foreach my $perun_entry (@perun_entries) {
 	my $cn = $perun_entry->get_value('cn');
-	$perun_entries_map{ $cn } = $perun_entry;
+	$perun_entries_map{ lc $cn } = $perun_entry;
 }
 
 # process data
@@ -135,10 +141,8 @@ sub process_add() {
 	foreach my $perun_entry (@perun_entries) {
 
 		my $cn = $perun_entry->get_value('cn');
-		unless (exists $ad_entries_map{$cn}) {
-
-			my @attrs_to_add = ('cn', 'samAccountName', 'objectClass');
-			my $new_ad_entry = clone_entry_with_specific_attributes($perun_entry, \@attrs_to_add);
+		unless (exists $ad_entries_map{lc $cn}) {
+			my $new_ad_entry = clone_entry_with_specific_attributes($perun_entry, \@baseAttrs);
 			# Add new entry to AD
 			my $response = $new_ad_entry->update($ldap);
 			unless ($response->is_error()) {
@@ -147,6 +151,7 @@ sub process_add() {
 				$counter_group_added++;
 			} else {
 				# FAIL
+				print STDERR "Group NOT added: " . $perun_entry->dn() . " | " . $response->error() . "\n";
 				ldap_log($service_name, "Group NOT added: " . $perun_entry->dn() . " | " . $response->error());
 				ldap_log($service_name, $new_ad_entry->ldif());
 				$counter_group_not_added++;
@@ -164,27 +169,35 @@ sub process_remove() {
 
 	foreach my $ad_entry (@ad_entries) {
 		my $cn = $ad_entry->get_value('cn');
-		unless (exists $perun_entries_map{$cn}) {
+		unless (exists $perun_entries_map{ lc $cn }) {
 
 			# clear members
 			# load members of a group from AD
 			my @to_be_removed = load_group_members($ldap, $ad_entry->dn(), $filter);
+
+			## HACK: do not remove GUEST- or L- accounts from groups
+			@to_be_removed = grep(!/CN=(Guest|L).*/, @to_be_removed);
+			# Focus only on users
+			#@to_be_removed = grep(/OU=(Users).*/, @to_be_removed);
 			my $response_remove = remove_members_from_entry($ldap, $service_name, $ad_entry, \@to_be_removed);
 			unless ($response_remove == $SUCCESS) {
+				print STDERR "Failed to remove all members from group during the group removal process: ".$ad_entry->dn() . "\n";
 				ldap_log($service_name, "Failed to remove all members from group during the group removal process: ".$ad_entry->dn());
 				$counter_group_not_emptied++;
-			} else {
-				my $response = $ldap->delete($ad_entry->dn());
-				unless ($response->is_error()) {
-					ldap_log($service_name, "Group removed: " . $ad_entry->dn());
-					$counter_group_removed++;
-				}
-				else {
-					ldap_log($service_name, "Group NOT removed: " . $ad_entry->dn() . " | " . $response->error());
-					ldap_log($service_name, $ad_entry->ldif());
-					$counter_group_not_removed++;
-				}
 			}
+			# NOT REMOVING GROUPS IN UCN AD
+			# else {
+			#         my $response = $ldap->delete($ad_entry->dn());
+			#         unless ($response->is_error()) {
+			#                 ldap_log($service_name, "Group removed: " . $ad_entry->dn());
+			#                 $counter_group_removed++;
+			#         }
+			#         else {
+			#                 ldap_log($service_name, "Group NOT removed: " . $ad_entry->dn() . " | " . $response->error());
+			#                 ldap_log($service_name, $ad_entry->ldif());
+			#                 $counter_group_not_removed++;
+			#         }
+			# }
 
 		}
 	}
@@ -195,15 +208,27 @@ sub process_remove() {
 # Update group members in AD
 #
 sub process_update() {
-
+	my %params;
 	foreach my $perun_entry (@perun_entries) {
+
+		%params = (
+			info => $perun_entry->get_value('info'),
+			description => $perun_entry->get_value('description')
+		);
+
+		if (exists $ad_entries_map{ lc $perun_entry->get_value('cn') }){
+			update_info(clone_entry_with_specific_attributes($perun_entry, \@baseAttrs), $ad_entries_map{ lc $perun_entry->get_value('cn') }, \%params);
+		}
 
 		my @per_val = $perun_entry->get_value('member');
 
 		# load members of a group from AD based on DN in Perun => Group must exists in AD
 		my @ad_val = load_group_members($ldap, $perun_entry->dn(), $filter);
+		## HACK: do not remove GUEST- or L- accounts from groups
+		@ad_val = grep(!/CN=(Guest|L).*/, @ad_val);
 
 		if ($? != 0) {
+			print STDERR "Unable to load Perun group members from AD: " . $perun_entry->dn() . "\n";
 			ldap_log($service_name, "Unable to load Perun group members from AD: " . $perun_entry->dn());
 			next;
 		}
@@ -230,6 +255,7 @@ sub process_update() {
 			} else {
 				# FAIL (to get group from AD)
 				$counter_group_members_not_updated++;
+				print STDERR "Group members NOT updated: " . $perun_entry->dn() . " | " . $response_ad->error() . "\n";
 				ldap_log($service_name, "Group members NOT updated: " . $perun_entry->dn() . " | " . $response_ad->error());
 			}
 		}
@@ -238,4 +264,34 @@ sub process_update() {
 
 	}
 
+}
+
+sub update_info {
+
+	my $entry = shift;
+	my $update_entry = shift;
+	my $params = shift;
+
+	my $params_updated = 0;
+	foreach (keys %{$params}){
+		if (compare_entry($update_entry, $entry, $_) == 1){
+			$update_entry->replace(
+				"$_" => $params->{$_},
+			);
+			$params_updated = 1;
+		}
+	}
+	if ($params_updated == 1){
+		my $response = $update_entry->update($ldap);
+		if ($response) {
+			unless ($response->is_error()) {
+				ldap_log($service_name, "Group Attributes Updated: " . $update_entry->dn() . " | ");
+				return 0;
+			} else {
+				print STDERR "Group Attributes NOT updated: " . $update_entry->ldif("change" => "true") . " | " . $response->error() . "\n";
+				ldap_log($service_name, "Group Attributes NOT updated: " . $update_entry->ldif("change" => "true") . " | " . $response->error() . " | ");
+				return 1;
+			}
+		}
+	}
 }


### PR DESCRIPTION
- 3 group representations (resource can represent tree/workplace/group)
- added debug mode
- functionality separated to subroutines