### PR TITLE
feat(ad_group_mu_ucn): skip groups with no computed name

### DIFF
--- a/gen/ad_group_mu_ucn
+++ b/gen/ad_group_mu_ucn
@@ -11,7 +11,7 @@ no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
 local $::SERVICE_NAME = "ad_group_mu_ucn";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.5";
+my $SCRIPT_VERSION = "3.0.6";
 
 sub addMemberToGroup;
 sub processWorkplaces;
@@ -23,6 +23,7 @@ sub writeDebug;
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
 my $fileName = "$DIRECTORY/$::SERVICE_NAME".".ldif";
+my $skippedGroupsFileName = "$DIRECTORY/skipped";
 my $baseDnFileName = "$DIRECTORY/baseDN";
 
 # Get hierarchical data without expired members
@@ -46,6 +47,7 @@ our $STATUS_EXPIRED;    *STATUS_EXPIRED =      \'EXPIRED';
 
 our $A_R_ADOUNAME; *A_R_ADOUNAME = \'urn:perun:resource:attribute-def:def:adOuName';
 our $A_G_INETCISPR; *A_G_INETCISPR = \'urn:perun:group:attribute-def:def:inetCispr';
+our $A_G_GROUP_NAME; *A_G_GROUP_NAME = \'urn:perun:group:attribute-def:core:name';
 our $A_G_DESCRIPTION; *A_G_DESCRIPTION = \'urn:perun:group:attribute-def:core:description';
 our $A_R_DESCRIPTION; *A_R_DESCRIPTION = \'urn:perun:resource:attribute-def:core:description';
 
@@ -77,6 +79,7 @@ close(FILE);
 
 our $groups = {};
 our $usersByGroups = {};
+our $skippedGroups = {};
 
 # FOR EACH RESOURCE
 foreach my $resourceId ($data->getResourceIds()) {
@@ -120,6 +123,15 @@ for my $group (sort keys %$groups) {
 
 close FILE;
 
+#
+# Print skipped data
+#
+open FILE,">:encoding(UTF-8)","$skippedGroupsFileName" or die "Cannot open $skippedGroupsFileName: $! \n";
+for my $group (keys %$skippedGroups) {
+	print FILE "gid=" . $skippedGroups->{$group}->{"id"} . "," . "name=" . $skippedGroups->{$group}->{"name"} . "\n";
+}
+close FILE;
+
 perunServicesInit::finalize;
 
 ####################
@@ -149,6 +161,15 @@ sub processTree {
 	foreach my $groupId ( $data->getGroupIdsForResource( resource => $resourceId ) ) {
 		writeDebug("Process Tree Group: $groupId", 1);
 		my $group = $data->getGroupAttributeValue(group => $groupId, attrName => $A_G_GROUP_NAME_COMPUTED);
+
+		#check if group has computed name (otherwise it does not belong to correct hierarchy)
+		unless (defined $group) {
+			my $groupName = $data->getGroupAttributeValue(group => $groupId, attrName => $A_G_GROUP_NAME);
+			$skippedGroups->{$groupId}->{"name"} = $groupName;
+			$skippedGroups->{$groupId}->{"id"} = $groupId;
+			writeDebug("Skipping group with missing computed name $groupId '$groupName'.", 2);
+			next;
+		}
 
 		#check if the name is unique through all resources
 		if ($uniqueNamesOfGroupsInTreeStructure->{$group}) {

--- a/send/ad_group_mu_ucn
+++ b/send/ad_group_mu_ucn
@@ -14,6 +14,7 @@ use ScriptLock;
 sub process_add;
 sub process_remove;
 sub process_update;
+sub process_skipped;
 
 # log counters
 my $counter_group_added = 0;
@@ -24,6 +25,7 @@ my $counter_group_not_removed = 0;
 my $counter_group_members_updated = 0;
 my $counter_group_members_updated_with_errors = 0;
 my $counter_group_members_not_updated = 0;
+my $counter_group_skipped = 0;
 
 # define service
 my $service_name = "ad_group_mu_ucn";
@@ -40,6 +42,7 @@ my $facility_name = $ARGV[0];
 chomp($facility_name);
 my $service_files_base_dir="../gen/spool";
 my $service_files_dir="$service_files_base_dir/$facility_name/$service_name";
+my $skippedGroupsFilename = "$service_files_dir/skipped";
 
 # BASE DN
 open my $file, '<', "$service_files_dir/baseDN";
@@ -90,6 +93,7 @@ foreach my $perun_entry (@perun_entries) {
 process_add();
 process_remove();
 process_update();
+process_skipped();
 
 # disconnect
 ldap_unbind($ldap);
@@ -97,6 +101,7 @@ ldap_unbind($ldap);
 # log results
 ldap_log($service_name, "Group added (without members): " . $counter_group_added . " entries.");
 ldap_log($service_name, "Group failed to add: " . $counter_group_not_added. " entries.");
+ldap_log($service_name, "Group skipped: " . $counter_group_skipped. " entries.");
 ldap_log($service_name, "-------------------------------------------------------------------------------------------------------");
 ldap_log($service_name, "Group updated (members): " . $counter_group_members_updated . " entries.");
 ldap_log($service_name, "Group updated with errors (members): " . $counter_group_members_updated_with_errors . " entries.");
@@ -109,6 +114,7 @@ ldap_log($service_name, "Group failed to remove: " . $counter_group_not_removed.
 # print results for TaskResults in GUI
 print "Group added (without members): " . $counter_group_added . " entries.\n";
 print "Group failed to add: " . $counter_group_not_added. " entries.\n";
+print "Group skipped: " . $counter_group_skipped. " entries.\n";
 print "-------------------------------------------------------------------------------------------------------\n";
 print "Group updated (members): " . $counter_group_members_updated . " entries.\n";
 print "Group updated with errors (members): " . $counter_group_members_updated_with_errors . " entries.\n";
@@ -264,6 +270,20 @@ sub process_update() {
 
 	}
 
+}
+
+#
+# Count invalid skipped groups
+#
+sub process_skipped {
+
+	if(-e $skippedGroupsFilename) {
+		open FILE, '<', $skippedGroupsFilename;
+		while (<FILE>) {
+			$counter_group_skipped++;
+		}
+		close FILE;
+	}
 }
 
 sub update_info {


### PR DESCRIPTION
* if group with no computed name is assigned to resource, it will be skipped
* only groups in hierarchy of the root group should be sent to AD
* skipped groups are now included in the task stats and will not end with error