### PR TITLE
fix(drupal_elixir): package must depend on newer version of the base

### DIFF
--- a/slave/process-drupal-elixir/dependencies
+++ b/slave/process-drupal-elixir/dependencies
@@ -1,1 +1,1 @@
-perun-slave-base
+perun-slave-base (>= 3.1.17)

--- a/slave/process-drupal-elixir/rpm.dependencies
+++ b/slave/process-drupal-elixir/rpm.dependencies
@@ -1,1 +1,1 @@
-perun-slave-base
+perun-slave-base >= 3.1.17


### PR DESCRIPTION
- Service slave script must depend on the newer version of the base package since it uses new function added in 3.1.17.