### PR TITLE
fix(k5login): check file exists before entries crosscheck

### DIFF
--- a/slave/process-k5login/bin/process-k5login.sh
+++ b/slave/process-k5login/bin/process-k5login.sh
@@ -32,21 +32,24 @@ function process {
 		#set home dir of user as current working directory
 		catch_error E_DIR_NOT_EXISTS cd "${HOME_DIR}"
 
-		#is there anything new to be added?
-		ADDED_PRINCIPALS=""
-		for PRINCIPAL in ${PRINCIPALS}; do
-			grep "^${PRINCIPAL}\\s*\$" "${K5LOGIN}" > /dev/null
-			if [ "$?" -eq 1 ]; then
-				ADDED_PRINCIPALS="${PRINCIPAL}"
-				break
-			fi
-		done
+		# if k5login file exists
+		if [[ -f ${K5LOGIN} ]]; then
+			#is there anything new to be added?
+			ADDED_PRINCIPALS=""
+			for PRINCIPAL in ${PRINCIPALS}; do
+				grep "^${PRINCIPAL}\\s*\$" "${K5LOGIN}" > /dev/null
+				if [ "$?" -eq 1 ]; then
+					ADDED_PRINCIPALS="${PRINCIPAL}"
+					break
+				fi
+			done
 
-		#if nothing to add, can skip to another user
-		if [ -z "${ADDED_PRINCIPALS}" ]; then
-			#skip this log, not important information for administrators
-			#log_msg I_K5LOGIN_NOT_UPDATED
-			continue
+			#if nothing to add, can skip to another user
+			if [ -z "${ADDED_PRINCIPALS}" ]; then
+				#skip this log, not important information for administrators
+				#log_msg I_K5LOGIN_NOT_UPDATED
+				continue
+			fi
 		fi
 
 		#prepare empty temporary file

--- a/slave/process-k5login/changelog
+++ b/slave/process-k5login/changelog
@@ -1,3 +1,10 @@
+perun-slave-process-k5login (3.1.9) stable; urgency=medium
+
+  * Check k5login file exists before trying to crosscheck its entries
+    when preventing unnecessary overwriting.
+
+ -- Johana Supikova <xsupikov@fi.muni.cz>  Thu, 7 Oct 2021 14:45:00 +0200
+
 perun-slave-process-k5login (3.1.8) stable; urgency=medium
 
   * Do not overwrite k5login files that have not changed.


### PR DESCRIPTION
* Slave script now checks if target file exists before crosschecking entries preventing unnecessary overwriting