### PR TITLE
fix: make sure to always print STDERR in generic_send.py

### DIFF
--- a/send/generic_send.py
+++ b/send/generic_send.py
@@ -182,9 +182,9 @@ if __name__ == "__main__":
 		else:
 			# in this situation 'ssh' was used, STDOUT has to be printed
 			print(stdout.decode("utf-8"))
+			print(stderr.decode("utf-8"), file=sys.stderr)
 		# for all situations different from time-out by our side we can return value from ERR_CODE as the result
 		if process.returncode != 0:
-			print(stderr.decode("utf-8"), file=sys.stderr)
 			print("Communication with slave script ends with return code: " + str(process.returncode), file=sys.stderr)
 
 	exit(process.returncode)


### PR DESCRIPTION
- Old script always prints STDERR, because slave scripts can use STDERR
  to log warn/error messages and still end with 0 return code.
  On perun side, non-empty STDERR is recognized as WARNING task result, so
  we must read it.