### PR TITLE
feat(o365_mu): removing and preserving resource mailboxes

### DIFF
--- a/gen/o365_mu
+++ b/gen/o365_mu
@@ -16,8 +16,8 @@ sub saveUsersToFile;
 sub saveGroupsToFile;
 
 our $SERVICE_NAME     = "o365_mu";
-our $PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.1";
+our $PROTOCOL_VERSION = "3.1.0";
+my $SCRIPT_VERSION = "3.1.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
@@ -39,6 +39,19 @@ our $A_UF_O365_STORE_AND_FORWARD;            *A_UF_O365_STORE_AND_FORWARD =     
 our $A_UF_O365_LICENCE;                      *A_UF_O365_LICENCE =                      \'urn:perun:user_facility:attribute-def:def:o365Licence';
 our $A_R_IS_FOR_O365_GROUP;                  *A_R_IS_FOR_O365_GROUP =                  \'urn:perun:resource:attribute-def:def:isForO365Group';
 our $A_F_ID;                                 *A_F_ID =                                 \'urn:perun:facility:attribute-def:core:id';
+
+our $UPN_TEXT = "UPN";
+our $MAIL_FORWARD_TEXT = "mailForward";
+our $ARCHIVE_TEXT = "archive";
+our $STORE_AND_FORWARD_TEXT = "storeAndForward";
+our $EMAIL_ADDRESSES = "emailAddresses";
+
+###------------------------------------------------------------------------------
+### RESOURCE MAILBOXES CONFIGURATION
+### WARNING: These variables are for purpose of resource mail boxes configuration
+###          and we are not using them at this moment! We still want to preserve
+###          this for continuing a work on service in the future.
+###------------------------------------------------------------------------------
 our $A_R_O365_RES_NAME;                      *A_R_O365_RES_NAME =                      \'urn:perun:resource:attribute-def:def:o365ResourceName';
 our $A_R_O365_RES_ALIAS;                     *A_R_O365_RES_ALIAS =                     \'urn:perun:resource:attribute-def:def:o365ResourceAlias';
 our $A_R_O365_RES_EMAIL_ADDRESES;            *A_R_O365_RES_EMAIL_ADDRESES =            \'urn:perun:resource:attribute-def:def:o365ResourceEmailAddresses';
@@ -66,7 +79,6 @@ our $A_GR_O365_RES_BOOK_IN_POLICY;           *A_GR_O365_RES_BOOK_IN_POLICY =    
 our $A_GR_O365_RES_REQUEST_IN_POLICY;        *A_GR_O365_RES_REQUEST_IN_POLICY =        \'urn:perun:group_resource:attribute-def:def:o365ResourceRequestInPolicy';
 our $A_GR_O365_RES_REQUEST_OUT_OF_POLICY;    *A_GR_O365_RES_REQUEST_OUT_OF_POLICY =    \'urn:perun:group_resource:attribute-def:def:o365ResourceRequestOutOfPolicy';
 our $A_GR_O365_RES_DELEGATES;                *A_GR_O365_RES_DELEGATES =                \'urn:perun:group_resource:attribute-def:def:o365ResourceDelegates';
-
 our $RES_NAME_TEXT = "RES_NAME";
 our $RES_ALIAS_TEXT = "RES_ALIAS";
 our $RES_EMAIL_ADDRESES_TEXT = "RES_EMAIL_ADDRESES";
@@ -94,11 +106,12 @@ our $RES_DELEGATES_TEXT = "RES_DELEGATES";
 our $RES_BOOK_IN_POLICY_TEXT = "RES_BOOK_IN_POLICY";
 our $RES_REQUEST_IN_POLICY_TEXT = "RES_REQUEST_IN_POLICY";
 our $RES_REQUEST_OUT_OF_POLICY_TEXT = "RES_REQUEST_OUT_OF_POLICY";
-our $UPN_TEXT = "UPN";
-our $MAIL_FORWARD_TEXT = "mailForward";
-our $ARCHIVE_TEXT = "archive";
-our $STORE_AND_FORWARD_TEXT = "storeAndForward";
-our $EMAIL_ADDRESSES = "emailAddresses";
+
+our $resourceMails = {};
+my $resourceMailsFileName = "$DIRECTORY/$::SERVICE_NAME-resource-mails";
+###------------------------------------------------------------------------------
+### END of RESOURCE MAILBOXES CONFIGURATION
+###------------------------------------------------------------------------------
 
 #Default forwarding domain for MU
 our $DEFAULT_FORWARDING_DOMAIN = '@mo.muni.cz';
@@ -109,7 +122,6 @@ our $DEFAULT_FORWARDING_DOMAIN = '@mo.muni.cz';
 
 our $users = {};
 our $groups = {};
-our $resourceMails = {};
 
 #-------------------------------------------------------------------------
 # PROCESSING FACILITY
@@ -135,12 +147,12 @@ foreach my $resourceId ( $data->getResourceIds() ) {
 
 my $usersFileName = "$DIRECTORY/$::SERVICE_NAME-users";
 my $groupsFileName = "$DIRECTORY/$::SERVICE_NAME-groups";
-my $resourceMailsFileName = "$DIRECTORY/$::SERVICE_NAME-resource-mails";
 my $facilityIdFileName = "$DIRECTORY/$::SERVICE_NAME-facilityId";
 
 saveUsersToFile $usersFileName, $users;
 saveGroupsToFile $groupsFileName, $groups;
-saveResourceMailsToFile $resourceMailsFileName, $resourceMails;
+###we don't want to process resource mailboxes until further change
+#saveResourceMailsToFile $resourceMailsFileName, $resourceMails;
 saveFacilityIdToFile $facilityIdFileName, $facilityId;
 
 #-------------------------------------------------------------------------
@@ -164,20 +176,21 @@ sub processResource {
 
 	#define attributes for processing o365 groups and o365 resource maling lists
 	my $isForO365Group = $data->getResourceAttributeValue( resource => $resourceId, attrName => $A_R_IS_FOR_O365_GROUP );
-	my $resName = $data->getResourceAttributeValue( resource => $resourceId, attrName => $A_R_O365_RES_NAME );
+	#my $resName = $data->getResourceAttributeValue( resource => $resourceId, attrName => $A_R_O365_RES_NAME );
 
 	#process all members from resource (users data)
 	foreach my $memberId ($data->getMemberIdsForResource( resource => $resourceId )) {
 		processResourceMember $memberId;
 	}
 
+	### Skip of processing resource mails
 	#if resource mail name exists, process it as resource mail (resource-mails data)
-	if($resName) {
-		#prevent duplicity in resource name
-		if($resourceMails->{$resName}) { die "There is a duplicity of two Resources with the same resourceMailName: $resName\n"; }
-
-		processResourceMail $resourceId;
-	}
+	#if($resName) {
+	#	#prevent duplicity in resource name
+	#	if($resourceMails->{$resName}) { die "There is a duplicity of two Resources with the same resourceMailName: $resName\n"; }
+	#
+	#	processResourceMail $resourceId;
+	#}
 
 	#if resource is set as o365 resource, process it with all it's groups (groups data)
 	if($isForO365Group) {
@@ -301,7 +314,9 @@ sub processResourceMember {
 		} else {
 			warn "Can't find emails for user with UCO: $UCO \n";
 		}
-		my $emailsString = join(',', sort @emailsArray);
+		#do not use sorting because of cache in send script (cache does not have sorted emails and such records would need to be updated even if there is no really change)
+		#my $emailsString = join(',', sort @emailsArray);
+		my $emailsString = join(',', @emailsArray);
 
 		unless($users->{$UCO}) {
 			$users->{$UCO}->{$UPN_TEXT} = $UCO . "@" . $domainName;

--- a/send/o365-connector.pl
+++ b/send/o365-connector.pl
@@ -97,13 +97,17 @@ our $COMMAND_GET_GROUP = "Get-MuniGroup";
 our $COMMAND_GET_O365_GROUP = "Get-MuniO365Group";
 our $COMMAND_GET_MAILBOX = "Get-MuniMailbox";
 our $COMMAND_GET_SHAREBOX = "Get-MuniSharebox";
-our $COMMAND_GET_RESOURCE = "Get-MuniResource";
-our $COMMAND_GET_RESOURCES = "Get-MuniResources";
 our $COMMAND_SET_GROUP = "Set-MuniGroup";
 our $COMMAND_SET_MAILBOX = "Set-MuniMailBox";
+our $COMMAND_TEST_MUNI_ERROR = "Test-MuniError";
+
+### RESOURCE MAILBOXES commands - not used, only preserved
+our $COMMAND_GET_RESOURCE = "Get-MuniResource";
+our $COMMAND_GET_RESOURCES = "Get-MuniResources";
 our $COMMAND_SET_RESOURCE = "Set-MuniResource";
 our $COMMAND_REMOVE_RESOURCE = "Remove-MuniResource";
-our $COMMAND_TEST_MUNI_ERROR = "Test-MuniError";
+### End of RESOURCE MAILBOXES commands
+
 #Basic content of every call
 our %content = ();
 	#"WaitMsec" => $MAX_WAIT_MSEC
@@ -206,32 +210,33 @@ GetOptions("help|h"	=> sub {
 	"forwarding|f=s"             => \$argForw,
 	"emails|e=s"                 => \$argEmailAddresses,
 	'contacts|t=s@{1,}'          => \@argContacts,
-	"alias|A=s"                  => \$argResAlias,
-	'resEmails|B=s@{1,}'         => \@argResEmails,
-	"displayName|C=s"            => \$argResDisplayName,
-	"type|D=s"                   => \$argResType,
-	"capacity|E=i"               => \$argResCapacity,
-	"additionalResponse|F=s"     => \$argResAdditionalResponse,
-	"extMeetingMsg|G=i"          => \$argResExtMeetingMsg,
-	"allowConflicts|H=i"         => \$argResAllowConflicts,
-	"bookingWindow|I=i"          => \$argResBookingWindow,
-	"percentageAllowed|J=i"      => \$argResPercentageAllowed,
-	"enforceSchedHorizon|K=i"    => \$argResEnforceSchedHorizon,
-	"maxConflictInstances|L=i"   => \$argResMaxConflictInstances,
-	"maxDuration|M=i"            => \$argResMaxDuration,
-	"schedDuringWorkHours|N=i"   => \$argResSchedDuringWorkHours,
-	"allBookInPolicy|O=i"        => \$argResAllBookInPolicy,
-	"allReqInPolicy|P=i"         => \$argResAllRequestInPolicy,
-	"allReqOutOfPolicy|Q=i"      => \$argResAllReqOutOfPolicy,
-	'workingDays|R=s@{1,}'       => \@argResWorkingDays,
-	"workingHoursStart|T=s"      => \$argResWorkingHoursStart,
-	"workingHoursEnd|U=s"        => \$argResWorkingHoursEnd,
-	"allowRecurMeetings|V=i"     => \$argResAllowRecurMeetings,
-	"addAdditionalResp|X=i"      => \$argResAddAdditionalResp,
-	'delegates|Y=s{1,}'          => \@argResDelegates,
-	'bookInPolicy|Z=s{1,}'       => \@argResBookInPolicy,
-	'requestInPolicy|x=s{1,}'    => \@argResRequestInPolicy,
-	'requestOutOfPolicy|y=s{1,}' => \@argResRequestOutOfPolicy
+	"alias|A=s"                  => \$argResAlias
+	### Resource mailboxes parameters are not used, only preserved
+	#'resEmails|B=s@{1,}'         => \@argResEmails,
+	#"displayName|C=s"            => \$argResDisplayName,
+	#"type|D=s"                   => \$argResType,
+	#"capacity|E=i"               => \$argResCapacity,
+	#"additionalResponse|F=s"     => \$argResAdditionalResponse,
+	#"extMeetingMsg|G=i"          => \$argResExtMeetingMsg,
+	#"allowConflicts|H=i"         => \$argResAllowConflicts,
+	#"bookingWindow|I=i"          => \$argResBookingWindow,
+	#"percentageAllowed|J=i"      => \$argResPercentageAllowed,
+	#"enforceSchedHorizon|K=i"    => \$argResEnforceSchedHorizon,
+	#"maxConflictInstances|L=i"   => \$argResMaxConflictInstances,
+	#"maxDuration|M=i"            => \$argResMaxDuration,
+	#"schedDuringWorkHours|N=i"   => \$argResSchedDuringWorkHours,
+	#"allBookInPolicy|O=i"        => \$argResAllBookInPolicy,
+	#"allReqInPolicy|P=i"         => \$argResAllRequestInPolicy,
+	#"allReqOutOfPolicy|Q=i"      => \$argResAllReqOutOfPolicy,
+	#'workingDays|R=s@{1,}'       => \@argResWorkingDays,
+	#"workingHoursStart|T=s"      => \$argResWorkingHoursStart,
+	#"workingHoursEnd|U=s"        => \$argResWorkingHoursEnd,
+	#"allowRecurMeetings|V=i"     => \$argResAllowRecurMeetings,
+	#"addAdditionalResp|X=i"      => \$argResAddAdditionalResp,
+	#'delegates|Y=s{1,}'          => \@argResDelegates,
+	#'bookInPolicy|Z=s{1,}'       => \@argResBookInPolicy,
+	#'requestInPolicy|x=s{1,}'    => \@argResRequestInPolicy,
+	#'requestOutOfPolicy|y=s{1,}' => \@argResRequestOutOfPolicy
 ) || die help;
 
 #Check existence of mandatory parameters
@@ -265,13 +270,20 @@ if($argCommand eq $COMMAND_SET_MAILBOX) {
 	setMailbox ( $COMMAND_STATUS_SET, undef, $argIdent, $argDeliv, $argArch, $argForw, $argEmailAddresses );
 } elsif ($argCommand eq $COMMAND_SET_GROUP) {
 	setGroup ( $COMMAND_STATUS_SET, undef, $argIdent, \@argContacts);
-} elsif ($argCommand eq $COMMAND_SET_RESOURCE) {
-	setResourceMail ( $COMMAND_STATUS_SET, undef, $argIdent, $argResAlias, \@argResEmails, $argResDisplayName, $argResType,
-	 $argResCapacity, $argResAdditionalResponse, $argResExtMeetingMsg, $argResAllowConflicts, $argResBookingWindow,
-	 $argResPercentageAllowed, $argResEnforceSchedHorizon, $argResMaxConflictInstances, $argResMaxDuration, $argResSchedDuringWorkHours,
-	 $argResAllBookInPolicy, $argResAllRequestInPolicy, $argResAllReqOutOfPolicy, \@argResWorkingDays, $argResWorkingHoursStart,
-	 $argResWorkingHoursEnd, $argResAllowRecurMeetings, $argResAddAdditionalResp, \@argResDelegates, \@argResBookInPolicy,
-	 \@argResRequestInPolicy, \@argResRequestOutOfPolicy);
+### Resource mailboxes commands are not allowed, only preserved
+#} elsif ($argCommand eq $COMMAND_SET_RESOURCE) {
+#	setResourceMail ( $COMMAND_STATUS_SET, undef, $argIdent, $argResAlias, \@argResEmails, $argResDisplayName, $argResType,
+#	 $argResCapacity, $argResAdditionalResponse, $argResExtMeetingMsg, $argResAllowConflicts, $argResBookingWindow,
+#	 $argResPercentageAllowed, $argResEnforceSchedHorizon, $argResMaxConflictInstances, $argResMaxDuration, $argResSchedDuringWorkHours,
+#	 $argResAllBookInPolicy, $argResAllRequestInPolicy, $argResAllReqOutOfPolicy, \@argResWorkingDays, $argResWorkingHoursStart,
+#	 $argResWorkingHoursEnd, $argResAllowRecurMeetings, $argResAddAdditionalResp, \@argResDelegates, \@argResBookInPolicy,
+#	 \@argResRequestInPolicy, \@argResRequestOutOfPolicy);
+#} elsif ($argCommand eq $COMMAND_GET_RESOURCE) {
+#	getResourceMail ( $COMMAND_STATUS_SET, undef, $argIdent);
+#} elsif ($argCommand eq $COMMAND_GET_RESOURCES) {
+#	getResourceMails ( $COMMAND_STATUS_SET, undef);
+#} elsif ($argCommand eq $COMMAND_REMOVE_RESOURCE) {
+#	removeResourceMail ( $COMMAND_STATUS_SET, undef, $argIdent);
 } elsif ($argCommand eq $COMMAND_PING_EMAIL) {
 	pingEmail ( $COMMAND_STATUS_SET, undef, $argIdent);
 } elsif ($argCommand eq $COMMAND_GET_CONTACT) {
@@ -284,12 +296,6 @@ if($argCommand eq $COMMAND_SET_MAILBOX) {
 	getO365Group ( $COMMAND_STATUS_SET, undef, $argIdent);
 } elsif ($argCommand eq $COMMAND_GET_SHAREBOX) {
 	getSharebox ( $COMMAND_STATUS_SET, undef, $argIdent);
-} elsif ($argCommand eq $COMMAND_GET_RESOURCE) {
-	getResourceMail ( $COMMAND_STATUS_SET, undef, $argIdent);
-} elsif ($argCommand eq $COMMAND_GET_RESOURCES) {
-	getResourceMails ( $COMMAND_STATUS_SET, undef);
-} elsif ($argCommand eq $COMMAND_REMOVE_RESOURCE) {
-	removeResourceMail ( $COMMAND_STATUS_SET, undef, $argIdent);
 } elsif ($argCommand eq $COMMAND_TEST_MUNI_ERROR) {
 	testMuniError ( $COMMAND_STATUS_SET, undef, $argIdent);
 } else {
@@ -1222,18 +1228,19 @@ sub resolveOutputByCommandName {
 		return getSharebox ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
 	} elsif ($actualCommand eq $COMMAND_GET_MAILBOX) {
 		return getMailbox ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
-	} elsif ($actualCommand eq $COMMAND_GET_RESOURCE) {
-		return getResourceMail ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
-	} elsif ($actualCommand eq $COMMAND_GET_RESOURCES) {
-		return getResourceMails ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
+	### Resource mailboxes commands are not supported any more, only preserved
+	#} elsif ($actualCommand eq $COMMAND_GET_RESOURCE) {
+	#	return getResourceMail ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
+	#} elsif ($actualCommand eq $COMMAND_GET_RESOURCES) {
+	#	return getResourceMails ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
+	#} elsif ($actualCommand eq $COMMAND_SET_RESOURCE) {
+	#	return setResourceMail ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
+	#} elsif ($actualCommand eq $COMMAND_REMOVE_RESOURCE) {
+	#	return removeResourceMail ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
 	} elsif ($actualCommand eq $COMMAND_SET_GROUP) {
 		return setGroup ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
 	} elsif ($actualCommand eq $COMMAND_SET_MAILBOX) {
 		return setMailbox ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
-	} elsif ($actualCommand eq $COMMAND_SET_RESOURCE) {
-		return setResourceMail ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
-	} elsif ($actualCommand eq $COMMAND_REMOVE_RESOURCE) {
-		return removeResourceMail ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
 	} elsif ($actualCommand eq $COMMAND_TEST_MUNI_ERROR) {
 		return testMuniError ( $COMMAND_STATUS_RESOLVE, $jsonOutput );
 	} else {

--- a/send/o365_mu
+++ b/send/o365_mu
@@ -101,7 +101,8 @@ trap 'rm -r -f "${LOCK_FILE}" "${TMP_HOSTNAME_DIR}"' EXIT
 #copy all needed files to the temporary directory
 cp $SERVICE_FILES_DIR/$SERVICE_NAME-users $TMP_HOSTNAME_DIR
 cp $SERVICE_FILES_DIR/$SERVICE_NAME-groups $TMP_HOSTNAME_DIR
-cp $SERVICE_FILES_DIR/$SERVICE_NAME-resource-mails $TMP_HOSTNAME_DIR;
+### We are not using resource mailboxes any more, this code will be preserved for further use
+#cp $SERVICE_FILES_DIR/$SERVICE_NAME-resource-mails $TMP_HOSTNAME_DIR;
 cp $SERVICE_FILES_DIR/$SERVICE_NAME-facilityId $TMP_HOSTNAME_DIR
 if [ $? -ne 0 ]; then
 	echo "Can't copy service file to temporary dir" >&2


### PR DESCRIPTION
- Because of technical issues with updating resource mailboxes data, we
were unable to finish migration of last version of this service to
production envrionment. The logic about resource mailboxes should be
removed, but there is a plan to further work on it in the future. For
this reason it was preserved and only removed from main code.
- Main parts of the code were commented and they are not processed any
more.
- All methodes and variables were preserved (but we are not using them)