### PR TITLE
fix: extend OK http codes in generic sender

### DIFF
--- a/send/generic_sender.py
+++ b/send/generic_sender.py
@@ -173,13 +173,13 @@ if __name__ == "__main__":
 					# in this situation 'curl' was used
 					if return_code == 0:
 						# check if curl ended without an error (ERR_CODE = 0) (if not, we can continue as usual, because there is an error on STDERR)
-						if int(stdout) != 200:
-							# check if HTTP_CODE is different from OK (200)
+						if int(stdout) not in send_lib.http_ok_codes:
+							# check if HTTP_CODE is different from OK
 							# if yes, then we will use HTTP_CODE as ERROR_CODE which is always non-zero
 							temp.seek(0, 0)
 							print(temp.read(), file=sys.stderr)
 						else:
-							# if HTTP_CODE is 200, then call was successful and result call can be printed with info
+							# if HTTP_CODE is OK, then call was successful and result call can be printed with info
 							# result call is saved in temp file
 							temp.seek(0, 0)
 							print(temp.read())

--- a/send/send_lib.py
+++ b/send/send_lib.py
@@ -27,6 +27,8 @@ DESTINATION_TYPE_SERVICE_SPECIFIC = "service-specific"
 TIMEOUT = 7200  # 120 * 60 sec = 2h
 TIMEOUT_KILL = 60  # 60 sec to kill after timeout
 
+http_ok_codes = [200, 201, 202, 203, 204]
+
 # regex checks
 HOST_PATTERN = re.compile(
 	"^(?!:\/\/)(?=.{1,255}$)((.{1,63}\.){1,127}(?![0-9]*$)[a-z0-9-]+\.?)$|^(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}$")


### PR DESCRIPTION
* more http status codes are considered to be responses of success
* if f.e. 204 is returned, then warning would be shown in propagation result, even though the propagation ended successfully