### PR TITLE
fix(users_emails): define variables before error messages

### DIFF
--- a/slave/process-users-emails/bin/process-users_emails.sh
+++ b/slave/process-users-emails/bin/process-users_emails.sh
@@ -3,14 +3,14 @@
 PROTOCOL_VERSION='3.0.0'
 
 function process {
+
 	DST_DIR="/tmp/"
+  DST_FILE="users_emails"
+	FROM_PERUN="${WORK_DIR}/users_emails"
 
 	### Status codes
-	I_CHANGED=(0 "${DST_FILE} updated")
-	E_CANNOT_COPY=(50 'Cannot copy file ${FROM_PERUN} to ${DST_DIR}/${DST_FILE}')
-
-	FROM_PERUN="${WORK_DIR}/users_emails"
-	DST_FILE="users_emails"
+	I_CHANGED=(0 "${DST_FILE} file updated")
+	E_CANNOT_COPY=(50 "Cannot copy file ${FROM_PERUN} to ${DST_DIR}/${DST_FILE}")
 
 	create_lock
 

--- a/slave/process-users-emails/changelog
+++ b/slave/process-users-emails/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-users-emails (3.1.2) stable; urgency=low
+
+  * Define variables before error messages so they get expanded
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Tue, 02 Aug 2022 07:40:00 +0200
+
 perun-slave-process-users-emails (3.1.1) stable; urgency=low
 
   * New package version for perun-slave-process-users-emails


### PR DESCRIPTION
- Otherwise we don't get paths expanded in error messages.