### PR TITLE
fix(rt_data_vocesnet): define variables before error messages

### DIFF
--- a/slave/process-rt-data-vocesnet/bin/process-rt_data_vocesnet.sh
+++ b/slave/process-rt-data-vocesnet/bin/process-rt_data_vocesnet.sh
@@ -6,12 +6,11 @@ function process {
 
 	DST_DIR="/tmp/"
 	DST_FILE="rt-data-vocesnet"
+	FROM_PERUN="${WORK_DIR}/rt_data_vocesnet"
 
 	### Status codes
-	I_CHANGED=(0 "${DST_FILE} updated")
-	E_NOT_CHANGE=(50 'Cannot copy file ${FROM_PERUN} to ${DST_FILE}')
-
-	FROM_PERUN="${WORK_DIR}/rt_data_vocesnet"
+	I_CHANGED=(0 "${DST_FILE} file updated")
+	E_CANNOT_COPY=(50 "Cannot copy file ${FROM_PERUN} to ${DST_DIR}/${DST_FILE}")
 
 	create_lock
 
@@ -20,6 +19,6 @@ function process {
 	if [ $? -eq 0 ]; then
 		log_msg I_CHANGED
 	else
-		log_msg E_NOT_CHANGED
+		log_msg E_CANNOT_COPY
 	fi
 }

--- a/slave/process-rt-data-vocesnet/changelog
+++ b/slave/process-rt-data-vocesnet/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-rt-data-vocesnet (3.0.1) stable; urgency=low
+
+  * Define variables before error messages so they get expanded
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Tue, 02 Aug 2022 07:40:00 +0200
+
 perun-slave-process-rt-data-vocesnet (3.0.0) stable; urgency=low
 
   * New package for processing service rt_data_vocesnet


### PR DESCRIPTION
- Otherwise we don't get paths expanded in error messages.