### PR TITLE
fix(ldap_it4i): fixed failing script and source mail

### DIFF
--- a/gen/ldap_it4i
+++ b/gen/ldap_it4i
@@ -22,9 +22,10 @@ our $A_USER_LOGIN_EINFRA; *A_USER_LOGIN_EINFRA = \'urn:perun:user:attribute-def:
 our $A_FIRST_NAME;  *A_FIRST_NAME = \'urn:perun:user:attribute-def:core:firstName';
 our $A_LAST_NAME;  *A_LAST_NAME = \'urn:perun:user:attribute-def:core:lastName';
 our $A_DISPLAY_NAME;  *A_DISPLAY_NAME = \'urn:perun:user:attribute-def:core:displayName';
-our $A_USER_PREFERRED_MAIL;  *A_USER_PREFERRED_MAIL = \'urn:perun:user:attribute-def:def:preferredMail';
 our $A_SSHKEYS;  *A_SSHKEYS = \'urn:perun:user:attribute-def:def:sshPublicKey';
 our $A_MEMBER_STATUS;  *A_MEMBER_STATUS =  \'urn:perun:member:attribute-def:core:status';
+our $A_USER_PREFERRED_MAIL;  *A_USER_PREFERRED_MAIL = \'urn:perun:user:attribute-def:def:preferredMail';
+our $A_MEMBER_MAIL;  *A_MEMBER_MAIL =  \'urn:perun:member:attribute-def:def:mail';
 
 our $STATUS_VALID;      *STATUS_VALID =        \'VALID';
 our $STATUS_EXPIRED;    *STATUS_EXPIRED =      \'EXPIRED';
@@ -46,7 +47,7 @@ foreach my $resourceId ( $data->getResourceIds() ) {
 		$users->{$login}->{$A_FIRST_NAME} = $data->getUserAttributeValue( member => $memberId, attrName => $A_FIRST_NAME );
 		$users->{$login}->{$A_LAST_NAME} = $data->getUserAttributeValue( member => $memberId, attrName => $A_LAST_NAME );
 		$users->{$login}->{$A_DISPLAY_NAME} = $data->getUserAttributeValue( member => $memberId, attrName => $A_DISPLAY_NAME );
-		$users->{$login}->{$A_USER_PREFERRED_MAIL} = $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_PREFERRED_MAIL );
+		$users->{$login}->{$A_MEMBER_MAIL} = $data->getMemberAttributeValue( member => $memberId, attrName => $A_MEMBER_MAIL ) || $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_PREFERRED_MAIL );
 		$users->{$login}->{$A_SSHKEYS} = $data->getUserAttributeValue( member => $memberId, attrName => $A_SSHKEYS );
 
 		my $status = $data->getMemberAttributeValue( member => $memberId, attrName => $A_MEMBER_STATUS );
@@ -96,7 +97,7 @@ for my $login (sort keys %$users) {
 	}
 
 	print FILE "displayName: " . $users->{$login}->{$A_DISPLAY_NAME} . "\n";
-	print FILE "mail: " . $users->{$login}->{$A_USER_PREFERRED_MAIL} . "\n";
+	print FILE "mail: " . $users->{$login}->{$A_MEMBER_MAIL} . "\n";
 	print FILE "userPassword: {SASL}" . $login . '@EINFRA' . "\n";
 	print FILE "status: " . $users->{$login}->{$A_MEMBER_STATUS} . "\n";
 

--- a/send/ldap_it4i
+++ b/send/ldap_it4i
@@ -54,7 +54,7 @@ ldap_bind($ldap, $conf[1], $conf[2]);
 
 # load all data
 my @users = load_perun($service_file);
-my @previousUsers = load_ad($ldap, $base_dn, $filter, ['uid','givenName','sn','cn','displayName','mail','status','sshPublicKey']);
+my @previousUsers = load_ad($ldap, $base_dn, $filter, ['uid','givenName','sn','cn','displayName','mail','status','sshPublicKey','userPassword']);
 
 my %previousUsersMap = ();
 foreach my $previousUser (@previousUsers) {
@@ -94,7 +94,7 @@ sub process_update() {
 
 			my $previousUser = $previousUsersMap{$user->get_value('uid')};
 
-			my @attrs = ('givenName','sn','cn','displayName','mail','status','sshPublicKey');
+			my @attrs = ('givenName','sn','cn','displayName','mail','status','sshPublicKey','userPassword');
 
 			# stored log messages to check if entry should be updated
 			my @entry_changed = ();
@@ -102,14 +102,14 @@ sub process_update() {
 			# check each attribute
 			foreach my $attr (@attrs) {
 				if (compare_entry( $previousUser, $user, $attr ) == 1) {
-					my $entry = $previousUser->get_value($attr);
-					my $perun_entry = $user->get_value($attr);
+					my @entry = $previousUser->get_value($attr);
+					my @perun_entry = $user->get_value($attr);
 
 					push(@entry_changed,
-						"$attr | " . join(", ", $entry) . " => " . join(", ", $perun_entry));
+						"$attr | " . join(", ", @entry) . " => " . join(", ", @perun_entry));
 					# replace value
 					$previousUser->replace(
-						$attr => \$perun_entry
+						$attr => \@perun_entry
 					);
 				}
 			}


### PR DESCRIPTION
- Even single value attributes can be compared like arrays, but it
  doesn't work the other way around.
- Update also userPassword since users will be setting it
  after initial import.
- As it will be filled with original value from IT4I, they want to
  prefer member mail attribute when exporting value back to LDAP.