### PR TITLE
refactor(drupal_elixir): use only warning when duplicate users are found

### DIFF
--- a/slave/base/bin/perun
+++ b/slave/base/bin/perun
@@ -131,6 +131,17 @@ function log_msg_without_exit {
 	fi
 }
 
+### Log message to stderr and exit with 0 return code
+function log_warn_to_err_exit {
+	TEXT="$1"
+	TIME=`date "+%H:%M:%S"`
+
+	MSG="Info: ${TEXT}"
+	echo "${TIME} ${MSG}" >&2
+	logger -t "${NAME}" -p daemon.error "${SERVICE}: ${MSG}" &>/dev/null
+	exit 0
+}
+
 ### Log debug only if variable DEBUG exists and is the length of this variable is nonzero
 function log_debug {
 	MSG="$1"

--- a/slave/base/changelog
+++ b/slave/base/changelog
@@ -1,3 +1,10 @@
+perun-slave-base (3.1.17) stable; urgency=low
+
+  * Added function log_warn_to_err_exit() that prints message to
+    stderr and exits with 0 exit code
+
+ -- David Flor <davidflor@seznam.cz>  Tue, 3 Jan 2023 14:50:00 +0100
+
 perun-slave-base (3.1.16) stable; urgency=low
 
   * Fixed print of E_LOCK_DIR_NOT_WRITABLE error message

--- a/slave/process-drupal-elixir/bin/process-drupal_elixir.sh
+++ b/slave/process-drupal-elixir/bin/process-drupal_elixir.sh
@@ -12,7 +12,6 @@ function process {
 	I_CHANGED=(0 '${FILE} updated')
 	I_NOT_CHANGED=(0 '${FILE} has not changed')
 	E_CHMOD=(51 'Cannot chmod on $WORK_DIR/$FILE')
-	E_DUPLICATES=(52 'Email duplicates: ${DUPLICATES}')
 
 	create_lock
 
@@ -41,6 +40,6 @@ function process {
 	#there are some duplicates between emails, need to end with error
 	if [ -s "${FILE_USER_DUPLICATES}" ]; then
 		DUPLICATES=`cat $FILE_USER_DUPLICATES`
-		log_msg E_DUPLICATES
+		log_warn_to_err_exit "Email duplicates: ${DUPLICATES}"
 	fi
 }

--- a/slave/process-drupal-elixir/changelog
+++ b/slave/process-drupal-elixir/changelog
@@ -1,3 +1,9 @@
+perun-slave-process-drupal-elixir (3.1.7) stable; urgency=low
+  * upon finding duplicates the script now exits with an ok error code
+    to prevent rerun of propagation with the same data
+
+ -- David Flor <davidflor@seznam.cz>  Tue, 3 Jan 2023 14:50:00 +0100
+
 perun-slave-process-drupal-elixir (3.1.6) stable; urgency=high
   * catching of duplicates on slave side were not working correctly, because
     there was wrong path to file with duplicates


### PR DESCRIPTION
* with duplicate users the slave script needs to end with an ok return code in order to prevent rerun of the propagation with the same data