### PR TITLE
fix(kerberos_renewal_principals): updated protocol version

### DIFF
--- a/gen/kerberos_renewal_principals
+++ b/gen/kerberos_renewal_principals
@@ -7,7 +7,7 @@ use perunServicesUtils;
 use File::Basename;
 
 local $::SERVICE_NAME = basename($0);
-local $::PROTOCOL_VERSION = "3.0.0";
+local $::PROTOCOL_VERSION = "3.1.0";
 my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;

--- a/slave/process-kerberos-renewal-principals/bin/process-kerberos_renewal_principals.sh
+++ b/slave/process-kerberos-renewal-principals/bin/process-kerberos_renewal_principals.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-PROTOCOL_VERSION='3.0.0'
+PROTOCOL_VERSION='3.1.0'
 
 function process {
 


### PR DESCRIPTION
- Generated files are now located in the subfolder and
  previous version of the slave script can't process them correctly.
- To prevent service from failing we must update protocol minor
  version so the gen/slave scripts can be deployed independently.