### PR TITLE
feat: 🎸 Update bbmri_* gen scripts for after BBMRI migration

### DIFF
--- a/gen/bbmri_collections
+++ b/gen/bbmri_collections
@@ -14,7 +14,7 @@ use utf8;
 
 local $::SERVICE_NAME = "bbmri_collections";
 local $::PROTOCOL_VERSION = "1.0.1";
-my $SCRIPT_VERSION = "1.0.2";
+my $SCRIPT_VERSION = "1.0.3";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
@@ -27,6 +27,7 @@ sub processMemberships;
 
 #Constants
 our $A_USER_ID;                   *A_USER_ID =               \'urn:perun:user:attribute-def:core:id';
+our $A_BBMRI_USER_ID;             *A_BBMRI_USER_ID =         \'urn:perun:user:attribute-def:virt:bbmriUserId';
 our $A_USER_STATUS;               *A_USER_STATUS =           \'urn:perun:member:attribute-def:core:status';
 our $A_MEMBER_IS_SUSPENDED;       *A_MEMBER_IS_SUSPENDED =   \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_USER_EMAIL;                *A_USER_EMAIL =            \'urn:perun:user:attribute-def:def:preferredMail';
@@ -48,6 +49,7 @@ our $u_email = {};
 our $u_name = {};
 our $u_eppn = {};
 our $u_organization = {};
+our $u_bbmri_user_id = {};
 
 our $groupStruc = {};
 our $g_name = {};
@@ -71,7 +73,8 @@ foreach my $resourceId ( $data->getResourceIds() ) {
 my @users;
 foreach my $uid (sort keys %$userStruc) {
 	my $user = {};
-	$user->{"id"} = $uid;
+	$user->{"id"} = "$userStruc->{$uid}->{$u_bbmri_user_id}";
+	$user->{"perun_user_id"} = $uid;
 	$user->{"displayName"} = $userStruc->{$uid}->{$u_name};
 	$user->{"status"} = $userStruc->{$uid}->{$u_status};
 	$user->{"mail"} = $userStruc->{$uid}->{$u_email};
@@ -100,7 +103,7 @@ foreach my $gid (sort keys %$groupStruc) {
 	my @members;
 	foreach my $uid (sort keys %{$membershipStruc->{$gid}}){
 		my $struct = {};
-		$struct->{"userId"} = $uid;
+		$struct->{"userId"} = "$userStruc->{$uid}->{$u_bbmri_user_id}";
 		push @members, $struct;
 	}
 
@@ -125,6 +128,7 @@ sub processUsers {
 	my ($gid, $memberId) = @_;
 
 	my $uid = $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_ID );
+	my $bbmriUserId = $data->getUserAttributeValue( member => $memberId, attrName => $A_BBMRI_USER_ID );
 	my $status = $data->getMemberAttributeValue(member => $memberId, attrName => $A_USER_STATUS);
 	my $isSuspended = $data->getMemberAttributeValue( member => $memberId, attrName => $A_MEMBER_IS_SUSPENDED );
 	if ($isSuspended) { $status = $STATUS_SUSPENDED; }
@@ -151,6 +155,7 @@ sub processUsers {
 	}
 	else{
 		$userStruc->{$uid}->{$u_status} = $status;
+		$userStruc->{$uid}->{$u_bbmri_user_id} = $bbmriUserId;
 		$userStruc->{$uid}->{$u_email} = $email;
 		$userStruc->{$uid}->{$u_name} = $d_name;
 		$userStruc->{$uid}->{$u_eppn} = \@eppns;

--- a/gen/bbmri_collections
+++ b/gen/bbmri_collections
@@ -27,7 +27,7 @@ sub processMemberships;
 
 #Constants
 our $A_USER_ID;                   *A_USER_ID =               \'urn:perun:user:attribute-def:core:id';
-our $A_BBMRI_USER_ID;             *A_BBMRI_USER_ID =         \'urn:perun:user:attribute-def:virt:bbmriUserId';
+our $A_BBMRI_USER_ID;             *A_BBMRI_USER_ID =         \'urn:perun:user:attribute-def:virt:login-namespace:bbmriid-persistent';
 our $A_USER_STATUS;               *A_USER_STATUS =           \'urn:perun:member:attribute-def:core:status';
 our $A_MEMBER_IS_SUSPENDED;       *A_MEMBER_IS_SUSPENDED =   \'urn:perun:member:attribute-def:virt:isSuspended';
 our $A_USER_EMAIL;                *A_USER_EMAIL =            \'urn:perun:user:attribute-def:def:preferredMail';

--- a/gen/bbmri_networks
+++ b/gen/bbmri_networks
@@ -27,7 +27,7 @@ sub processMemberships;
 
 #Constants
 our $A_USER_ID;                   *A_USER_ID =               \'urn:perun:user:attribute-def:core:id';
-our $A_BBMRI_USER_ID;             *A_BBMRI_USER_ID =         \'urn:perun:user:attribute-def:virt:bbmriUserId';
+our $A_BBMRI_USER_ID;             *A_BBMRI_USER_ID =         \'urn:perun:user:attribute-def:virt:login-namespace:bbmriid-persistent';
 our $A_USER_STATUS;               *A_USER_STATUS =           \'urn:perun:member:attribute-def:core:status';
 our $A_USER_EMAIL;                *A_USER_EMAIL =            \'urn:perun:user:attribute-def:def:preferredMail';
 our $A_USER_EPPNS;                *A_USER_EPPNS =            \'urn:perun:user:attribute-def:virt:eduPersonPrincipalNames';

--- a/gen/bbmri_networks
+++ b/gen/bbmri_networks
@@ -14,7 +14,7 @@ use utf8;
 
 local $::SERVICE_NAME = "bbmri_networks";
 local $::PROTOCOL_VERSION = "1.0.0";
-my $SCRIPT_VERSION = "1.0.1";
+my $SCRIPT_VERSION = "1.0.2";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
@@ -27,6 +27,7 @@ sub processMemberships;
 
 #Constants
 our $A_USER_ID;                   *A_USER_ID =               \'urn:perun:user:attribute-def:core:id';
+our $A_BBMRI_USER_ID;             *A_BBMRI_USER_ID =         \'urn:perun:user:attribute-def:virt:bbmriUserId';
 our $A_USER_STATUS;               *A_USER_STATUS =           \'urn:perun:member:attribute-def:core:status';
 our $A_USER_EMAIL;                *A_USER_EMAIL =            \'urn:perun:user:attribute-def:def:preferredMail';
 our $A_USER_EPPNS;                *A_USER_EPPNS =            \'urn:perun:user:attribute-def:virt:eduPersonPrincipalNames';
@@ -45,6 +46,7 @@ our $u_status = {};
 our $u_email = {};
 our $u_name = {};
 our $u_eppn = {};
+our $u_bbmri_user_id = {};
 
 our $groupStruc = {};
 our $g_name = {};
@@ -67,7 +69,8 @@ foreach my $resourceId ( $data->getResourceIds() ) {
 my @users;
 foreach my $uid (sort keys %$userStruc) {
 	my $user = {};
-	$user->{"id"} = $uid;
+	$user->{"id"} = "$userStruc->{$uid}->{$u_bbmri_user_id}";
+	$user->{"perun_user_id"} = $uid;
 	$user->{"displayName"} = $userStruc->{$uid}->{$u_name};
 	$user->{"status"} = $userStruc->{$uid}->{$u_status};
 	$user->{"mail"} = $userStruc->{$uid}->{$u_email};
@@ -93,7 +96,7 @@ foreach my $gid (sort keys %$groupStruc) {
 	my @members;
 	foreach my $uid (sort keys %{$membershipStruc->{$gid}}){
 		my $struct = {};
-		$struct->{"userId"} = $uid;
+		$struct->{"userId"} = "$userStruc->{$uid}->{$u_bbmri_user_id}";
 		push @members, $struct;
 	}
 
@@ -118,6 +121,7 @@ sub processUsers {
 	my ($gid, $memberId) = @_;
 
 	my $uid = $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_ID );
+	my $bbmriUserId = $data->getUserAttributeValue( member => $memberId, attrName => $A_BBMRI_USER_ID );
 	my $status = $data->getMemberAttributeValue( member => $memberId, attrName => $A_USER_STATUS );
 	my $isSuspended = $data->getMemberAttributeValue( member => $memberId, attrName => $A_MEMBER_IS_SUSPENDED );
 	if ($isSuspended) { $status = $STATUS_SUSPENDED; }
@@ -143,6 +147,7 @@ sub processUsers {
 	}
 	else{
 		$userStruc->{$uid}->{$u_status} = $status;
+		$userStruc->{$uid}->{$u_bbmri_user_id} = $bbmriUserId;
 		$userStruc->{$uid}->{$u_email} = $email;
 		$userStruc->{$uid}->{$u_name} = $d_name;
 		$userStruc->{$uid}->{$u_eppn} = \@eppns;


### PR DESCRIPTION
Change uses the BBMRI User ID extracted from a virtual attribute. The reason for doing so is the change in the IDs of users when they are moved into the LS AAI.

DEPLOY only to LS AAI, when BBMRI is migrated.