### PR TITLE
feat: removed redundant filterExpiredMembers parameter

### DIFF
--- a/gen/ad_admin_group_mu_ucn
+++ b/gen/ad_admin_group_mu_ucn
@@ -9,7 +9,7 @@ no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
 local $::SERVICE_NAME = "ad_admin_group_mu_ucn";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 sub addMemberToGroup;
 sub processWorkplaces;
@@ -23,7 +23,7 @@ my $DIRECTORY = perunServicesInit::getDirectory;
 my $fileName = "$DIRECTORY/$::SERVICE_NAME".".ldif";
 
 #Get hierarchical data without expired members
-my $data = perunServicesInit::getHashedDataWithGroups(1);
+my $data = perunServicesInit::getHashedDataWithGroups;
 my $DEBUG = 0;
 
 #Constants

--- a/gen/ad_admin_user_mu_ucn
+++ b/gen/ad_admin_user_mu_ucn
@@ -10,13 +10,13 @@ use Encode;
 
 local $::SERVICE_NAME = "ad_admin_user_mu_ucn";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
 my $fileName = "$DIRECTORY/$::SERVICE_NAME".".ldif";
 
-my $data = perunServicesInit::getHashedHierarchicalData(1);
+my $data = perunServicesInit::getHashedHierarchicalData;
 
 #Constants
 our $A_F_DOMAIN;  *A_F_DOMAIN = \'urn:perun:facility:attribute-def:def:adDomain';

--- a/gen/ad_group_mu_ucn
+++ b/gen/ad_group_mu_ucn
@@ -11,7 +11,7 @@ no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
 local $::SERVICE_NAME = "ad_group_mu_ucn";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.4";
+my $SCRIPT_VERSION = "3.0.5";
 
 sub addMemberToGroup;
 sub processWorkplaces;
@@ -26,7 +26,7 @@ my $fileName = "$DIRECTORY/$::SERVICE_NAME".".ldif";
 my $baseDnFileName = "$DIRECTORY/baseDN";
 
 # Get hierarchical data without expired members
-my $data = perunServicesInit::getHashedDataWithGroups(1);
+my $data = perunServicesInit::getHashedDataWithGroups;
 my $DEBUG = 0;
 
 #Constants

--- a/gen/ad_user_mu_ucn
+++ b/gen/ad_user_mu_ucn
@@ -8,14 +8,14 @@ use utf8;
 
 local $::SERVICE_NAME = "ad_user_mu_ucn";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.1";
+my $SCRIPT_VERSION = "3.0.2";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
 my $fileName = "$DIRECTORY/$::SERVICE_NAME".".ldif";
 my $baseDnFileName = "$DIRECTORY/baseDN";
 
-my $data = perunServicesInit::getHashedHierarchicalData(1);
+my $data = perunServicesInit::getHashedHierarchicalData;
 
 #Constants
 our $A_F_BASE_DN;  *A_F_BASE_DN = \'urn:perun:facility:attribute-def:def:adBaseDN';

--- a/gen/arcgis_licenses_mu
+++ b/gen/arcgis_licenses_mu
@@ -8,11 +8,11 @@ use JSON::XS;
 use utf8;
 
 our $SERVICE_NAME     = "arcgis_licenses_mu";
-our $PROTOCOL_VERSION = "3.0.0";
+our $PROTOCOL_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
-my $data      = perunServicesInit::getHashedDataWithGroups(1);
+my $data      = perunServicesInit::getHashedDataWithGroups;
 
 #Constants
 our $A_USER_FIRST_NAME;             *A_USER_FIRST_NAME =             \'urn:perun:user:attribute-def:core:firstName';

--- a/gen/insight_mu
+++ b/gen/insight_mu
@@ -9,12 +9,12 @@ use POSIX qw(strftime);
 
 our $SERVICE_NAME = "insight_mu";
 our $PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
 # get only valid members
-my $data = perunServicesInit::getHashedDataWithGroups(1);
+my $data = perunServicesInit::getHashedDataWithGroups;
 
 # CONSTANTS
 our $A_USER_ID;                  *A_USER_ID =                  \'urn:perun:user:attribute-def:core:id';

--- a/gen/netbox
+++ b/gen/netbox
@@ -9,14 +9,14 @@ use Data::Dumper;
 
 our $SERVICE_NAME     = "netbox";
 our $PROTOCOL_VERSION = "3.0.0";
-my  $SCRIPT_VERSION   = "3.0.0";
+my  $SCRIPT_VERSION   = "3.0.1";
 
 my $file_name_users = "netbox_users";
 my $file_name_groups = "netbox_groups";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
-my $data =      perunServicesInit::getHashedHierarchicalData(1);
+my $data =      perunServicesInit::getHashedHierarchicalData;
 
 #Constants
 our $A_RESOURCE_GROUP_NAME;       *A_RESOURCE_GROUP_NAME =   \'urn:perun:resource:attribute-def:def:netboxGroupName';

--- a/gen/perunServicesInit.pm
+++ b/gen/perunServicesInit.pm
@@ -144,54 +144,42 @@ sub getFacility {
 
 sub getHashedHierarchicalData {
 	if(defined $local_data) { return $local_data; }
-  my $filterExpiredMembers = shift;
-  unless($filterExpiredMembers) { $filterExpiredMembers = 0; }
-  my $data = $servicesAgent->getHashedHierarchicalData(service => $service->getId, facility => $facility->getId, filterExpiredMembers => $filterExpiredMembers, consentEval => $CONSENT_EVAL);
+  my $data = $servicesAgent->getHashedHierarchicalData(service => $service->getId, facility => $facility->getId, consentEval => $CONSENT_EVAL);
   logData $data, 'hashedHierarchicalData';
   return $data;
 }
 
 sub getHierarchicalData {
 	if(defined $local_data) { return $local_data; }
-	my $filterExpiredMembers = shift;
-	unless($filterExpiredMembers) { $filterExpiredMembers = 0; }
-	my $data = $servicesAgent->getHierarchicalData(service => $service->getId, facility => $facility->getId, filterExpiredMembers => $filterExpiredMembers);
+	my $data = $servicesAgent->getHierarchicalData(service => $service->getId, facility => $facility->getId);
 	logData $data, 'hierarchicalData';
 	return $data;
 }
 
 sub getFlatData {
 	if(defined $local_data) { return $local_data; }
-	my $filterExpiredMembers = shift;
-	unless($filterExpiredMembers) { $filterExpiredMembers = 0; }
-	my $data = $servicesAgent->getFlatData(service => $service->getId, facility => $facility->getId, filterExpiredMembers => $filterExpiredMembers);
+	my $data = $servicesAgent->getFlatData(service => $service->getId, facility => $facility->getId);
 	logData $data, 'flatData';
 	return $data;
 }
 
 sub getHashedDataWithGroups {
 	if(defined $local_data) { return $local_data; }
-	my $filterExpiredMembers = shift;
-	unless($filterExpiredMembers) { $filterExpiredMembers = 0; }
-	my $data = $servicesAgent->getHashedDataWithGroups(service => $service->getId, facility => $facility->getId, filterExpiredMembers => $filterExpiredMembers, consentEval => $CONSENT_EVAL);
+	my $data = $servicesAgent->getHashedDataWithGroups(service => $service->getId, facility => $facility->getId, consentEval => $CONSENT_EVAL);
 	logData $data, 'hashedDataWithGroups';
 	return $data;
 }
 
 sub getDataWithGroups {
 	if(defined $local_data) { return $local_data; }
-	my $filterExpiredMembers = shift;
-	unless($filterExpiredMembers) { $filterExpiredMembers = 0; }
-	my $data = $servicesAgent->getDataWithGroups(service => $service->getId, facility => $facility->getId, filterExpiredMembers => $filterExpiredMembers);
+	my $data = $servicesAgent->getDataWithGroups(service => $service->getId, facility => $facility->getId);
 	logData $data, 'dataWithGroups';
 	return $data;
 }
 
 sub getDataWithVos {
 	if(defined $local_data) { return $local_data; }
-	my $filterExpiredMembers = shift;
-	unless($filterExpiredMembers) { $filterExpiredMembers = 0; }
-	my $data = $servicesAgent->getDataWithVos(service => $service->getId, facility => $facility->getId, filterExpiredMembers => $filterExpiredMembers);
+	my $data = $servicesAgent->getDataWithVos(service => $service->getId, facility => $facility->getId);
 	logData $data, 'dataWithVos';
 	return $data;
 }


### PR DESCRIPTION
* the parameter was passed by perun services' gen scripts as flag if members with expired group status should be included in the retrieved data
* the information is now stored in the database with the service object and does not need to be passed separately anymore

BREAKING CHANGE: removed filterExpiredMembers parameter