### PR TITLE
feat: use generic_send.py in rt_data_vocesnet and users_emails

### DIFF
--- a/send/rt_data_vocesnet
+++ b/send/rt_data_vocesnet
@@ -1,4 +1,4 @@
 #!/bin/bash
-SERVICE_NAME="rt_data_vocesnet"
+export SERVICE_NAME="rt_data_vocesnet"
 
-. generic_send
+python3 generic_send.py "$1" "$2" "$3"

--- a/send/users_emails
+++ b/send/users_emails
@@ -1,4 +1,4 @@
 #!/bin/bash
-SERVICE_NAME="users_emails"
+export SERVICE_NAME="users_emails"
 
-. generic_send
+python3 generic_send.py "$1" "$2" "$3"


### PR DESCRIPTION
- Use generic_send python script instead of old bash script to improve
  security. Switched services are rt_data_vocesnet and users_emails.