### PR TITLE
refactor(drupal_elixir): use only warning when duplicate users are found

### DIFF
--- a/slave/process-drupal-elixir/bin/process-drupal_elixir.sh
+++ b/slave/process-drupal-elixir/bin/process-drupal_elixir.sh
@@ -12,7 +12,7 @@ function process {
 	I_CHANGED=(0 '${FILE} updated')
 	I_NOT_CHANGED=(0 '${FILE} has not changed')
 	E_CHMOD=(51 'Cannot chmod on $WORK_DIR/$FILE')
-	E_DUPLICATES=(52 'Email duplicates: ${DUPLICATES}')
+	E_DUPLICATES=(0 'Email duplicates: ${DUPLICATES}')
 
 	create_lock
 


### PR DESCRIPTION
We need to end with OK return code in order to end with warning on duplicate users.