### PR TITLE
fix(fs_home): shorten window for race-condition

### DIFF
--- a/slave/process-fs-home/bin/process-fs_home.sh
+++ b/slave/process-fs-home/bin/process-fs_home.sh
@@ -23,7 +23,7 @@ function process {
 
 	create_lock
 
-	UMASK=0755   #default pemissions
+	UMASK=0755   #default permissions
 	[ -f "$UMASK_FILE" ] && UMASK=`head -n 1 "$UMASK_FILE"`
 
 	#if QUOTA_ENABLED is not set in prescript, try to get info from quota_enabled file
@@ -107,9 +107,13 @@ function process {
 			catch_error E_CANNOT_SET_OWNERSHIP chown -R "${U_UID}":"${U_GID}" "${TMP_HOME_DIR}"
 			catch_error E_CANNOT_SET_PERMISSIONS chmod "$UMASK" "${TMP_HOME_DIR}"
 
-			catch_error E_CANNOT_MOVE_TEMP mv "${TMP_HOME_DIR}" "${HOME_DIR}"
+      if [ ! -d "${HOME_DIR}" ]; then
+			  catch_error E_CANNOT_MOVE_TEMP mv "${TMP_HOME_DIR}" "${HOME_DIR}"
+			  log_msg I_DIR_CREATED
+			else
+			  catch_error E_BAD_HOME_OWNER [ `stat -L -c "%u" ${HOME_DIR}` -eq ${U_UID} ]
+			fi
 
-			log_msg I_DIR_CREATED
 		else
 			catch_error E_BAD_HOME_OWNER [ `stat -L -c "%u" ${HOME_DIR}` -eq ${U_UID} ]
 		fi

--- a/slave/process-fs-home/changelog
+++ b/slave/process-fs-home/changelog
@@ -1,3 +1,11 @@
+perun-slave-process-fs-home (3.1.11) stable; urgency=low
+
+  * Re-check that home folder doesn't exist just before mv to
+    slim chance for race-condition when service is propagated
+    to two facilities with shared /home volume.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Thu, 18 Aug 2022 08:40:00 +0200
+
 perun-slave-process-fs-home (3.1.10) stable; urgency=low
 
   * It is now possible to skip creating a home directory from mid hook.
@@ -15,12 +23,12 @@ perun-slave-process-fs-home (3.1.9) stable; urgency=high
   * some arguments as user login, home mount point, gid etc. were removed from
     quotas template in script and also in pre script
   * this version of service fs_home supports new quotas attributes in Perun,
-    although format of data in the file is the same. To active it administrator 
+    although format of data in the file is the same. To active it administrator
     has to set attribute readyForNewQuotas on Facility to 'true'
   * Protocol version was increased, new format is not supported with older
     versions of protocol communication
-  * IMPORTANT: pre|post scripts and mid hooks can be also affected by these 
-    changes and administrator should check and modify their behavior before 
+  * IMPORTANT: pre|post scripts and mid hooks can be also affected by these
+    changes and administrator should check and modify their behavior before
     updating to this version
 
  -- Michal Stava <stavamichal@gmail.com>  Tue, 02 Apr 2019 13:25:00 +0200


### PR DESCRIPTION
- Re-check that home folder doesn't exist before mv command
  to prevent race-condition when service is propagated to
  two facilities with shared /home volume.