### PR TITLE
ci: un-hide patch commits from changelog

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,14 +9,10 @@
 				"preset": "conventionalcommits",
 				"presetConfig": {
 					"types": [
-						{
-							"type": "feat",
-							"section": "New features and notable changes",
-							"hidden": false
-						},
-						{ "type": "fix", "hidden": true },
-						{ "type": "perf", "hidden": true },
-						{ "type": "revert", "hidden": true },
+						{ "type": "feat", "hidden": false },
+						{ "type": "fix", "hidden": false },
+						{ "type": "perf", "hidden": false },
+						{ "type": "revert", "hidden": false },
 						{ "type": "docs", "hidden": true },
 						{ "type": "style", "hidden": true },
 						{ "type": "chore", "hidden": true },


### PR DESCRIPTION
affects UPGRADE.md and GitHub release descriptions