### PR TITLE
feat(gen): redundant code removed

### DIFF
--- a/gen/pbsmon_json
+++ b/gen/pbsmon_json
@@ -43,6 +43,21 @@ $struc->{'reserved_machines'} = [];
 $struc->{'frontends'} = [];
 
 
+# Get attribute values from obtained attributes (input).
+#
+# Usage:
+# my $data = $attributesAgent->getRequiredAttributes(service => $service->getId, host => $host->getId);
+# my %facilityAttributes = attributesToHash $data
+# print $facilityAttributes{"urn:perun:facility:attribute-def:core:name"}, "\n";
+#
+sub attributesToHash {
+	my %attributesHash;
+	foreach my $attr (@_) {
+		$attributesHash{$attr->getName}=$attr->getValue;
+	}
+	return %attributesHash;
+}
+
 my $physicalMachinesStruc = {};
 
 my $agent = perunServicesInit->getAgent;
@@ -134,9 +149,9 @@ for my $item (sort { $b->{"facilityListingPriority"} <=> $a->{"facilityListingPr
 			}
 		);
 		$physicalMachinesStruc->{$mergedOwner} = \%ownerStruc;
-}
+	}
 
-push @{$physicalMachinesStruc->{$mergedOwner}->{'resources'}}, $facilityStruc;
+	push @{$physicalMachinesStruc->{$mergedOwner}->{'resources'}}, $facilityStruc;
 
 
 	my @hosts = $facilitiesAgent->getHosts(facility => $facility->getId);
@@ -153,7 +168,7 @@ push @{$physicalMachinesStruc->{$mergedOwner}->{'resources'}}, $facilityStruc;
 		$facilityStruc->{'cpu'} = $hostsStruc[0]->{'cpu'};
 	} else {
 		$facilityStruc->{'machines'} = \@hostsStruc;
-}
+	}
 }
 
 for my $key (sort keys %$physicalMachinesStruc) {

--- a/gen/perunServicesInit.pm
+++ b/gen/perunServicesInit.pm
@@ -3,7 +3,7 @@ package perunServicesInit;
 
 use Exporter 'import';
 @EXPORT_OK = qw(init);
-@EXPORT= qw(getDirectory getDestinationDirectory getHierarchicalData getDataWithGroups getDataWithVos getHashedDataWithGroups getHashedHierarchicalData);
+@EXPORT= qw(getDirectory getDestinationDirectory getHashedDataWithGroups getHashedHierarchicalData);
 
 use strict;
 use warnings;
@@ -18,19 +18,11 @@ use IO::Compress::Gzip qw(gzip $GzipError) ;
 use Storable;
 
 # variables define possible getData methods what can be execute
-our $DATA_TYPE_HIERARCHICAL="hierarchical";
 our $DATA_TYPE_HASHED_HIERARCHICAL="hashedhierarchical";
-our $DATA_TYPE_FLAT="flat";
 our $DATA_TYPE_HASHED_WITH_GROUPS="hashedwithgroups";
-our $DATA_TYPE_WITH_GROUPS="withgroups";
-our $DATA_TYPE_WITH_VOS="withvos";
 our $DATA_TYPE = {
 	$DATA_TYPE_HASHED_HIERARCHICAL => sub {getHashedHierarchicalData(@_)},
-	$DATA_TYPE_HIERARCHICAL => sub {getHierarchicalData(@_)},
-	$DATA_TYPE_FLAT => sub {getFlatData(@_)},
 	$DATA_TYPE_HASHED_WITH_GROUPS => sub {getHashedDataWithGroups(@_)},
-	$DATA_TYPE_WITH_GROUPS => sub {getDataWithGroups(@_)},
-	$DATA_TYPE_WITH_VOS => sub {getDataWithVos(@_)},
 };
 
 #die at the very end of script when any warning occur during executing
@@ -62,11 +54,11 @@ sub init {
 
 	# some services support variable getData method type, default is hierarchical
 	# if service does not support this variable behavior, then it does not care about this setting
-	if(!defined($getDataType)) { $getDataType = "hierarchical"; }
+	if(!defined($getDataType)) { $getDataType = $DATA_TYPE_HASHED_HIERARCHICAL; }
 	if(defined($DATA_TYPE->{$getDataType})) {
 		$::GET_DATA_METHOD = $DATA_TYPE->{$getDataType};
 	} else {
-		die "Not supported getData type $getDataType! Use one of these: '$DATA_TYPE_HIERARCHICAL', '$DATA_TYPE_HASHED_HIERARCHICAL', '$DATA_TYPE_FLAT', '$DATA_TYPE_WITH_GROUPS', '$DATA_TYPE_HASHED_WITH_GROUPS' or '$DATA_TYPE_WITH_VOS'.";
+		die "Not supported getData type $getDataType! Use one of these: '$DATA_TYPE_HASHED_HIERARCHICAL' or '$DATA_TYPE_HASHED_WITH_GROUPS'.";
 	}
 
 	if(defined $local_data_file) {
@@ -149,38 +141,10 @@ sub getHashedHierarchicalData {
   return $data;
 }
 
-sub getHierarchicalData {
-	if(defined $local_data) { return $local_data; }
-	my $data = $servicesAgent->getHierarchicalData(service => $service->getId, facility => $facility->getId);
-	logData $data, 'hierarchicalData';
-	return $data;
-}
-
-sub getFlatData {
-	if(defined $local_data) { return $local_data; }
-	my $data = $servicesAgent->getFlatData(service => $service->getId, facility => $facility->getId);
-	logData $data, 'flatData';
-	return $data;
-}
-
 sub getHashedDataWithGroups {
 	if(defined $local_data) { return $local_data; }
 	my $data = $servicesAgent->getHashedDataWithGroups(service => $service->getId, facility => $facility->getId, consentEval => $CONSENT_EVAL);
 	logData $data, 'hashedDataWithGroups';
-	return $data;
-}
-
-sub getDataWithGroups {
-	if(defined $local_data) { return $local_data; }
-	my $data = $servicesAgent->getDataWithGroups(service => $service->getId, facility => $facility->getId);
-	logData $data, 'dataWithGroups';
-	return $data;
-}
-
-sub getDataWithVos {
-	if(defined $local_data) { return $local_data; }
-	my $data = $servicesAgent->getDataWithVos(service => $service->getId, facility => $facility->getId);
-	logData $data, 'dataWithVos';
 	return $data;
 }
 

--- a/gen/perunServicesUtils.pm
+++ b/gen/perunServicesUtils.pm
@@ -2,7 +2,7 @@
 package perunServicesUtils;
 use Exporter;
 @ISA = ('Exporter');
-@EXPORT = qw(attributesToHash dataToAttributesHashes getAttributeSorting quotaToKb uniqList convertNonAsciiToEscapedUtf8Form);
+@EXPORT = qw(getAttributeSorting quotaToKb uniqList convertNonAsciiToEscapedUtf8Form);
 
 use strict;
 use warnings;
@@ -11,37 +11,6 @@ use feature qw(switch);
 no if $] >= 5.018, warnings => "experimental"; #supress warnings on experimetal features like "switch"
 
 #use Perun::Agent;
-
-# Get attributes from getData function and convert them into hash
-#
-# Usage:
-# my $data = perunServicesInit::getHierarchicalData;
-# my %facilityAttributes = attributesToHash $data->getAttributes
-# print $facilityAttributes{"urn:perun:facility:attribute-def:core:name"}, "\n";
-#
-sub attributesToHash {
-	my %attributesHash;
-	foreach my $attr (@_) {
-		$attributesHash{$attr->getName}=$attr->getValue;
-	}
-	return %attributesHash;
-}
-
-# Get "data" from getData function and convert them into array of attributes. Attributes is represented by REFERENCE to hash.
-#
-# Usage:
-# my $data = perunServicesInit::getHierarchicalData;
-# foreach my $resourceAttributes (dataToAttributesHashes $data->getChildElements) {
-#   print $resourceAttributes->{"urn:perun:resource:attribute-def:core:name"}, "\n";
-# }
-#
-sub dataToAttributesHashes {
-	my @arrayOfHashes = ();
-	foreach my $entity (@_) {
-		push @arrayOfHashes, { attributesToHash $entity->getAttributes } ;
-	}
-	return @arrayOfHashes;
-}
 
 # Return sorting function which can be used as parameter for sort
 # This function can sort hashREF.


### PR DESCRIPTION
* getFlatData, getHierarchicalData, getDataWithGroups, getDataWithVos, dataToAttributesHashes subroutines removed
* related comments updated
* default getDataType changed from 'Hierarchical' to 'HashedHierarchical'
* related output (help) text adjusted

breaking change: getFlatData, getHierarchicalData, getDataWithGroups, getDataWithVos, dataToAttributesHashes subroutines cannot be used anymore