### PR TITLE
Ad admin scripts

### DIFF
--- a/gen/ad_admin_group_mu_ucn
+++ b/gen/ad_admin_group_mu_ucn
@@ -1,0 +1,143 @@
+#!/usr/bin/perl
+use feature "switch";
+use Switch;
+use strict;
+use warnings;
+use perunServicesInit;
+use perunServicesUtils;
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
+
+local $::SERVICE_NAME = "ad_admin_group_mu_ucn";
+local $::PROTOCOL_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.0";
+
+sub addMemberToGroup;
+sub processWorkplaces;
+sub processGroup;
+sub createGroup;
+sub processTree;
+sub writeDebug;
+
+perunServicesInit::init;
+my $DIRECTORY = perunServicesInit::getDirectory;
+my $fileName = "$DIRECTORY/$::SERVICE_NAME".".ldif";
+
+#Get hierarchical data without expired members
+my $data = perunServicesInit::getHashedDataWithGroups(1);
+my $DEBUG = 0;
+
+#Constants
+our $A_LOGIN; *A_LOGIN = \'urn:perun:user:attribute-def:def:login-namespace:mu-adm';
+our $A_R_GROUP_NAME;  *A_R_GROUP_NAME = \'urn:perun:resource:attribute-def:def:adGroupName';
+our $A_MR_V_IS_BANNED;  *A_MR_V_IS_BANNED = \'urn:perun:member_resource:attribute-def:virt:isBanned';
+our $A_R_DESCRIPTION; *A_R_DESCRIPTION = \'urn:perun:resource:attribute-def:core:description';
+
+# Default description of group in Active Directory
+my $defaultDescription = "no-desc in Perun";
+# OUs for groups and users
+my $adOuNameGroups = "OU=PrivilegedGroups,OU=MU,DC=ucn,DC=muni,DC=cz";
+my $adOuNameUsers = "OU=PrivilegedUsers,OU=MU,DC=ucn,DC=muni,DC=cz";
+
+our $groups = {};
+our $usersByGroups = {};
+
+# FOR EACH RESOURCE
+foreach my $resourceId ($data->getResourceIds()) {
+	processGroup($resourceId);
+}
+
+#
+# Print group data LDIF
+#
+open FILE,">:encoding(UTF-8)","$fileName" or die "Cannot open $fileName: $! \n";
+
+for my $group (sort keys %$groups) {
+
+	print FILE "dn: CN=" . $group . "," . $adOuNameGroups . "\n";
+	print FILE "cn: " . $group . "\n";
+	print FILE "samAccountName: " . $group . "\n";
+	print FILE "description: " . $groups->{$group}->{"description"} . "\n";
+	print FILE "objectClass: group\n";
+	print FILE "objectClass: top\n";
+
+	my @groupMembers = sort keys %{$usersByGroups->{$group}};
+	for my $member (@groupMembers) {
+		print FILE "member: " . $member . "\n";
+	}
+
+	# there must be empty line after each entry
+	print FILE "\n";
+
+}
+
+close FILE;
+
+perunServicesInit::finalize;
+
+####################
+# Helper functions #
+####################
+
+sub addMemberToGroup {
+	my $memberId = shift;
+	my $group = shift;
+	my $resourceId = shift;
+
+	my $login = $data->getUserAttributeValue( member => $memberId, attrName => $A_LOGIN );
+	my $isBanned = $data->getMemberResourceAttributeValue( member => $memberId, resource => $resourceId, attrName => $A_MR_V_IS_BANNED );
+
+	addMember($login, $group, $isBanned)
+}
+
+sub processGroup {
+	my $resourceId = shift;
+
+	my $group = $data->getResourceAttributeValue( resource => $resourceId, attrName => $A_R_GROUP_NAME );
+	my $description = $data->getResourceAttributeValue( resource => $resourceId, attrName => $A_R_DESCRIPTION );
+
+	writeDebug("Process Standard Group: '$group'", 1);
+	createGroup($group, $description);
+
+	writeDebug("Continue to add members", 3);
+	foreach my $memberId ($data->getMemberIdsForResource( resource => $resourceId )) {
+		addMemberToGroup($memberId, $group, $resourceId);
+	}
+}
+
+sub createGroup {
+	my $name = shift;
+	my $description = shift;
+
+	# Ensure that there is one group with specific name
+	$groups->{$name}->{"description"} =  $description || $defaultDescription;
+	writeDebug("Group created", 3);
+}
+
+sub addMember {
+	my $login = shift;
+	my $group = shift;
+	my $isBanned = shift;
+
+	#skip banned members
+	return if $isBanned;
+
+	# allow only UČOadm, 9UČOadm logins
+
+	return unless $login;
+	if ($login =~ /^9[0-9]{6}adm$/ or $login =~ /^[0-9]{1,6}adm$/) {
+
+		# store UČO and 9UČO users
+		$usersByGroups->{$group}->{"CN=" . $login . "," . $adOuNameUsers} = 1
+
+	}
+}
+
+sub writeDebug {
+	my $message = shift;
+	my $indentation = shift;
+
+	return unless $DEBUG;
+
+	print "\t" x $indentation;
+	print $message . "\n";
+}

--- a/gen/ad_admin_user_mu_ucn
+++ b/gen/ad_admin_user_mu_ucn
@@ -1,0 +1,118 @@
+#!/usr/bin/perl
+use feature "switch";
+use strict;
+use warnings;
+use perunServicesInit;
+use perunServicesUtils;
+use MIME::Base64;
+use utf8;
+use Encode;
+
+local $::SERVICE_NAME = "ad_admin_user_mu_ucn";
+local $::PROTOCOL_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.0";
+
+perunServicesInit::init;
+my $DIRECTORY = perunServicesInit::getDirectory;
+my $fileName = "$DIRECTORY/$::SERVICE_NAME".".ldif";
+
+my $data = perunServicesInit::getHashedHierarchicalData(1);
+
+#Constants
+our $A_F_DOMAIN;  *A_F_DOMAIN = \'urn:perun:facility:attribute-def:def:adDomain';
+
+our $A_LOGIN; *A_LOGIN = \'urn:perun:user:attribute-def:def:login-namespace:mu-adm';
+our $A_FIRST_NAME;  *A_FIRST_NAME = \'urn:perun:user:attribute-def:core:firstName';
+our $A_LAST_NAME;  *A_LAST_NAME = \'urn:perun:user:attribute-def:core:lastName';
+our $A_DISPLAY_NAME;  *A_DISPLAY_NAME = \'urn:perun:user:attribute-def:core:displayName';
+our $A_MAIL;  *A_MAIL = \'urn:perun:user:attribute-def:def:preferredMail';
+
+our $A_MEMBER_STATUS; *A_MEMBER_STATUS = \'urn:perun:member:attribute-def:core:status';
+
+our $STATUS_VALID; *STATUS_VALID = \'VALID';
+our $STATUS_EXPIRED; *STATUS_EXPIRED = \'EXPIRED';
+
+# Get the facility ID
+my $facilityId = $data->getFacilityId();
+
+# CHECK ON FACILITY ATTRIBUTES
+if (!defined($data->getFacilityAttributeValue( attrName => $A_F_DOMAIN ))) {
+	exit 1;
+}
+
+my $baseDN = "OU=PrivilegedUsers,OU=MU,DC=ucn,DC=muni,DC=cz";
+my $domain = $data->getFacilityAttributeValue( attrName => $A_F_DOMAIN );
+my $uac = "66048";
+
+# GATHER USERS
+my $users;  # $users->{$login}->{ATTR} = $attrValue;
+
+#
+# AGGREGATE DATA
+#
+# FOR EACH RESOURCE
+foreach my $resourceId ( $data->getResourceIds() ){
+        
+	# EACH USER ON RESOURCE
+	foreach my $memberId ($data->getMemberIdsForResource( resource => $resourceId )) {
+
+		my $login = $data->getUserAttributeValue( member => $memberId, attrName => $A_LOGIN );
+		next unless $login;
+		my $memberStatus = $data->getMemberAttributeValue( member => $memberId, attrName => $A_MEMBER_STATUS );
+		next unless ($memberStatus eq $STATUS_VALID);
+
+		# store standard attrs
+		$users->{$login}->{"DN"} = "CN=" . $login . "," . $baseDN;
+		$users->{$login}->{$A_FIRST_NAME} = $data->getUserAttributeValue(member => $memberId, attrName => $A_FIRST_NAME);
+		$users->{$login}->{$A_LAST_NAME} = $data->getUserAttributeValue(member => $memberId, attrName => $A_LAST_NAME);
+		$users->{$login}->{$A_DISPLAY_NAME} = $data->getUserAttributeValue(member => $memberId, attrName => $A_DISPLAY_NAME);
+		$users->{$login}->{$A_MAIL} = $data->getUserAttributeValue(member => $memberId, attrName => $A_MAIL);
+	}
+}
+
+#
+# PRINT user data LDIF
+#
+open FILE,">$fileName" or die "Cannot open $fileName: $! \n";
+binmode FILE, ":utf8";
+
+# FOR EACH USER ON FACILITY
+my @logins = sort keys %{$users};
+for my $login (@logins) {
+
+	# print attributes, which are never empty
+	print FILE "dn: " . $users->{$login}->{"DN"} . "\n";
+
+	print FILE "cn: " . $login . "\n";
+	print FILE "samAccountName: " . $login . "\n";
+	print FILE "userPrincipalName: " . $login . "\@" . $domain . "\n";
+	# enable accounts (if not) using service propagation
+	print FILE "userAccountControl: " . $uac . "\n";
+
+	# skip attributes which are empty and LDAP can't handle it (FIRST_NAME, EMAIL)
+	my $sn = $users->{$login}->{$A_LAST_NAME};
+	my $givenName = $users->{$login}->{$A_FIRST_NAME};
+	my $displayName = ($users->{$login}->{$A_FIRST_NAME} || "") . " " . ($users->{$login}->{$A_LAST_NAME} || "") . " (adm)";
+	my $mail = $users->{$login}->{$A_MAIL};
+
+	if (defined $displayName and length $displayName) {
+		print FILE "displayName: " . $displayName . "\n";
+	}
+	if (defined $sn and length $sn) {
+		print FILE "sn: " . $sn . "\n";
+	}
+	if (defined $givenName and length $givenName) {
+		print FILE "givenName: " . $givenName . "\n";
+	}
+	if (defined $mail and length $mail) {
+		print FILE "mail: " . $mail . "\n";
+	}
+
+	# There MUST be an empty line after each entry, so entry sorting and diff works on slave part
+	print FILE "\n";
+
+}
+
+close(FILE);
+
+perunServicesInit::finalize;

--- a/send/ad_admin_group_mu_ucn
+++ b/send/ad_admin_group_mu_ucn
@@ -1,0 +1,270 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
+use Net::LDAPS;
+use Net::LDAP::Entry;
+use Net::LDAP::Message;
+use Net::LDAP::LDIF;
+
+# Import shared AD library
+use ADConnector;
+use ScriptLock;
+
+sub process_add;
+sub process_remove;
+sub process_update;
+
+# log counters
+my $counter_group_added = 0;
+my $counter_group_not_added = 0;
+my $counter_group_not_emptied = 0;
+my $counter_group_removed = 0;
+my $counter_group_not_removed = 0;
+my $counter_group_members_updated = 0;
+my $counter_group_members_updated_with_errors = 0;
+my $counter_group_members_not_updated = 0;
+
+# define service
+my $service_name = "ad_admin_group_mu_ucn";
+
+# operations results
+my $RESULT_ERRORS = "errors";
+my $RESULT_CHANGED = "changed";
+my $RESULT_UNCHANGED = "unchanged";
+my $SUCCESS = 1;
+my $FAIL = 0;
+
+# GEN folder location
+my $facility_name = $ARGV[0];
+chomp($facility_name);
+my $service_files_base_dir="../gen/spool";
+my $service_files_dir="$service_files_base_dir/$facility_name/$service_name";
+
+# BASE DN
+my $base_dn = "OU=PrivilegedGroups,OU=MU,DC=ucn,DC=muni,DC=cz";
+
+# propagation destination
+my $namespace = $ARGV[1];
+chomp($namespace);
+
+# create service lock
+my $lock = ScriptLock->new($facility_name . "_" . $service_name . "_" . $namespace);
+($lock->lock() == 1) or die "Unable to get lock, service propagation was already running.";
+
+# init configuration
+my @conf = init_config($namespace);
+my @ldap_locations = resolve_domain_controlers($conf[0]);
+
+my $ldap = ldap_connect_multiple_options(\@ldap_locations);
+my $filter = '(objectClass=group)';
+my @baseAttrs = ('cn', 'samAccountName', 'objectClass', 'description');
+
+
+# connect
+ldap_bind($ldap, $conf[1], $conf[2]);
+
+# load all data
+my @perun_entries = load_perun($service_files_dir . "/" . $service_name . ".ldif");
+my @ad_entries = load_ad($ldap, $base_dn, $filter, ['cn', 'description']);
+
+my %ad_entries_map = ();
+my %perun_entries_map = ();
+
+foreach my $ad_entry (@ad_entries) {
+	my $cn = $ad_entry->get_value('cn');
+	$ad_entries_map{ lc $cn } = $ad_entry;
+}
+foreach my $perun_entry (@perun_entries) {
+	my $cn = $perun_entry->get_value('cn');
+	$perun_entries_map{ lc $cn } = $perun_entry;
+}
+
+# process data
+process_add();
+process_remove();
+process_update();
+
+# disconnect
+ldap_unbind($ldap);
+
+# log results
+ldap_log($service_name, "Group added (without members): " . $counter_group_added . " entries.");
+ldap_log($service_name, "Group failed to add: " . $counter_group_not_added. " entries.");
+ldap_log($service_name, "-------------------------------------------------------------------------------------------------------");
+ldap_log($service_name, "Group updated (members): " . $counter_group_members_updated . " entries.");
+ldap_log($service_name, "Group updated with errors (members): " . $counter_group_members_updated_with_errors . " entries.");
+ldap_log($service_name, "Group failed to update (members): " . $counter_group_members_not_updated. " entries.");
+ldap_log($service_name, "-------------------------------------------------------------------------------------------------------");
+ldap_log($service_name, "Group removed: " . $counter_group_removed . " entries.");
+ldap_log($service_name, "Group failed to empty during removal: " . $counter_group_not_emptied . " entries.");
+ldap_log($service_name, "Group failed to remove: " . $counter_group_not_removed. " entries.");
+
+# print results for TaskResults in GUI
+print "Group added (without members): " . $counter_group_added . " entries.\n";
+print "Group failed to add: " . $counter_group_not_added. " entries.\n";
+print "-------------------------------------------------------------------------------------------------------\n";
+print "Group updated (members): " . $counter_group_members_updated . " entries.\n";
+print "Group updated with errors (members): " . $counter_group_members_updated_with_errors . " entries.\n";
+print "Group failed to update (members): " . $counter_group_members_not_updated. " entries.\n";
+print "-------------------------------------------------------------------------------------------------------\n";
+print "Group removed: " . $counter_group_removed . " entries.\n";
+print "Group failed to empty during removal: " . $counter_group_not_emptied . " entries.\n";
+print "Group failed to remove: " . $counter_group_not_removed. " entries.\n";
+
+$lock->unlock();
+
+if ($counter_group_not_added or $counter_group_members_not_updated or $counter_group_not_removed or $counter_group_not_emptied) {
+	die "Some entries failed to process.\nSee log at: ~/perun-engine/send/logs/$service_name.log";
+}
+if ($counter_group_members_updated_with_errors > 0) { die "Some members were not updated.\nSee log at: ~/perun-engine/send/logs/$service_name.log";}
+
+# END of main script
+
+###########################################
+#
+# Main processing functions
+#
+###########################################
+
+#
+# Add new group entries to AD
+#
+sub process_add() {
+
+	foreach my $perun_entry (@perun_entries) {
+
+		my $cn = $perun_entry->get_value('cn');
+		unless (exists $ad_entries_map{lc $cn}) {
+			my $new_ad_entry = clone_entry_with_specific_attributes($perun_entry, \@baseAttrs);
+			# Add new entry to AD
+			my $response = $new_ad_entry->update($ldap);
+			unless ($response->is_error()) {
+				# SUCCESS
+				ldap_log($service_name, "Group added (without members): " . $perun_entry->dn());
+				$counter_group_added++;
+			} else {
+				# FAIL
+				print STDERR "Group NOT added: " . $perun_entry->dn() . " | " . $response->error() . "\n";
+				ldap_log($service_name, "Group NOT added: " . $perun_entry->dn() . " | " . $response->error());
+				ldap_log($service_name, $new_ad_entry->ldif());
+				$counter_group_not_added++;
+			}
+
+		}
+	}
+
+}
+
+#
+# Remove group entries in AD
+#
+sub process_remove() {
+
+	foreach my $ad_entry (@ad_entries) {
+		my $cn = $ad_entry->get_value('cn');
+		unless (exists $perun_entries_map{ lc $cn }) {
+
+			# clear members
+			# load members of a group from AD
+			my @to_be_removed = load_group_members($ldap, $ad_entry->dn(), $filter);
+
+			# Focus only on users
+			my $response_remove = remove_members_from_entry($ldap, $service_name, $ad_entry, \@to_be_removed);
+			unless ($response_remove == $SUCCESS) {
+				print STDERR "Failed to remove all members from group during the group removal process: ".$ad_entry->dn() . "\n";
+				ldap_log($service_name, "Failed to remove all members from group during the group removal process: ".$ad_entry->dn());
+				$counter_group_not_emptied++;
+			}
+		}
+	}
+
+}
+
+#
+# Update group members in AD
+#
+sub process_update() {
+	my %params;
+	foreach my $perun_entry (@perun_entries) {
+
+		%params = (
+			description => $perun_entry->get_value('description')
+		);
+
+		if (exists $ad_entries_map{ lc $perun_entry->get_value('cn') }){
+			update_info(clone_entry_with_specific_attributes($perun_entry, \@baseAttrs), $ad_entries_map{ lc $perun_entry->get_value('cn') }, \%params);
+		}
+
+		my @per_val = $perun_entry->get_value('member');
+
+		# load members of a group from AD based on DN in Perun => Group must exists in AD
+		my @ad_val = load_group_members($ldap, $perun_entry->dn(), $filter);
+
+		if ($? != 0) {
+			print STDERR "Unable to load Perun group members from AD: " . $perun_entry->dn() . "\n";
+			ldap_log($service_name, "Unable to load Perun group members from AD: " . $perun_entry->dn());
+			next;
+		}
+
+		# sort to compare
+		my @sorted_ad_val = sort(@ad_val);
+		my @sorted_per_val = sort(@per_val);
+
+		# compare using smart-match (perl 5.10.1+)
+		unless(@sorted_ad_val ~~ @sorted_per_val) {
+
+			my %ad_val_map = map { $_ => 1 } @sorted_ad_val;
+			my %per_val_map = map { $_ => 1 } @sorted_per_val;
+
+			# members of group are not equals
+			# we must get reference to real group from AD in order to call "replace"
+			my $response_ad = $ldap->search( base => $perun_entry->dn(), filter => $filter, scope => 'base' );
+			unless ($response_ad->is_error()) {
+				# SUCCESS
+				my $ad_entry = $response_ad->entry(0);
+				my $result = update_group_membership($ldap, $service_name, $ad_entry, \%ad_val_map, \%per_val_map);
+				$counter_group_members_updated++ if ($result eq $RESULT_CHANGED);
+				$counter_group_members_updated_with_errors++ if ($result eq $RESULT_ERRORS);
+			} else {
+				# FAIL (to get group from AD)
+				$counter_group_members_not_updated++;
+				print STDERR "Group members NOT updated: " . $perun_entry->dn() . " | " . $response_ad->error() . "\n";
+				ldap_log($service_name, "Group members NOT updated: " . $perun_entry->dn() . " | " . $response_ad->error());
+			}
+		}
+
+		# group is unchanged
+
+	}
+
+}
+
+sub update_info {
+	my $entry = shift;
+	my $update_entry = shift;
+	my $params = shift;
+
+	my $params_udapted = 0;
+	foreach (keys %{$params}){
+		if (compare_entry($update_entry, $entry, $_) == 1){
+			$update_entry->replace(
+				"$_" => $params->{$_},
+			);
+			$params_udapted = 1;
+		}
+	}
+	if ($params_udapted == 1){
+		my $response = $update_entry->update($ldap);
+		if ($response) {
+			unless ($response->is_error()) {
+				ldap_log($service_name, "Group Attributes Updated: " . $update_entry->dn() . " | ");
+				return 0;
+			} else {
+				print STDERR "Group Attributes NOT updated: " . $update_entry->ldif("change" => "true") . " | " . $response->error() . "\n";
+				ldap_log($service_name, "Group Attributes NOT updated: " . $update_entry->ldif("change" => "true") . " | " . $response->error() . " | ");
+				return 1;
+			}
+		}
+	}
+}

--- a/send/ad_admin_user_mu_ucn
+++ b/send/ad_admin_user_mu_ucn
@@ -1,0 +1,196 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
+use Net::LDAPS;
+use Net::LDAP::Entry;
+use Net::LDAP::Message;
+use Net::LDAP::LDIF;
+use DBI;
+
+# Import shared AD library
+use ADConnector;
+use ScriptLock;
+
+sub process_disable;
+sub process_update;
+
+# log counters
+my $counter_remove = 0;
+my $counter_remove_fail = 0;
+my $counter_update = 0;
+my $counter_update_fail = 0;
+
+# define service
+my $service_name = "ad_admin_user_mu_ucn";
+
+# GEN folder location
+my $facility_name = $ARGV[0];
+chomp($facility_name);
+my $service_files_base_dir="../gen/spool";
+my $service_files_dir="$service_files_base_dir/$facility_name/$service_name";
+
+my $base_dn = "OU=PrivilegedUsers,OU=MU,DC=ucn,DC=muni,DC=cz";
+
+# propagation destination
+my $namespace = $ARGV[1];
+chomp($namespace);
+
+my $filter = '(objectClass=person)';
+
+# create service lock
+my $lock = ScriptLock->new($facility_name . "_" . $service_name . "_" . $namespace);
+($lock->lock() == 1) or die "Unable to get lock, service propagation was already running.";
+
+# init configuration
+my @conf = init_config($namespace);
+my @ldap_locations = resolve_domain_controlers($conf[0]);
+my $ldap = ldap_connect_multiple_options(\@ldap_locations);
+# connect
+ldap_bind($ldap, $conf[1], $conf[2]);
+
+# load all data
+my @perun_entries = load_perun($service_files_dir . "/" . $service_name . ".ldif");
+my @ad_entries = load_ad($ldap, $base_dn, $filter, ['cn','displayName','sn','givenName','mail','userAccountControl','samAccountName']);
+
+my %ad_entries_map = ();
+my %perun_entries_map = ();
+
+foreach my $entry (@ad_entries) {
+	my $login = $entry->get_value('cn');
+	$ad_entries_map{ $login } = $entry;
+}
+
+foreach my $entry (@perun_entries) {
+	my $login = $entry->get_value('cn');
+	$perun_entries_map{ $login } = $entry;
+}
+
+# process data
+process_disable();
+process_update();
+
+# disconnect
+ldap_unbind($ldap);
+
+# log results
+ldap_log($service_name, "Disabled: " . $counter_remove . " entries.");
+ldap_log($service_name, "NOT Disabled: " . $counter_remove_fail . " entries.");
+ldap_log($service_name, "Updated: " . $counter_update. " entries.");
+ldap_log($service_name, "NOT Updated: " . $counter_update_fail . " entries.");
+
+# print results for TaskResults in GUI
+print "Disabled: " . $counter_remove . " entries.\n";
+print "NOT Disabled: " . $counter_remove_fail . " entries.\n";
+print "Updated: " . $counter_update. " entries.\n";
+print "NOT Updated: " . $counter_update_fail. " entries.\n";
+
+$lock->unlock();
+my $counter_fail = $counter_remove_fail + $counter_update_fail;
+if ($counter_fail > 0) { die "Failed to process: " . $counter_fail . " entries.\nSee log at: ~/perun-engine/send/logs/$service_name.log";}
+
+# END of main script
+
+###########################################
+#
+# Main processing functions
+#
+###########################################
+
+sub process_disable() {
+	foreach my $entry (@ad_entries) {
+
+		# We create only entries for normal UČO users
+		my $login = $entry->get_value('cn');
+		next if exists $perun_entries_map{$login};
+
+		my $entry_uac = $entry->get_value('userAccountControl');
+		if (is_uac_enabled($entry_uac) == 1){
+	                # Account enabled -> disable it
+			$entry->replace(
+                	        'userAccountControl' => disable_uac($entry_uac)
+                	);
+                	my $response = $entry->update($ldap);
+                	unless ($response->is_error()) {
+                    		# SUCCESS
+                    		ldap_log($service_name, "Disabled user: " . $entry->dn());
+                    		$counter_remove++;
+                	} else {
+                    		# FAIL
+				print STDERR "User NOT Disabled: " . $entry->dn() . " | " . $response->error() . "\n";
+                    		ldap_log($service_name, "NOT Disabled: " . $entry->dn() . " | " . $response->error());
+                    		ldap_log($service_name, $entry->ldif());
+                    		$counter_remove_fail++;
+                	}   
+            	}
+	}
+}
+
+#
+# Update existing user entries in AD
+#
+sub process_update() {
+
+	foreach my $perun_entry (@perun_entries) {
+
+		if (exists $ad_entries_map{$perun_entry->get_value('cn')}) {
+
+			my $ad_entry = $ad_entries_map{$perun_entry->get_value('cn')};
+
+			# attrs without cn since it's part of DN to be updated
+			my @attrs = ('displayName','sn','givenName','mail');
+
+			# stored log messages to check if entry should be updated
+			my @entry_changed = ();
+
+			# check each attribute
+			foreach my $attr (@attrs) {
+				if (compare_entry($ad_entry , $perun_entry , $attr) == 1) {
+					# store value for log
+					my @ad_val = $ad_entry->get_value($attr);
+					my @perun_val = $perun_entry->get_value($attr);
+					push(@entry_changed, "$attr | " . join(", ",sort(@ad_val)) .  " => " . join(", ",sort(@perun_val)));
+					# replace value
+					$ad_entry->replace(
+						$attr => \@perun_val
+					);
+				}
+			}
+
+			# check UAC
+			my $ad_entry_uac = $ad_entry->get_value('userAccountControl');
+
+			# if disabled -> enable it
+			unless (is_uac_enabled($ad_entry_uac) == 1) {
+
+				my $original_ad_entry_uac = $ad_entry_uac;
+				my $new_ad_entry_uac = enable_uac($ad_entry_uac);
+				push( @entry_changed, "userAccountControl | $original_ad_entry_uac => $new_ad_entry_uac" );
+				$ad_entry->replace(
+					'userAccountControl' => $new_ad_entry_uac
+				);
+
+			}
+
+			if (@entry_changed) {
+				# Update entry in AD
+				my $response = $ad_entry->update($ldap);
+				unless ($response->is_error()) {
+					# SUCCESS
+					foreach my $log_message (@entry_changed) {
+						#ldap_log($service_name, "Updated: " . $ad_entry->dn() . " | " . $log_message);
+					}
+					$counter_update++;
+				} else {
+					# FAIL
+					print STDERR "User NOT updated: " . $ad_entry->dn() . " | " . $response->error() . "\n";
+					ldap_log($service_name, "NOT updated: " . $ad_entry->dn() . " | " . $response->error());
+					ldap_log($service_name, $ad_entry->ldif());
+					$counter_update_fail++;
+				}
+			}
+
+		}
+
+	}
+}


### PR DESCRIPTION
* Added scripts for ad_admin_user_mu_ucn and ad_admin_group_mu_ucn services.
* These services are used to manage privileged users and their groups in the ad. 
* Privileged users are users with the `mu-adm` login.