### PR TITLE
chore: change commitlint rules

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,6 +1,9 @@
 {
 	"extends": ["@commitlint/config-conventional"],
 	"helpUrl": "https://perunaai.atlassian.net/wiki/spaces/STRIBOG/pages/13467868/Semantic+versioning",
+	"rules": {
+		"body-max-line-length": [2, "always", 200]
+	},
 	"prompt": {
 		"questions": {
 			"scope": {

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,7 @@ on:
 jobs:
     run-commitlint-on-pr:
         runs-on: ubuntu-latest
+        if: startsWith(github.head_ref, 'dependabot/npm_and_yarn/') != true
         steps:
             - uses: actions/checkout@v3
               with:


### PR DESCRIPTION
* The body-max-line-length rule was raised from the default 100 characters to 200 characters.
* Branches from the dependabot are now excluded from the commlint check.