### PR TITLE
refactor(gen): removed unused internal method params in drupal_elixir

### DIFF
--- a/gen/drupal_elixir
+++ b/gen/drupal_elixir
@@ -129,14 +129,14 @@ sub processUsers {
 
 	my $uid = $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_ID );
 	my $login = $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_LOGIN );
-	my $status = $data->getMemberAttributeValue( member => $memberId, group => $groupId, attrName => $A_USER_STATUS );
-	if($data->getMemberAttributeValue( member => $memberId, group => $groupId, attrName => $A_MEMBER_IS_SUSPENDED )) {
+	my $status = $data->getMemberAttributeValue( member => $memberId, attrName => $A_USER_STATUS );
+	if($data->getMemberAttributeValue( member => $memberId, attrName => $A_MEMBER_IS_SUSPENDED )) {
 		$status = $STATUS_SUSPENDED;
 	}
 	my $email = $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_EMAIL );
 	my $d_name = $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_D_NAME );
 
-	# Select right eppn from the list of eppns, TEMPORARLY get google one, then we will use elixir
+	# Select right eppn from the list of eppns, TEMPORARILY get google one, then we will use elixir
 	my @eppns = @{$data->getUserAttributeValue( member => $memberId, attrName => $A_USER_EPPNS)};
 
 


### PR DESCRIPTION
- Getting member attribute doesn't required group IDs.