### PR TITLE
feat: optionally append BA credentials to URL destinations

### DIFF
--- a/send/generic_send.py
+++ b/send/generic_send.py
@@ -55,6 +55,17 @@ if __name__ == "__main__":
 		temp = tempfile.NamedTemporaryFile(mode="w+")
 		transport_command.extend(["-i", "-H", "Content-Type:application/x-tar", "-w", "%{http_code}", "--show-error",
 								  "--silent", "-o", temp.name, "-X", "PUT", "--data-binary", "@-"])
+		# Append optional BA credentials to URL destinations from standardized config
+		try:
+			sys.path.insert(1, f'/etc/perun/services/' + service_name + '/')
+			credentials = __import__(service_name).credentials
+			if destination in credentials.keys():
+				username = credentials.get(destination).get('username')
+				password = credentials.get(destination).get('password')
+				transport_command.extend(["-u", username + ":" + password])
+		except Exception:
+			# this means that config file does not exist or properties are not set
+			pass
 	else:
 		transport_command = ["ssh", "-o", "PasswordAuthentication=no", "-o", "StrictHostKeyChecking=no", "-o",
 							 "GSSAPIAuthentication=no", "-o", "GSSAPIKeyExchange=no", "-o", "ConnectTimeout=5"]

--- a/send/generic_sender.py
+++ b/send/generic_sender.py
@@ -118,6 +118,12 @@ if __name__ == "__main__":
 		temp = tempfile.NamedTemporaryFile(mode="w+")
 		# errors will be saved to temp file
 		transport_command = prepare_url_transport_command(temp)
+		# append BA credentials if present in service config for the destination
+		auth = send_lib.get_auth_credentials(service_name, destination)
+		if auth != None:
+			username = auth[0]
+			password = auth[1]
+			transport_command.extend(["-u", username + ":" + password])
 	elif transport_command is None:
 		transport_command = prepare_ssh_transport_command()
 


### PR DESCRIPTION
- If BA credentials are present in standardized service config file, append them to the CURL command like '-u user:pass'.
- Supported in generic_send.py and generic_sender.py scripts when everything runs the standard way. If you override transport_command or create it by using generic_sender.prepare_url_transport_command() then no credentials are appended, and you have to do it by yourself.
- We can't simply use overridden transport_command for this functionality, since it doesn't work for URL destinations correctly (can't catch stdout in temporary file).