### PR TITLE
fix(fs_home_mu): set data limit to 0 if missing

### DIFF
--- a/gen/fs_home_mu
+++ b/gen/fs_home_mu
@@ -190,7 +190,7 @@ foreach my $resourceId ( $data->getResourceIds() ) {
 					$dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_QUOTA_HEADER} = 0;
 				}
 				unless ($dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_LIMIT_HEADER}) {
-					$dataForUserQuotasByUID->{$uid}->{$volume}->{$FILE_LIMIT_HEADER} = 0;
+					$dataForUserQuotasByUID->{$uid}->{$volume}->{$DATA_LIMIT_HEADER} = 0;
 				}
 			}
 		}


### PR DESCRIPTION
- Set data limit to 0 if setting is not provided by Perun.
  We do the same for data quota.