### PR TITLE
feat(atlassian_mu): allow changing domain via facility attribute

### DIFF
--- a/gen/atlassian_mu
+++ b/gen/atlassian_mu
@@ -10,25 +10,36 @@ use utf8;
 
 local $::SERVICE_NAME = "atlassian_mu";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
 my $data = perunServicesInit::getHashedHierarchicalData;
 
-#forward declaration
+# Forward declaration
 sub processUsers;
 sub processResource;
 sub processMemberships;
 
-#Constants
+# Constants
 our $A_USER_ID;                        *A_USER_ID =                        \'urn:perun:user:attribute-def:core:id';
 our $A_USER_LOGIN;                     *A_USER_LOGIN =                     \'urn:perun:user_facility:attribute-def:virt:login';
 our $A_USER_GIVEN_NAME;                *A_USER_GIVEN_NAME =                \'urn:perun:user:attribute-def:core:firstName';
 our $A_USER_FAMILY_NAME;               *A_USER_FAMILY_NAME =               \'urn:perun:user:attribute-def:core:lastName';
 our $A_RESOURCE_ATLASSIAN_GROUP_NAME;  *A_RESOURCE_ATLASSIAN_GROUP_NAME =  \'urn:perun:resource:attribute-def:def:atlassianGroupName';
+our $A_FACILITY_ATLASSIAN_DOMAIN;      *A_FACILITY_ATLASSIAN_DOMAIN =      \'urn:perun:facility:attribute-def:def:atlassianDomain';
+our $A_MEMBER_STATUS;                  *A_MEMBER_STATUS =                  \'urn:perun:member:attribute-def:core:status';
 
-my $domain = "\@muni.cz";
+our $STATUS_VALID;                     *STATUS_VALID =                     \'VALID';
+
+# Hard limits might depend on directory! (Reference limits: https://support.atlassian.com/provisioning-users/docs/understand-user-provisioning/)
+my $MEMBERS_HARD_LIMIT = 35000;
+my $USERS_HARD_LIMIT = 150000;
+
+if (!defined($data->getFacilityAttributeValue( attrName => $A_FACILITY_ATLASSIAN_DOMAIN ))) {
+	exit 1;
+}
+my $domain = $data->getFacilityAttributeValue( attrName => $A_FACILITY_ATLASSIAN_DOMAIN );
 
 my $userStruc = {};
 my $resourceStruc = {};
@@ -46,6 +57,11 @@ foreach my $resourceId ($data->getResourceIds()) {
 
 # PREPARE USERSDATA TO JSON
 my %users = ();
+my $usersSize = keys %$userStruc;
+if ($usersSize >= $USERS_HARD_LIMIT) {
+	print STDERR "Users limit (" . $USERS_HARD_LIMIT . " users) reached!\n";
+	exit 1;
+}
 foreach my $uid (sort keys %$userStruc) {
 	my $userInfo = {};
 	$userInfo->{$emailHeader} = $userStruc->{$uid}->{$emailHeader};
@@ -68,6 +84,11 @@ foreach my $resourceId (sort keys %$resourceStruc) {
 		push @members, $userStruc->{$uid}->{$emailHeader};
 	}
 
+	if (scalar(@members) >= $MEMBERS_HARD_LIMIT) {
+		print STDERR "Members limit (" . $MEMBERS_HARD_LIMIT . " members) reached on resource #" . $resourceId  . "!\n";
+		exit 1;
+	}
+
 	$groups{$resourceStruc->{$resourceId}->{$A_RESOURCE_ATLASSIAN_GROUP_NAME}} = \@members;
 }
 
@@ -86,13 +107,17 @@ perunServicesInit::finalize;
 sub processUsers {
 	my ($resourceId, $memberId) = @_;
 
+	if ($data->getMemberAttributeValue( member => $memberId, attrName => $A_MEMBER_STATUS ) ne $STATUS_VALID) {
+		return;
+	}
+
 	my $uid = $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_ID );
 	my $userFamilyName = $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_FAMILY_NAME );
 	my $userGivenName = $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_GIVEN_NAME );
 	my $login = $data->getUserFacilityAttributeValue( member => $memberId, facility => $data->getFacilityId, attrName => $A_USER_LOGIN );
 
 	unless (exists $userStruc->{$uid}) {
-		$userStruc->{$uid}->{$emailHeader} = $login . $domain;
+		$userStruc->{$uid}->{$emailHeader} = $login . '@' . $domain;
 		$userStruc->{$uid}->{$familyNameHeader} = $userFamilyName;
 		$userStruc->{$uid}->{$givenNameHeader} = $userGivenName;
 	}


### PR DESCRIPTION
* domain is used in email addresses which uniquely identifies user in atlassian
* now facilityadmins will be able to change the domain
* result mail consists of user_facility login + '@' + facility domain
* fixed missing slashes '/' in api calls
* added total members and users check due to atlassian limits
* group memberships are sent in chunks due to atlassian limits