### PR TITLE
fix(vsup_tritius): fixed utf8 encoding

### DIFF
--- a/send/vsup_tritius
+++ b/send/vsup_tritius
@@ -6,6 +6,8 @@ use Getopt::Long qw(:config no_ignore_case);
 use Data::Dumper;
 use Encode qw(encode);
 use ScriptLock;
+use utf8;
+binmode STDOUT, ":utf8";
 
 my $username;
 my $password;
@@ -52,8 +54,10 @@ if(!defined($password) || !defined($username) || !defined($tableName)) {
 my $dataByUco = {};
 
 open FILE, $service_file or die "Could not open $service_file: $!";
+binmode FILE, ":utf8";
 while(my $line = <FILE>) {
 	my @parts = split /\t/, $line;
+	chomp(@parts);
 	$dataByUco->{$parts[0]}->{'LOGIN'} = $parts[1];
 	$dataByUco->{$parts[0]}->{'TYPE'} = (($parts[2] ne '') ? $parts[2] : 'STU');  # fallback to students
 	$dataByUco->{$parts[0]}->{'EMAIL'} = $parts[3];


### PR DESCRIPTION
- Tell perl that sourcing data file is in utf8.
- Chomp on data to remove newlines.