### PR TITLE
fix(scs_it4i): use send_lib.py, support v2 API

### DIFF
--- a/gen/scs_it4i
+++ b/gen/scs_it4i
@@ -6,8 +6,8 @@ use perunServicesUtils;
 use File::Basename;
 
 our $SERVICE_NAME = basename($0);
-our $PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.1";
+our $PROTOCOL_VERSION = "3.1.0";
+my $SCRIPT_VERSION = "3.0.2";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
@@ -16,6 +16,7 @@ my $data = perunServicesInit::getHashedHierarchicalData;
 #Constants
 
 our $A_USER_LOGIN_EINFRA_PERSIST; *A_USER_LOGIN_EINFRA_PERSIST = \'urn:perun:user:attribute-def:virt:login-namespace:einfraid-persistent';
+our $A_USER_LOGIN_EINFRA;         *A_USER_LOGIN_EINFRA =         \'urn:perun:user:attribute-def:def:login-namespace:einfra';
 our $A_ORGANIZATION;              *A_ORGANIZATION =              \'urn:perun:user:attribute-def:def:organization';
 our $A_BLOCK_COLLISION;           *A_BLOCK_COLLISION =           \'urn:perun:user:attribute-def:def:it4iBlockCollision';
 our $A_COMMON_NAME;               *A_COMMON_NAME =               \'urn:perun:user:attribute-def:core:commonName';
@@ -39,27 +40,28 @@ my $users;
 foreach my $memberId ($data->getMemberIdsForFacility()) {
 
 	my $collision = $data->getUserAttributeValue( member => $memberId, attrName => $A_BLOCK_COLLISION );
-	my $login = $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_LOGIN_EINFRA_PERSIST ) || "";
+	my $login = $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_LOGIN_EINFRA ) || "";
 
 	# Check if user is not prohibited in IT4I !!
 	if (defined $collision) {
 		die "Login '$login' has collision with old IT4I data. Propagations was stopped for safety."
 	}
 	$users->{$login}->{"uuid"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_UUID) || "";
+	$users->{$login}->{"id"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_USER_LOGIN_EINFRA_PERSIST ) || "";
 	$users->{$login}->{"login"} = $login;
-	$users->{$login}->{"commonName"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_COMMON_NAME ) || "";
-	$users->{$login}->{"displayName"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_DISPLAY_NAME ) || "";
-	$users->{$login}->{"firstName"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_FIRST_NAME ) || "";
-	$users->{$login}->{"lastName"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_LAST_NAME ) || "";
-	$users->{$login}->{"middleName"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_MIDDLE_NAME) || "";
-	$users->{$login}->{"titleAfter"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_TITLE_AFTER ) || "";
-	$users->{$login}->{"titleBefore"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_TITLE_BEFORE ) || "";
+	$users->{$login}->{"common_name"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_COMMON_NAME ) || "";
+	$users->{$login}->{"display_name"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_DISPLAY_NAME ) || "";
+	$users->{$login}->{"first_name"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_FIRST_NAME ) || "";
+	$users->{$login}->{"last_name"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_LAST_NAME ) || "";
+	$users->{$login}->{"middle_name"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_MIDDLE_NAME) || "";
+	$users->{$login}->{"title_after"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_TITLE_AFTER ) || "";
+	$users->{$login}->{"title_before"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_TITLE_BEFORE ) || "";
 	$users->{$login}->{"citizenship"} = "";
 	$users->{$login}->{"country"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_COUNTRY ) || "";
 	$users->{$login}->{"organization"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_ORGANIZATION ) || "";
-	$users->{$login}->{"preferredLanguage"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_PREF_LANGUAGE ) || "";
-	$users->{$login}->{"preferredMail"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_PREF_MAIL ) || "";
-	$users->{$login}->{"institutionsCountries"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_INSTIT_COUNTRIES ) || [];
+	$users->{$login}->{"preferred_language"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_PREF_LANGUAGE ) || "";
+	$users->{$login}->{"preferred_mail"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_PREF_MAIL ) || "";
+	$users->{$login}->{"institutions_countries"} = $data->getUserAttributeValue( member => $memberId, attrName => $A_INSTIT_COUNTRIES ) || [];
 
 }
 

--- a/send/scs_it4i
+++ b/send/scs_it4i
@@ -1,40 +1,30 @@
-#!/usr/bin/env python3
+#!/usr/local/bin/python3.11
 
 import sys
-import os
 import requests
 import json
-import re
+import send_lib
 from json.decoder import JSONDecodeError
 
-urlPattern = re.compile("^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;()*$']*[-a-zA-Z0-9+&@#/%=~_|()*$']")
+# FIXME - change to default python when we migrate to containers
+SERVICE_NAME = "scs_it4i"
 
 if __name__ == "__main__":
 
-    # check input
-    if len(sys.argv) != 4 and len(sys.argv) != 3:
-        print("Error: Expected number of arguments is 2 or 3 (FACILITY_NAME, DESTINATION and optional DESTINATION_TYPE)", file=sys.stderr)
-        exit(1)
+    send_lib.check_input_fields(sys.argv, True)
 
-    facility_name = sys.argv[1]
+    facility = sys.argv[1]
     destination = sys.argv[2]
-    if len(sys.argv) == 3:
-        # if there is no destination type, use default 'url'
-        destination_type = "url"
-    else:
-        destination_type = sys.argv[3]
+    destination_type = sys.argv[3]
 
-    if destination_type != "url":
-        print("Only 'url' type of destination is supported.", file=sys.stderr)
-        exit(1)
+    send_lib.check_destination_type_allowed(sys.argv[3], send_lib.DESTINATION_TYPE_URL)
+    send_lib.check_destination_format(destination, destination_type)
 
-    if not (re.fullmatch(urlPattern, destination)):
-        print("Destination '" + destination + "' is not in valid URL format!", file=sys.stderr)
-        exit(1)
+    send_lib.create_lock(SERVICE_NAME, destination)
 
     # Import client config (file must have .py -> "scs_it4i.py")
     try:
-        sys.path.insert(1, '/etc/perun/services/scs_it4i/')
+        sys.path.insert(1, send_lib.SERVICES_DIR + "/" + SERVICE_NAME + "/")
         CLIENT_ID = __import__("scs_it4i").CLIENT_ID
         CLIENT_SECRET = __import__("scs_it4i").CLIENT_SECRET
         TOKEN_API = __import__("scs_it4i").TOKEN_API
@@ -76,9 +66,7 @@ if __name__ == "__main__":
         exit(1)
 
     # read all lines at once
-    service_files_base_dir = os.getcwd() + "/../gen/spool"
-    service_files_dir = service_files_base_dir + "/" + facility_name + "/scs_it4i"
-
+    service_files_dir = send_lib.get_gen_folder(facility, SERVICE_NAME)
     file = open(service_files_dir + "/scs_it4i", mode='r')
     all_of_it = file.read()
     file.close()
@@ -93,7 +81,7 @@ if __name__ == "__main__":
     user_attr_req = requests.post(
         destination,
         headers = { "Authorization": "Bearer " + token_st["access_token"] },
-        json = all_of_it
+        json = all_of_it_json
     )
 
     response = user_attr_req.text.strip()


### PR DESCRIPTION
- Service endpoint uses new version of API.
- Updated object param names (use underscores instead of came-case).
- Pass "einfra" login as "login" param.
- Pass "einfraid-persistent" login as "id" param.
- Switch to using send_lib.py where possible instead of custom code.
- Temporary switch to pytho3.11.
- Fixed passing JSON to the request.